### PR TITLE
fix: require receipt outcome to match terminal state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project are documented here. Format follows
   `!res.ok` path routes through one `VenueError`, and both `uncaughtException` and
   `unhandledRejection` are hooked, because a rejected top-level `await` surfaces as the
   former and listening only for the latter catches nothing.
+- Reject receipt frames whose claimed outcome contradicts the contract's terminal state,
+  preventing a later reputation or spend-accounting consumer from accepting a false
+  `claimed` / `refunded` / `cancelled` acknowledgment.
 
 ## [0.1.0] - 2026-09-01
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -177,7 +177,8 @@ late — the payee gambles against the refund; the rail arbitrates.
 - `refund`: payer, while locked, at/after `refundAfterMs`.
 - `cancel`: either party, before any lock exists (proposed/accepted).
 - `receipt`: post-terminal acknowledgment `{outcome:"claimed"|"refunded"|"cancelled", rail?,
-  ref?}` — the line a reputation/spend-accounting layer would consume later; no transition.
+  ref?}` — `outcome` must match the contract's terminal state. This is the line a
+  reputation/spend-accounting layer would consume later; it makes no transition.
 
 ## 4. State machine
 

--- a/src/machine.ts
+++ b/src/machine.ts
@@ -178,6 +178,9 @@ export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number
       }
       if (frame.contract !== state.contract) return reject(state, "receipt names a different contract");
       if (!isParty(state, frame.from)) return reject(state, "receipt from a non-party");
+      if (frame.outcome !== state.status) {
+        return reject(state, `receipt outcome ${frame.outcome} does not match ${state.status}`);
+      }
       return { ok: true, state };
     }
   }

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -217,6 +217,13 @@ describe("tclk state machine", () => {
     }, T0 + 3);
     expect(receipt.ok).toBe(true);
     expect(receipt.state.status).toBe("claimed");
+
+    const contradictoryReceipt = applyFrame(claimed.state, {
+      type: "receipt", from: PAYER_DID, contract: state.contract!, outcome: "refunded",
+    }, T0 + 3);
+    expect(contradictoryReceipt.ok).toBe(false);
+    expect(contradictoryReceipt.reason).toMatch(/does not match claimed/);
+    expect(contradictoryReceipt.state).toBe(claimed.state);
   });
 
   it("payee-initiated offers assign roles correctly at accept", () => {


### PR DESCRIPTION
## What

Reject receipt frames whose `outcome` does not match the contract's terminal state. Callers now get a fail-closed rejection instead of accepting a contradictory post-terminal acknowledgment.

## Why

Receipts are intended for later reputation and spend-accounting consumers. A `claimed` contract previously accepted, for example, a signed `refunded` receipt, allowing downstream records to contradict the state machine's terminal result. The specification now makes the existing terminal-state invariant explicit.

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` (124 tests)
- [x] Golden vectors untouched
- [x] `CHANGELOG.md` has an `[Unreleased]` entry
- [x] `SPEC.md` updated
- [x] New surface on the money path: nothing new
