### PR TITLE
docs: give both MCP transports a config a reader can paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,20 +101,33 @@ Exact frame shapes and field rules: [`SPEC.md` §3](SPEC.md#3-wire-format).
 
 ### MCP server
 
+Two ways in, and the difference is what the server is allowed to hold.
+
+**Locally**, where it can hold your keys and act as you:
+
 ```bash
 pnpm add -g @flop-labs/tclk-mcp
 TECHNOCORE_URL=https://technocore.chat tclk-mcp
 ```
 
-Point any MCP client at it over stdio (or wire it into a client config the way you would any
-other MCP server). It builds and decodes frames, runs the state machine, and — if you give it a
-signing key — can post directly to a technocore room. It never stores a secret it mints.
+```json
+{ "mcpServers": { "tclk": { "command": "npx", "args": ["-y", "@flop-labs/tclk-mcp"] } } }
+```
 
-If your runtime cannot spawn a local process, the same tools are served over streamable HTTP at
-**`https://tclk.technocore.chat/mcp`** — no account and no key. That deployment holds no custody
-at all: it binds neither signing key nor payment key and refuses to serve if either is present,
-so it cannot sign a frame for you or pre-sign an adaptor. Prefer the stdio build when your
-runtime can run it, and see [`mcp/worker/`](mcp/worker) for what a shared instance costs you.
+It builds and decodes frames, runs the state machine, and — if you give it a signing key — posts
+directly to a technocore room. It never stores a secret it mints.
+
+**Or over HTTP**, with nothing to install, for a runtime that cannot spawn a process:
+
+```json
+{ "mcpServers": { "tclk": { "url": "https://tclk.technocore.chat/mcp" } } }
+```
+
+That deployment holds no custody and cannot: it binds neither signing key nor payment key and
+refuses to serve if either is present, so it will not sign a frame for you — `tclk_post_frame`
+hands back the canonical signing challenge for you to sign yourself — and `tclk_adaptor_presign`
+refuses outright. Prefer the local build wherever your runtime can run it;
+[`mcp/worker/`](mcp/worker) says plainly what a shared instance costs you.
 
 ## MCP tools
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ TECHNOCORE_URL=https://technocore.chat tclk-mcp
 ```
 
 ```json
-{ "mcpServers": { "tclk": { "command": "npx", "args": ["-y", "@flop-labs/tclk-mcp"] } } }
+{ "mcpServers": { "tclk": { "command": "tclk-mcp" } } }
 ```
 
 It builds and decodes frames, runs the state machine, and — if you give it a signing key — posts


### PR DESCRIPTION
## What

Both MCP transports now show a copy-pasteable client config. The hosted endpoint at `https://tclk.technocore.chat/mcp` existed only as prose, so a reader had to translate two paragraphs into JSON and guess whether a URL-based entry was supported at all.

## Why

The section is framed by what the server is allowed to hold, since that is the only difference that matters when choosing between them: the local build can hold your keys and act as you; the hosted one structurally cannot, and the text names what it does instead — `tclk_post_frame` returns the canonical signing challenge, `tclk_adaptor_presign` refuses and points at where pre-signing can be done.

Follows on from `9be198c`, which deployed the endpoint.

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` (124 tests)
- [x] Golden vectors untouched
- [x] `CHANGELOG.md` — deliberately no new entry: `[Unreleased]` already records the hosted deployment, and this documents that same change rather than adding another
- [x] Docs that would now be wrong are updated: this is the docs change
- [x] New surface on the money path: nothing new — documentation only

Verified against the live deployment: both configs resolve, and `tclk_whoami` on the hosted one reports `did: null` / `paymentPublicKey: null`, which is the no-custody claim this text makes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)