### PR TITLE
fix(examples): retry a transient venue 5xx instead of dying mid-deal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `examples/live-deal.mjs` retries a transient server error instead of dying mid-deal.
+  `req()` looped only on `429`, so any `5xx` returned straight through and threw at the
+  call site — the venue's intermittent `503`s killed two runs in three. It now backs off
+  geometrically (1s, 2s, 4s) on `500`, `502`, `503` and `504`, keeps obeying `retry-after`
+  on a `429`, and never retries a status the venue meant, so a refusal still surfaces as
+  the `VenueError` carrying its own first line. A run that dies between `lock` and
+  `reveal` sits until `refundAfterMs`, so the example a newcomer copies is the right place
+  for the retry discipline the protocol needs. The policy is a pure function in
+  `examples/retry.mjs` with unit cover in `tests/retry.test.ts` ([#2]).
+
 - `SPEC.md` §2 no longer claims a deal room is "derivable by the two parties and nobody
   else". It is not: the same bullet says the offer *and* the accept are both public in
   `tclk-offers`, and the room name is derived from exactly those two, so anyone who read the
@@ -89,3 +99,5 @@ module is unaudited reference cryptography. Published as
   restated, so the two deployments cannot drift.
 - Both packages ship `NOTICE` alongside `LICENSE`, as Apache-2.0 §4(d) requires — npm
   includes the licence automatically but not the notice it points at.
+
+[#2]: https://github.com/flop-labs/tclk/issues/2

--- a/examples/live-deal.mjs
+++ b/examples/live-deal.mjs
@@ -25,6 +25,7 @@ import {
   stateNote, stateNoteValue, tryDecodeFrame,
 } from "../dist/index.js";
 import { canonicalMessage, nextNonce, signerFromSeed, sweep } from "../mcp/dist/signing.js";
+import { retryPlan } from "./retry.mjs";
 
 const BASE = process.env.TECHNOCORE_URL ?? "https://technocore.chat";
 
@@ -95,12 +96,16 @@ process.on("unhandledRejection", reportAndExit);
 async function req(url, init, what) {
   for (let attempt = 0; ; attempt += 1) {
     const res = await fetch(url, init);
-    if (res.status !== 429) return res;
-    if (attempt >= 3) throw new Error(`${what}: still rate limited after ${attempt} waits`);
-    const stated = Number(res.headers.get("retry-after"));
-    const waitMs = (Number.isFinite(stated) && stated > 0 ? stated : 5) * 1000;
-    log("", `rate limited — waiting ${waitMs / 1000}s, as the venue asked`);
-    await new Promise((resolve) => setTimeout(resolve, waitMs));
+    const plan = retryPlan(res.status, res.headers.get("retry-after"), attempt);
+    if (!plan.retry) {
+      // Out of retries, or a status the venue meant. Either way the response goes back to
+      // the caller, whose `!res.ok` turns it into a VenueError carrying the venue's own
+      // first line — the same treatment every other refusal in this file gets.
+      if (plan.why) log("", `${what}: ${plan.why}`);
+      return res;
+    }
+    log("", plan.why);
+    await new Promise((resolve) => setTimeout(resolve, plan.waitMs));
   }
 }
 
@@ -118,6 +123,10 @@ async function post(signer, room, frame) {
   // so the sweep is the identity here; doing it anyway is what keeps that true by rule
   // rather than by luck.
   const text = sweep(encodeFrame(frame));
+  // One nonce for the whole call, retries included. A retried write therefore replays the
+  // same signed URL, which is what makes it safe to repeat: if an earlier attempt did land
+  // before the venue stopped answering, the replay is refused as a used nonce rather than
+  // posting the frame twice. Minting a fresh nonce per attempt is what would double-post.
   const nonce = nextNonce();
   const sig = signer.sign(canonicalMessage(room, nonce, text));
   const res = await req(

--- a/examples/retry.mjs
+++ b/examples/retry.mjs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The retry policy `examples/live-deal.mjs` uses, as a pure function so it can be tested
+// without a network. `req()` there does the sleeping and the fetching; everything that
+// decides *whether* to wait and *how long* lives here.
+//
+// Two retriable classes, for different reasons:
+//
+//   429  the venue chose to refuse and said when to come back. Its `retry-after` is an
+//        instruction, so it wins over any local schedule.
+//   5xx  the venue did not choose anything — it was overloaded or a proxy answered for it.
+//        Nothing states when to return, so back off geometrically and give up.
+//
+// A 4xx that is not 429 is the venue's considered answer and is never retried: repeating a
+// refused write cannot make it succeed and spends the caller's budget finding that out.
+
+/** How many waits before giving up and handing the response back to the caller. */
+export const RETRY_LIMIT = 3;
+
+/** Statuses where the venue never formed an opinion, so asking again can differ. */
+export const RETRIABLE_SERVER_STATUS = new Set([500, 502, 503, 504]);
+
+/** The venue's own default when it refuses without naming a delay, in seconds. */
+const DEFAULT_RATE_LIMIT_WAIT_S = 5;
+
+/** First backoff step for a 5xx, doubling per attempt: 1s, 2s, 4s. */
+const SERVER_BACKOFF_BASE_MS = 1000;
+
+/**
+ * Decide what to do about one response.
+ *
+ * `retryAfter` is the raw `retry-after` header value (string or null) — parsed here rather
+ * than by the caller so the "it said 0, or `-1`, or a date" cases have one home.
+ *
+ * Deliberately no jitter: one script making one deal is not a thundering herd, and a
+ * deterministic schedule is one a reader can predict and a test can assert.
+ *
+ * @returns {{retry: boolean, waitMs: number, why: string}}
+ */
+export function retryPlan(status, retryAfter, attempt) {
+  const no = { retry: false, waitMs: 0, why: "" };
+
+  if (status === 429) {
+    if (attempt >= RETRY_LIMIT) {
+      return { ...no, why: `still rate limited after ${attempt} waits` };
+    }
+    const stated = Number(retryAfter);
+    const seconds = Number.isFinite(stated) && stated > 0 ? stated : DEFAULT_RATE_LIMIT_WAIT_S;
+    return {
+      retry: true,
+      waitMs: seconds * 1000,
+      why: `rate limited — waiting ${seconds}s, as the venue asked`,
+    };
+  }
+
+  if (RETRIABLE_SERVER_STATUS.has(status)) {
+    if (attempt >= RETRY_LIMIT) {
+      return { ...no, why: `venue still returning ${status} after ${attempt} retries` };
+    }
+    const waitMs = SERVER_BACKOFF_BASE_MS * 2 ** attempt;
+    return {
+      retry: true,
+      waitMs,
+      why: `venue returned ${status} — retrying in ${waitMs / 1000}s`,
+    };
+  }
+
+  return no;
+}

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The example's retry policy. Regression cover for #2: a transient 5xx from the venue
+// killed a run mid-deal because `req()` looped only on 429, and a run that dies between
+// `lock` and `reveal` sits until `refundAfterMs` on a rail that held value.
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error - examples/ is plain ESM and carries no declarations; tsc builds only src/.
+import { RETRIABLE_SERVER_STATUS, RETRY_LIMIT, retryPlan } from "../examples/retry.mjs";
+
+describe("retryPlan", () => {
+  it("retries every server status the venue never chose", () => {
+    // The bug: each of these returned straight through and threw at the call site.
+    for (const status of [500, 502, 503, 504]) {
+      const plan = retryPlan(status, null, 0);
+      expect(plan.retry, `status ${status} must be retried`).toBe(true);
+      expect(plan.waitMs).toBeGreaterThan(0);
+      expect(plan.why).toContain(String(status));
+    }
+  });
+
+  it("backs off geometrically and then gives up", () => {
+    expect(retryPlan(503, null, 0).waitMs).toBe(1000);
+    expect(retryPlan(503, null, 1).waitMs).toBe(2000);
+    expect(retryPlan(503, null, 2).waitMs).toBe(4000);
+
+    const exhausted = retryPlan(503, null, RETRY_LIMIT);
+    expect(exhausted.retry).toBe(false);
+    // The caller turns this into a VenueError carrying the venue's own line, so the
+    // reason still has to name what happened.
+    expect(exhausted.why).toContain("503");
+  });
+
+  it("obeys retry-after on a 429, and falls back when it is absent or nonsense", () => {
+    expect(retryPlan(429, "12", 0).waitMs).toBe(12_000);
+    expect(retryPlan(429, null, 0).waitMs).toBe(5000);
+    for (const bad of ["0", "-1", "soon", "", "NaN"]) {
+      expect(retryPlan(429, bad, 0).waitMs, `retry-after: ${bad}`).toBe(5000);
+    }
+  });
+
+  it("never retries a refusal the venue meant", () => {
+    // A 403 is a considered answer — a used nonce, an unowned room. Repeating it cannot
+    // change it and spends the caller's per-minute budget discovering that.
+    for (const status of [200, 400, 403, 404, 409, 422]) {
+      expect(retryPlan(status, null, 0).retry, `status ${status}`).toBe(false);
+    }
+  });
+
+  it("does not treat 501 or 505 as transient", () => {
+    // "Not implemented" and "version not supported" are permanent; retrying is noise.
+    expect(RETRIABLE_SERVER_STATUS.has(501)).toBe(false);
+    expect(retryPlan(501, null, 0).retry).toBe(false);
+    expect(retryPlan(505, null, 0).retry).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #2.

`req()` looped only on `429`, so every `5xx` returned straight through and the `!res.ok` checks threw at the call site. @10tenchan109 measured two runs in three dying on a transient `503`; I hit the same venue returning `503` on `/.well-known/security.txt` while working on this today, so it is current rather than historical.

## Why this is more than an example fix

The walkthrough is what agents copy. A run that dies between `lock` and `reveal` is not merely inconvenient — on a rail that held value the contract sits until `refundAfterMs`. `AGENTS.md` says fail closed everywhere on the money path; dying on a transient error the venue never chose is the opposite, and the one file a newcomer runs is the natural place to show the retry discipline the protocol needs.

## What changes

Retry `500`, `502`, `503`, `504` with a geometric backoff — 1s, 2s, 4s — keep obeying `retry-after` on a `429`, and never retry a status the venue meant.

- **`501` and `505` are deliberately excluded.** "Not implemented" and "version not supported" are permanent; retrying them is noise.
- **A `4xx` is the venue's considered answer.** Repeating a refused write cannot make it succeed, and it does spend the caller's per-minute budget finding that out.
- **No jitter, on purpose.** One script making one deal is not a thundering herd, and a deterministic schedule is one a reader can predict and a test can assert.

## Two behaviours preserved deliberately

**Exhausting the retries returns the response rather than throwing a bare `Error`.** The caller's `!res.ok` then turns it into the `VenueError` carrying the venue's own first line — the treatment every other refusal in this file gets, per the comment on `VenueError`. The old `429` path threw a bare `Error` instead, which skipped that. The reason still names the status, so nothing is lost.

**The nonce is minted once per `post()`, retries included.** This is load-bearing and was not obvious, so it is now a comment. A retried write replays the *same* signed URL, which is exactly what makes repeating it safe: if an earlier attempt did land before the venue stopped answering, the replay is refused as a used nonce rather than posting the frame twice. Minting a fresh nonce per attempt is what would double-post — worth stating before someone "fixes" it that way.

## Tests

`examples/live-deal.mjs` self-executes under top-level `await`, so it cannot be imported. The retry *decision* is therefore extracted as a pure function in `examples/retry.mjs`; `req()` keeps the fetching and the sleeping. That extraction is what makes a regression test possible, and it is the only structural change here.

`tests/retry.test.ts` fails on two cases against the old policy and passes with the fix:

```
× retries every server status the venue never chose
  AssertionError: status 500 must be retried: expected false to be true
× backs off geometrically and then gives up
  AssertionError: expected +0 to be 1000
Tests  2 failed | 3 passed
```

with the fix: `Tests  5 passed`.

## CI, run locally in the documented order

```
pnpm install --frozen-lockfile
pnpm -r --include-workspace-root build     clean
pnpm -r --include-workspace-root test      65 + 33 + 31 passed
```

`SPEC.md` is unchanged — this is example transport behaviour, not protocol. `CHANGELOG.md` has an `[Unreleased] / Fixed` entry. No version bump, no unrelated refactor.

Reported by `did:key:z6MkmDkcrgAGa2DZ9qxfmMjNpwaKBXkDt3owfUPKyUxRQAtx`.