### PR TITLE
fix(machine): reject a non-finite or negative clock instead of sailing past every deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `applyFrame` now rejects non-finite or negative wall-clock inputs without changing contract state.
 - `SPEC.md` §2 no longer claims a deal room is "derivable by the two parties and nobody
   else". It is not: the same bullet says the offer *and* the accept are both public in
   `tclk-offers`, and the room name is derived from exactly those two, so anyone who read the

--- a/src/machine.ts
+++ b/src/machine.ts
@@ -76,10 +76,14 @@ function isParty(state: ContractState, did: string): boolean {
 }
 
 /**
- * Apply one frame at wall-clock `nowMs`. Structural validation runs first (a frame
- * that fails it is rejected, not thrown on); then the transition guards.
+ * Apply one frame at wall-clock `nowMs`. Clock and structural validation run first
+ * (bad input is rejected, not thrown on); then the transition guards.
  */
 export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number): StepResult {
+  if (!Number.isFinite(nowMs) || nowMs < 0) {
+    return reject(state, "tclk: nowMs must be a finite non-negative number");
+  }
+
   try {
     validateFrame(frame);
   } catch (error) {

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -226,6 +226,34 @@ describe("tclk state machine", () => {
     expect(contradictoryReceipt.state).toBe(claimed.state);
   });
 
+  it.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["negative", -1],
+  ])("rejects %s nowMs without changing state", (_label, nowMs) => {
+    const { state } = accepted();
+    const step = applyFrame(state, {
+      type: "lock", from: PAYER_DID, contract: state.contract!, rail: "flop-htlc", ref: "escrow-42",
+    }, nowMs);
+
+    expect(step.ok).toBe(false);
+    expect(step.reason).toBe("tclk: nowMs must be a finite non-negative number");
+    expect(step.state).toBe(state);
+  });
+
+  it("keeps exact expiry and refund deadline boundaries", () => {
+    const { offer, accept, state } = accepted();
+    expect(applyFrame(openContract(offer), accept, EXPIRES).ok).toBe(false);
+
+    const locked = applyFrame(state, {
+      type: "lock", from: PAYER_DID, contract: state.contract!, rail: "flop-htlc", ref: "escrow-42",
+    }, T0);
+    expect(locked.ok).toBe(true);
+    expect(applyFrame(locked.state, {
+      type: "refund", from: PAYER_DID, contract: state.contract!,
+    }, REFUND_AFTER).ok).toBe(true);
+  });
+
   it("payee-initiated offers assign roles correctly at accept", () => {
     const offer = makeOffer({
       from: PAYEE_DID, role: "payee", amount: "5", asset: "USDC", lock: "hash",


### PR DESCRIPTION
## What

- Validate `applyFrame`'s `nowMs` at the entry point and reject non-finite or negative values with a `tclk:` reason while returning the unchanged state.
- Add regression coverage for `NaN`, `Infinity`, and `-1`, plus exact expiry and refund deadline boundaries.
- Add the fix to the `[Unreleased]` section of `CHANGELOG.md`.

Changed files:

- `src/machine.ts`
- `tests/tclk.test.ts`
- `CHANGELOG.md`

## Why

JavaScript comparisons with `NaN` are false in both directions, so an invalid clock could pass the accept, lock, and reveal transition paths. The entry-point guard makes malformed clock input fail closed and preserves state identity on rejection. `nowMs` is a runtime clock value, so this change requires it to be finite and non-negative without changing the existing deadline wire validation or predicates. No changes were made to `SPEC.md` or the golden vectors.

The regression test was run before the implementation guard was added:

- `./node_modules/.bin/vitest run tests/tclk.test.ts` — failed as expected: all 3 new invalid-clock cases returned `ok: true` (`3 failed, 32 passed`).

## Checks

- `./node_modules/.bin/tsc -p tsconfig.json` — passed, exit 0.
- `./node_modules/.bin/vitest run tests/tclk.test.ts` — passed, 1 file / 35 tests.
- `./node_modules/.bin/vitest run` — passed, 5 files / 64 tests.
- `git diff --check` — passed.
- `tests/vectors.test.ts` — unchanged; no MCP files were changed.

Verified against main at 81a8346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uhG6aaquxZR5hQ5woXGtX