### PR TITLE
fix(locks): close the union — an unknown lock kind verifies nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- Unknown lock kinds now fail closed in statement validation and secret verification.
 - `SPEC.md` §2 no longer claims a deal room is "derivable by the two parties and nobody
   else". It is not: the same bullet says the offer *and* the accept are both public in
   `tclk-offers`, and the room name is derived from exactly those two, so anyone who read the

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -286,7 +286,8 @@ const KEYS: Record<TclkFrame["type"], { allowed: string[]; required: string[] }>
 /** Validate a hash/point statement for the given lock kind (fail-closed boolean). */
 export function isValidStatement(lock: LockKind, statement: string): boolean {
   if (lock === "hash") return HEX32.test(statement);
-  return HEX33.test(statement) && isValidPointStatement(statement);
+  if (lock === "point") return HEX33.test(statement) && isValidPointStatement(statement);
+  return false;
 }
 
 /** Validate one frame structurally. Throws with a reason on the first violation. */

--- a/src/locks.ts
+++ b/src/locks.ts
@@ -44,7 +44,8 @@ export function verifyHashPreimage(hash: string, preimage: string | Uint8Array):
 /** Check a revealed secret against a statement for either lock kind. Fail-closed boolean. */
 export function verifySecret(lock: LockKind, statement: string, secret: string | Uint8Array): boolean {
   if (lock === "hash") return verifyHashPreimage(statement, secret);
-  return verifyPointWitness(statement, secret);
+  if (lock === "point") return verifyPointWitness(statement, secret);
+  return false;
 }
 
 /**

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -21,6 +21,7 @@ import {
   generateHashLock,
   generatePointLock,
   hashLockFromPreimage,
+  isValidStatement,
   lockTerms,
   makeAccept,
   makeOffer,
@@ -181,6 +182,18 @@ describe("tclk locks", () => {
     expect(verifySecret("point", p.statement, p.witness)).toBe(true);
     expect(verifySecret("hash", h.hash, p.witness)).toBe(false);
     expect(verifySecret("point", p.statement, h.preimage)).toBe(false);
+    expect(verifySecret("banana" as never, p.statement, p.witness)).toBe(false);
+  });
+
+  it("rejects unknown lock kinds in statement checks", () => {
+    const h = generateHashLock();
+    const p = generatePointLock();
+
+    expect(isValidStatement("hash", h.hash)).toBe(true);
+    expect(isValidStatement("point", p.statement)).toBe(true);
+    expect(isValidStatement("hash", p.statement)).toBe(false);
+    expect(isValidStatement("point", h.hash)).toBe(false);
+    expect(isValidStatement("banana" as never, p.statement)).toBe(false);
   });
 
   it("validateDeadlines enforces both margins, fail-closed", () => {


### PR DESCRIPTION
## What

- Added explicit runtime dispatch for `hash` and `point` lock kinds in `verifySecret` and `isValidStatement`; any unknown kind now returns `false`.
- Added regression coverage for unknown kinds and preserved hash/point valid and invalid behavior.
- Added the fix to the `[Unreleased]` section of `CHANGELOG.md`.

Files changed:

- `src/locks.ts`
- `src/frames.ts`
- `tests/tclk.test.ts`
- `CHANGELOG.md`

## Why

`LockKind` is a closed `{hash, point}` union, but JavaScript callers can still pass a malformed discriminator at runtime. The previous implicit fallback treated every non-`hash` value as `point`, so an unknown kind such as `banana` could accept a valid point witness. The money path must fail closed.

## Checks

All commands were run after exporting the requested local tool path.

- Without the fix: `./node_modules/.bin/vitest run tests/tclk.test.ts` exited 1; 30 of 32 tests passed and both unknown-kind regression cases failed because they received `true` instead of `false`.
- With the fix: `./node_modules/.bin/vitest run tests/tclk.test.ts` exited 0; 1 test file and all 32 tests passed.
- `./node_modules/.bin/tsc -p tsconfig.json` exited 0.
- `./node_modules/.bin/vitest run` exited 0; 5 test files and all 61 tests passed.
- `git diff --check` exited 0.

Verified against main at 81a8346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uhG6aaquxZR5hQ5woXGtX