### PR TITLE
fix(examples): anchor step-5 verification's read on the offer's own seq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- `examples/live-deal.mjs` step 5 (third-party verification) no longer reads `tclk-offers`
+  through the venue's default trailing window, which a busy shared room can push this run's
+  own offer out of before verification gets there. `post()` now returns the `seq` the venue
+  assigned the posted record, and the step-5 read anchors on `since=offerSeq - 1` instead
+  (#11).
+
 ### Added
 
 - A hosted deployment of the MCP server at `https://tclk.technocore.chat/mcp`, streamable

--- a/examples/live-deal.mjs
+++ b/examples/live-deal.mjs
@@ -104,14 +104,26 @@ async function req(url, init, what) {
   }
 }
 
-/** Read a room the way any stranger would. */
-async function readRoom(room) {
-  const res = await req(`${BASE}/r/${room}?format=json`, undefined, `read ${room}`);
+/**
+ * Read a room the way any stranger would. `since`, when given, narrows to seq > since —
+ * pass the seq a record of interest landed at (minus one) rather than nothing, or the
+ * venue's default window is the newest N records regardless of whether the one you want
+ * is still in it (#11).
+ */
+async function readRoom(room, since) {
+  const suffix = since === undefined ? "" : `&since=${since}`;
+  const res = await req(`${BASE}/r/${room}?format=json${suffix}`, undefined, `read ${room}`);
   if (!res.ok) throw await refusal(`read ${room}`, res);
   return res.json();
 }
 
-/** Post one frame through the signed lane, as the given identity. */
+/**
+ * Post one frame through the signed lane, as the given identity. Returns the swept text
+ * and the `seq` the venue assigned the record — a caller that reads the room back later
+ * (step 5 does, for `tclk-offers`) can anchor a `since` on that instead of trusting the
+ * venue's default trailing window, which a busy shared room can push a record out of
+ * before the read happens (#11).
+ */
 async function post(signer, room, frame) {
   // Sign the text AFTER the venue's single-line sweep — those are the bytes it stores and
   // the bytes a later reader re-verifies against. Our frames are already printable ASCII,
@@ -121,7 +133,7 @@ async function post(signer, room, frame) {
   const nonce = nextNonce();
   const sig = signer.sign(canonicalMessage(room, nonce, text));
   const res = await req(
-    `${BASE}/r/${room}`,
+    `${BASE}/r/${room}?format=json`,
     {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -130,7 +142,8 @@ async function post(signer, room, frame) {
     `post to ${room}`,
   );
   if (!res.ok) throw await refusal(`post to ${room}`, res);
-  return text;
+  const { posted } = await res.json();
+  return { text, seq: posted.seq };
 }
 
 /** The note surface the paper rail records onto, wired to the venue's /kv routes. */
@@ -242,7 +255,7 @@ const offer = makeOffer({
   expiresMs: now + 10 * 60_000,
   job: { proto: "a2a", id: taskId, context: `/kv/${specNote.ns}/${specNote.key}` },
 });
-await post(payer, OFFER_ROOM, offer);
+const { seq: offerSeq } = await post(payer, OFFER_ROOM, offer);
 log(1, `offer      posted to /r/${OFFER_ROOM}  id ${offer.id.slice(0, 18)}…`);
 
 // 2 — the payee mints the secret and publishes only its statement.
@@ -291,7 +304,10 @@ await notes.set(note.ns, note.key, stateNoteValue("claimed", ref), {
 // 5 — a third party, holding no secrets, reconstructs the deal from the venue alone.
 console.log();
 log(5, "third-party verification, from the rooms only:");
-const board = await readRoom(OFFER_ROOM);
+// Anchored on the offer's own seq (#11): `tclk-offers` is shared by every deal on the
+// venue, so the default trailing window can push this run's offer out before step 5 gets
+// here if enough other activity landed in between.
+const board = await readRoom(OFFER_ROOM, offerSeq - 1);
 const dealLog = await readRoom(room);
 
 const offerLine = board.messages.map((m) => tryDecodeFrame(m.text)).find((f) => f?.id === offer.id);


### PR DESCRIPTION
Closes #11.

## What changes for a caller

`examples/live-deal.mjs` step 5 reconstructs the deal by reading `tclk-offers`
back, but `readRoom()` passed no `since`, so the venue served only its
default trailing window (newest 50 records). `tclk-offers` is shared by
every deal on the venue, so enough unrelated activity between steps 1 and 5
pushes this run's own offer out of that window before verification gets to
read it — the failure looks like a tclk bug rather than a read limitation,
which is exactly what #11 reports.

`post()` now returns `{ text, seq }` — the `seq` the venue assigns the
posted record, from the `?format=json` response body's `posted` field —
instead of only `text`. Step 5 anchors its read on `since = offerSeq - 1`
(excludes older records, includes the offer itself) instead of trusting the
default window. This is the fix the issue itself proposes, reusing the
`since` support `mcp/src/technocore.ts` already has rather than adding
anything new.

No other caller of `post()` used its return value, so the signature change
is contained to this file.

## Verification

- `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build
  && pnpm -r --include-workspace-root test` — 124/124 tests pass, clean
  build.
- Ran `examples/live-deal.mjs` end to end against a real (self-hosted, not
  the shared production venue) technocore instance to confirm the fix
  actually works against the server's real response shape, not just a
  read of the code: step 5 replayed the frames and reached
  `status: claimed`.
- `CHANGELOG.md` updated under `[Unreleased]`.

I did not add an automated regression test for this: `examples/` isn't
covered by the `tests/**` root scope or `mcp/tests`, and reproducing the
50-record-window race would mean writing 50+ unrelated records to a shared
room between steps 1 and 5, which isn't practical to assert on in CI. Happy
to add something if there's a pattern you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)