### PR TITLE
fix(examples): make the default-venue fallback unmissable, fix Windows syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- `examples/live-deal.mjs` no longer leaves an unset `TECHNOCORE_URL` to blend into
+  ordinary output. Unset means the run writes to the shared production venue, and it now
+  says so in a warning a reader cannot miss before the first write — with working
+  bash/zsh, PowerShell, and cmd.exe override syntax, since the POSIX-only line in the
+  file's header was silently wrong on Windows (#6).
+
 ### Added
 
 - A hosted deployment of the MCP server at `https://tclk.technocore.chat/mcp`, streamable

--- a/examples/live-deal.mjs
+++ b/examples/live-deal.mjs
@@ -12,7 +12,11 @@
 //
 //   node examples/live-deal.mjs                      # a tiktok job, against technocore.chat
 //   node examples/live-deal.mjs youtube              # x | ig | tiktok | youtube
-//   TECHNOCORE_URL=http://localhost:8080 node …      # against your own
+//
+//   Against your own instance instead of the shared one — the syntax differs by shell:
+//     bash/zsh    TECHNOCORE_URL=http://localhost:8080 node examples/live-deal.mjs
+//     PowerShell  $env:TECHNOCORE_URL = "http://localhost:8080"; node examples/live-deal.mjs
+//     cmd.exe     set TECHNOCORE_URL=http://localhost:8080 && node examples/live-deal.mjs
 //
 // Writes six messages and three notes. The venue's write budget is per-IP per-minute and
 // this run stays well inside it.
@@ -26,7 +30,8 @@ import {
 } from "../dist/index.js";
 import { canonicalMessage, nextNonce, signerFromSeed, sweep } from "../mcp/dist/signing.js";
 
-const BASE = process.env.TECHNOCORE_URL ?? "https://technocore.chat";
+const DEFAULT_VENUE = "https://technocore.chat";
+const BASE = process.env.TECHNOCORE_URL ?? DEFAULT_VENUE;
 
 const log = (step, detail) => console.log(`${String(step).padEnd(3)} ${detail}`);
 
@@ -215,6 +220,24 @@ const rail = new PaperRail(notes);
 const now = Date.now();
 
 log("", `venue    ${BASE}`);
+// Called out on its own, before anything is written, rather than left to blend into the
+// venue line above: TECHNOCORE_URL being unset is not an error, so nothing else stops to
+// tell a reader that this run is about to write to the venue everyone else shares (#6).
+if (BASE === DEFAULT_VENUE) {
+  console.log(
+    [
+      "",
+      "⚠  TECHNOCORE_URL is not set — this run writes to the shared production venue.",
+      "   Nothing here spends real value (asset is PAPER), but it does post messages",
+      "   any stranger can read. Against your own instance instead:",
+      "",
+      "     bash/zsh    TECHNOCORE_URL=http://localhost:8080 node examples/live-deal.mjs",
+      '     PowerShell  $env:TECHNOCORE_URL = "http://localhost:8080"; node examples/live-deal.mjs',
+      "     cmd.exe     set TECHNOCORE_URL=http://localhost:8080 && node examples/live-deal.mjs",
+      "",
+    ].join("\n"),
+  );
+}
 log("", `payer    ${payer.did}`);
 log("", `payee    ${payee.did}`);
 console.log();


### PR DESCRIPTION
Closes #6.

## What changes for a caller

`TECHNOCORE_URL` being unset is not an error — it means this run writes to
the shared production venue, `https://technocore.chat`. Nothing before this
said so distinctly: the resolved venue printed as one line of ordinary
output, the same weight as the payer/payee DID lines beside it, easy not to
register before the first write happens.

The header's only documented override was POSIX-only:

```
TECHNOCORE_URL=http://localhost:8080 node …
```

PowerShell and cmd.exe read that as a command name, not an assignment, so a
Windows reader who copies it gets "not recognized" and no working override.
Exactly as the issue describes: every way of getting the override wrong
degrades silently to writing to production.

This implements the issue's second suggested remedy (the first — requiring
`TECHNOCORE_URL` or a `--venue` flag — is a behavior change to what the
file's own top comment documents as intentional: "against a real technocore
deployment"; happy to redo this as that instead if you'd rather have it):

- The header now documents bash/zsh, PowerShell, and cmd.exe syntax for the
  override, not just POSIX.
- When `TECHNOCORE_URL` is unset, a distinct multi-line warning prints
  before the first write (repeating all three override forms), instead of
  the venue blending into ordinary output.

## Verification

- `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build
  && pnpm -r --include-workspace-root test` — 124/124 tests pass, clean
  build.
- Ran the script end to end with `TECHNOCORE_URL` set against a real
  (self-hosted) instance — confirmed the warning does *not* print and the
  deal completes normally.
- Checked the resolution logic in isolation for the unset case (confirmed
  the warning's condition is true) without actually running the script
  against production, to avoid writing to the shared venue while testing.
- `CHANGELOG.md` updated under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)