### PR TITLE
fix(examples): read the offer board whole, not through the tail window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `examples/live-deal.mjs` step 5 reads the offer board through `/r/<room>/export` rather
+  than the venue's tail window. `?format=json` answers with the newest `limit` records — 50
+  by default, 200 at most — which bounds the result rather than paging through history, so
+  `since` narrows that window from below and never anchors it. `tclk-offers` is shared by
+  every deal on the venue, so a run's own offer leaves the window while its deal is still in
+  flight, and the third-party verification then fails to find a deal that completed
+  correctly. Measured on the hosted venue the day this was found: the board held 68 records
+  and the unqualified read returned the newest 50, putting 26.5% of it out of reach. Export
+  takes no `limit` and is byte-exact, which is also what a fold of signed frames needs. The
+  deal room keeps its windowed read: it is derived per contract and holds four frames.
 - `SPEC.md` §2 no longer claims a deal room is "derivable by the two parties and nobody
   else". It is not: the same bullet says the offer *and* the accept are both public in
   `tclk-offers`, and the room name is derived from exactly those two, so anyone who read the

--- a/examples/live-deal.mjs
+++ b/examples/live-deal.mjs
@@ -104,11 +104,44 @@ async function req(url, init, what) {
   }
 }
 
-/** Read a room the way any stranger would. */
+/** Read a room the way any stranger would: the venue's tail window. */
 async function readRoom(room) {
   const res = await req(`${BASE}/r/${room}?format=json`, undefined, `read ${room}`);
   if (!res.ok) throw await refusal(`read ${room}`, res);
   return res.json();
+}
+
+/**
+ * Every record a room still holds, in the same shape `readRoom` returns.
+ *
+ * `?format=json` answers with the NEWEST `limit` records — 50 by default, 200 at most.
+ * That is a bound on the result, not a cursor into history: `since` narrows the window
+ * from below and never anchors it, so once more than `limit` records sit above a record,
+ * no combination of the two reaches it. `tclk-offers` is shared by every deal on this
+ * venue, so a run's own offer leaves that window while the deal is still in flight (#11).
+ *
+ * `/export` takes no `limit`: it streams the retained file, bounded by one fstat at open
+ * and truncated to the last complete line. Byte-exact, which is the property a fold of
+ * signed frames needs — a signed record re-verifies only against the bytes as stored.
+ * It is the whole ring rather than a page, so it belongs at a verification step and not
+ * in a loop.
+ */
+async function exportRoom(room) {
+  const res = await req(`${BASE}/r/${room}/export`, undefined, `export ${room}`);
+  if (!res.ok) throw await refusal(`export ${room}`, res);
+  const messages = [];
+  for (const line of (await res.text()).split("\n")) {
+    if (line.trim() === "") continue;
+    // Anything a stranger wrote is in here too, and step 5 folds it deliberately. A line
+    // that is not a record at all is skipped for the same reason `tryDecodeFrame` returns
+    // null rather than throwing: one unusable line must cost only itself.
+    try {
+      messages.push(JSON.parse(line));
+    } catch {
+      continue;
+    }
+  }
+  return { room, count: messages.length, messages };
 }
 
 /** Post one frame through the signed lane, as the given identity. */
@@ -291,7 +324,10 @@ await notes.set(note.ns, note.key, stateNoteValue("claimed", ref), {
 // 5 — a third party, holding no secrets, reconstructs the deal from the venue alone.
 console.log();
 log(5, "third-party verification, from the rooms only:");
-const board = await readRoom(OFFER_ROOM);
+// The board, whole: `tclk-offers` carries every deal on the venue, so the tail window
+// this used to read can no longer hold this run's offer by the time step 5 looks (#11).
+// The deal room stays a windowed read — it is derived per contract and holds four frames.
+const board = await exportRoom(OFFER_ROOM);
 const dealLog = await readRoom(room);
 
 const offerLine = board.messages.map((m) => tryDecodeFrame(m.text)).find((f) => f?.id === offer.id);


### PR DESCRIPTION
## What

Step 5's read of `tclk-offers` moves from the venue's tail window to `GET /r/<room>/export`.
The deal-room read is unchanged.

## Why

#11. `?format=json` answers with the newest `limit` records — 50 by default, 200 at most. That
bounds the result rather than paging through history: `since` narrows the window from below and
never anchors it, so once more than `limit` records sit above one, neither parameter reaches it.
`tclk-offers` carries every deal on the venue, so a run's own offer leaves the window mid-deal
and step 5 then fails on a deal that completed correctly. Measured the day this was found: 68
records on the board, the read returning the newest 50.

Subsumes #18, which implements the `since` fix I proposed in #11 before I traced it to
`read_messages`. Against a stub of both read shapes, with the offer 58 records back on a
68-record board:

```
no since        count=50  first=19  finds offer: false
since=offer-1   count=50  first=19  finds offer: false
/export         count=68  first=1   finds offer: true
```

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test`
- [x] Golden vectors untouched — the diff is `examples/` and `CHANGELOG.md` only
- [x] `CHANGELOG.md` has an `[Unreleased]` entry for anything user-visible
- [x] Docs that would now be wrong are updated — none are: `README.md` and `SPEC.md` describe
      what the example does and that `tclk-offers` is public, neither how a reader pages it
- [x] New surface on the money path: **nothing new.** Step 5 is post-settlement verification,
      and the frames it folds already came from a world-writable room any reader could fetch.
      Export returns more of other people's records, which moves the run's `skipped` count and
      no decision — `tryDecodeFrame` returns null and `applyFrame` returns `{ok:false}` rather
      than throwing.