### PR TITLE
feat(rail): add EvmHashRail, a hash-lock evm-htlc settlement rail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules/
 dist/
 coverage/
 *.tsbuildinfo
+
+# Foundry
+out/
+cache/
+broadcast/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- An `evm-htlc` settlement rail (`contracts/EvmHashRail.sol`, `src/evm-hash-rail.ts`, exported
+  from `@flop-labs/tclk/evm-hash-rail`) — the first rail here that holds real value rather than
+  rehearsing (`PaperRail`) or recording in-process (`MemoryRail`). Hash-lock only
+  (`Predicate::Hash`, verified on-chain with the `sha256` precompile to match the statement
+  encoding byte-for-byte); point-lock is a separate rail, later. `viem` is an optional peer
+  dependency kept off the main entry point, so nothing that never touches EVM pays for it. tclk
+  DIDs are Ed25519 and carry no EVM address; the caller supplies the DID → address and
+  asset → token mappings at construction, the same way `PaperRail` takes a `NoteStore` — the
+  protocol layer stays out of it. `claim` is permissionless on-chain: funds move only to the
+  `payee` address recorded at lock time, so relaying a revealed secret gives a stranger
+  nothing to take. `examples/live-deal-evm.mjs` runs the full choreography — offer, accept,
+  lock, reveal — against a throwaway anvil chain it starts itself, and checks the ERC20
+  balance actually moved.
 - A hosted deployment of the MCP server at `https://tclk.technocore.chat/mcp`, streamable
   HTTP, no account and no key. It is the no-custody Worker build: it binds neither
   `TECHNOCORE_SIGNING_KEY` nor `TCLK_PAYMENT_KEY` and refuses to serve if either is present,

--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ three work with what ships here and none of them touch the frames:
 
 ## Status
 
-**Alpha. No rail holds value yet — not "you shouldn't", but "you can't".** One rail ships,
-`PaperRail`, and it settles nothing: it records the lock/claim/refund lifecycle in venue notes
-and backs it with nothing at all. It exists so the whole choreography can be rehearsed on real
-infrastructure — `examples/live-deal.mjs` runs a complete deal end to end — before a rail that
-holds value exists. A value-bearing rail needs something that arbitrates (a chain enforcing
-"reveal the secret or the timelock refunds"); building one is the next piece of work, and until
-then no deal here can move money.
+**Alpha.** `PaperRail` records the lock/claim/refund lifecycle in venue notes and backs it with
+nothing at all — it exists so the whole choreography can be rehearsed on real infrastructure,
+`examples/live-deal.mjs` runs a complete deal end to end. `EvmHashRail`
+([`contracts/EvmHashRail.sol`](contracts/EvmHashRail.sol), hash-lock only) is the first rail
+that holds real value: an EVM chain is the arbiter, enforcing "reveal the secret or the timelock
+refunds" the same as any HTLC — `examples/live-deal-evm.mjs` runs a complete deal against a
+local chain and moves an ERC20 balance. It is new and unaudited; deploy it at your own risk.
+Point-lock settlement (the PTLC half) has no rail yet.
 
 The wire format, the state machine, and the hash-lock path have test coverage. The point-lock /
 adaptor-signature path is **unaudited reference crypto**: full-Schnorr with random nonces, *not*
@@ -53,8 +54,10 @@ Bitcoin today. "PTLC" here means the protocol shape, not Bitcoin compatibility.
 | package | what it is |
 |---|---|
 | [`src/`](src) (`@flop-labs/tclk`) | The core library: frames, contract ids, hash/point locks, the state machine, the `SettlementRail` interface, A2A/ACP mappings. No network calls. |
+| [`contracts/`](contracts) | `EvmHashRail.sol`, the hash-lock `evm-htlc` rail. Bound from TS via `@flop-labs/tclk/evm-hash-rail` (`viem`, optional peer dependency). |
 | [`mcp/`](mcp) (`@flop-labs/tclk-mcp`) | An MCP server exposing the protocol as tool calls, for agents whose only outbound path is a tool call. Stateless — see below. |
 | [`examples/live-deal.mjs`](examples/live-deal.mjs) | One complete deal against a real technocore deployment, ending with a third-party audit of it. Runs a realistic content job: `node examples/live-deal.mjs [x\|ig\|tiktok\|youtube]`. |
+| [`examples/live-deal-evm.mjs`](examples/live-deal-evm.mjs) | One complete deal settled on `EvmHashRail`, against a throwaway `anvil` chain the script starts itself. |
 
 ## Quickstart
 

--- a/contracts/EvmHashRail.sol
+++ b/contracts/EvmHashRail.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import {IERC20} from "./IERC20.sol";
+
+/// @notice tclk/1 `evm-htlc` settlement rail (SPEC.md §5) — hash-lock only (`Predicate::Hash`).
+/// Point-lock (`t*G == Y`) is a separate contract, out of scope here.
+///
+/// One lock per `hashLock`. `hashLock` is the 32-byte sha256 statement tclk already computes
+/// off-chain (`generateHashLock`/`verifySecret` in src/locks.ts) — this contract enforces the
+/// exact same predicate on-chain, using the `sha256` precompile so both sides agree byte-for-byte.
+///
+/// Deadlines (`claimByMs`/`refundAfterMs`) are ms-epoch, matching tclk's `LockTerms` exactly —
+/// this contract never rescales them. Every on-chain comparison instead scales `block.timestamp`
+/// (seconds) up by 1000, so the ms values passed in are stored and compared unmodified.
+contract EvmHashRail {
+    enum Status {
+        None,
+        Locked,
+        Claimed,
+        Refunded
+    }
+
+    struct Lock {
+        address payer;
+        address payee;
+        address token;
+        uint256 amount;
+        uint256 claimByMs;
+        uint256 refundAfterMs;
+        Status status;
+    }
+
+    mapping(bytes32 => Lock) public locks;
+
+    event Locked(
+        bytes32 indexed hashLock,
+        address indexed payer,
+        address indexed payee,
+        address token,
+        uint256 amount,
+        uint256 claimByMs,
+        uint256 refundAfterMs
+    );
+    event Claimed(bytes32 indexed hashLock, bytes32 preimage);
+    event Refunded(bytes32 indexed hashLock);
+
+    /// @notice Escrow `amount` of `token` under `hashLock`, callable by the payer.
+    /// Pulls funds via `transferFrom` — the payer must approve this contract first.
+    function lock(
+        bytes32 hashLock,
+        address payee,
+        uint256 amount,
+        address token,
+        uint256 claimByMs,
+        uint256 refundAfterMs
+    ) external {
+        require(locks[hashLock].status == Status.None, "EvmHashRail: lock exists");
+        require(payee != address(0), "EvmHashRail: payee is zero address");
+        require(amount > 0, "EvmHashRail: amount is zero");
+        require(claimByMs < refundAfterMs, "EvmHashRail: claimByMs must precede refundAfterMs");
+        require(
+            block.timestamp * 1000 < refundAfterMs,
+            "EvmHashRail: refusing to lock into an already-open refund window"
+        );
+
+        locks[hashLock] = Lock({
+            payer: msg.sender,
+            payee: payee,
+            token: token,
+            amount: amount,
+            claimByMs: claimByMs,
+            refundAfterMs: refundAfterMs,
+            status: Status.Locked
+        });
+
+        emit Locked(hashLock, msg.sender, payee, token, amount, claimByMs, refundAfterMs);
+
+        require(
+            IERC20(token).transferFrom(msg.sender, address(this), amount),
+            "EvmHashRail: transferFrom failed"
+        );
+    }
+
+    /// @notice Release to the payee. Permissionless — anyone may relay the preimage, funds
+    /// only ever move to the `payee` address recorded at lock time.
+    function claim(bytes32 hashLock, bytes32 preimage) external {
+        Lock storage held = locks[hashLock];
+        require(held.status != Status.None, "EvmHashRail: claim on an unknown lock");
+        require(held.status == Status.Locked, "EvmHashRail: claim on a lock that is not locked");
+        require(block.timestamp * 1000 < held.refundAfterMs, "EvmHashRail: claim after refundAfterMs");
+        require(sha256(abi.encodePacked(preimage)) == hashLock, "EvmHashRail: secret does not open the statement");
+
+        held.status = Status.Claimed;
+        emit Claimed(hashLock, preimage);
+
+        require(IERC20(held.token).transfer(held.payee, held.amount), "EvmHashRail: transfer failed");
+    }
+
+    /// @notice Return to the payer, only at/after `refundAfterMs`, only the payer.
+    function refund(bytes32 hashLock) external {
+        Lock storage held = locks[hashLock];
+        require(held.status != Status.None, "EvmHashRail: refund on an unknown lock");
+        require(held.status == Status.Locked, "EvmHashRail: refund on a lock that is not locked");
+        require(msg.sender == held.payer, "EvmHashRail: only the payer refunds");
+        require(block.timestamp * 1000 >= held.refundAfterMs, "EvmHashRail: refund before refundAfterMs");
+
+        held.status = Status.Refunded;
+        emit Refunded(hashLock);
+
+        require(IERC20(held.token).transfer(held.payer, held.amount), "EvmHashRail: transfer failed");
+    }
+}

--- a/contracts/IERC20.sol
+++ b/contracts/IERC20.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+/// @notice The minimal ERC20 surface EvmHashRail needs. Deliberately not the full
+/// standard (no metadata, no allowance getter) — this rail only ever calls transferFrom/transfer.
+interface IERC20 {
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function transfer(address to, uint256 amount) external returns (bool);
+}

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import {IERC20} from "../IERC20.sol";
+
+/// @notice Test-only ERC20: public mint, no supply cap, no access control. Never deploy this
+/// for anything real — it exists so EvmHashRail's tests and the anvil e2e demo have a token
+/// to move. Not part of the rail's production surface.
+contract MockERC20 is IERC20 {
+    string public constant name = "Mock FLOP";
+    string public constant symbol = "FLOP";
+    uint8 public constant decimals = 6;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "MockERC20: insufficient allowance");
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) private {
+        require(balanceOf[from] >= amount, "MockERC20: insufficient balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+    }
+}

--- a/examples/live-deal-evm.mjs
+++ b/examples/live-deal-evm.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// One tclk/1 deal, end to end, settled on a real (local) chain instead of rehearsed.
+//
+// Same choreography as live-deal.mjs — offer, accept, lock, reveal — but the rail is
+// contracts/EvmHashRail.sol on a throwaway anvil chain this script starts itself, and the
+// hash lock it settles actually moves an ERC20 balance from payer to payee. No venue: this
+// exercises the settlement leg, which is the part live-deal.mjs's PaperRail cannot.
+//
+//   forge build && pnpm build && node examples/live-deal-evm.mjs
+//
+// Requires `anvil` on PATH (comes with Foundry: https://getfoundry.sh).
+// Set ANVIL_URL to point at a chain you're already running instead of spawning one.
+
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import {
+  createPublicClient, createWalletClient, http, getAddress,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { foundry } from "viem/chains";
+
+import {
+  applyFrame, generateHashLock, lockTerms, makeAccept, makeOffer, openContract,
+} from "../dist/index.js";
+import { EvmHashRail } from "../dist/evm-hash-rail.js";
+import { signerFromSeed } from "../mcp/dist/signing.js";
+
+const log = (step, detail) => console.log(`${String(step).padEnd(3)} ${detail}`);
+
+function artifact(relativePath) {
+  return JSON.parse(readFileSync(new URL(relativePath, import.meta.url)));
+}
+const EvmHashRailArtifact = artifact("../out/EvmHashRail.sol/EvmHashRail.json");
+const MockERC20Artifact = artifact("../out/MockERC20.sol/MockERC20.json");
+
+const RPC_URL = process.env.ANVIL_URL ?? "http://127.0.0.1:8545";
+let anvil = null;
+
+/** Spawn anvil and wait for both RPC readiness and its printed dev account keys. */
+async function startAnvil() {
+  if (process.env.ANVIL_URL) return [];
+  anvil = spawn("anvil", ["--port", new URL(RPC_URL).port || "8545"], { stdio: ["ignore", "pipe", "pipe"] });
+  let out = "";
+  anvil.stdout.on("data", (chunk) => { out += chunk; });
+  anvil.stderr.on("data", (chunk) => { out += chunk; });
+  anvil.on("error", (err) => {
+    console.error(`\nCould not start anvil (${err.message}). Install Foundry: https://getfoundry.sh`);
+    process.exit(1);
+  });
+
+  const deadline = Date.now() + 15_000;
+  for (;;) {
+    try {
+      const res = await fetch(RPC_URL, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: [] }),
+      });
+      if (res.ok) break;
+    } catch { /* not listening yet */ }
+    if (Date.now() > deadline) throw new Error("anvil did not become ready within 15s");
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+
+  const keys = [...out.matchAll(/^\(\d+\)\s+(0x[0-9a-fA-F]{64})\s*$/gm)].map((m) => m[1]);
+  if (keys.length < 2) throw new Error("could not parse anvil's dev account private keys from its output");
+  return keys;
+}
+
+function stopAnvil() {
+  anvil?.kill();
+}
+process.on("exit", stopAnvil);
+process.on("SIGINT", () => { stopAnvil(); process.exit(130); });
+
+try {
+  const devKeys = await startAnvil();
+  log("", `chain      ${RPC_URL}`);
+
+  const publicClient = createPublicClient({ chain: foundry, transport: http(RPC_URL) });
+  const payerAccount = privateKeyToAccount(devKeys[0]);
+  const payeeAccount = privateKeyToAccount(devKeys[1]);
+  const payerEvm = createWalletClient({ chain: foundry, transport: http(RPC_URL), account: payerAccount });
+  const payeeEvm = createWalletClient({ chain: foundry, transport: http(RPC_URL), account: payeeAccount });
+
+  // The tclk-level identities are unrelated key material (Ed25519 DIDs) from the EVM
+  // accounts above (secp256k1) — exactly the gap AddressBook exists to bridge.
+  const payer = signerFromSeed(randomBytes(32));
+  const payee = signerFromSeed(randomBytes(32));
+  log("", `payer did  ${payer.did}`);
+  log("", `payer evm  ${payerAccount.address}`);
+  log("", `payee did  ${payee.did}`);
+  log("", `payee evm  ${payeeAccount.address}`);
+  console.log();
+
+  // 0 — deploy the token and the rail. Any funded account can deploy; here, the payer.
+  const tokenDeployHash = await payerEvm.deployContract({
+    abi: MockERC20Artifact.abi,
+    bytecode: MockERC20Artifact.bytecode.object,
+  });
+  const { contractAddress: token } = await publicClient.waitForTransactionReceipt({ hash: tokenDeployHash });
+
+  const railDeployHash = await payerEvm.deployContract({
+    abi: EvmHashRailArtifact.abi,
+    bytecode: EvmHashRailArtifact.bytecode.object,
+  });
+  const { contractAddress: railAddress } = await publicClient.waitForTransactionReceipt({ hash: railDeployHash });
+  log(0, `deployed   MockERC20 ${token}`);
+  log("", `           EvmHashRail ${railAddress}`);
+
+  const amount = 1_000_000n; // 1.0 FLOP at the mock token's 6 decimals
+  await publicClient.waitForTransactionReceipt({
+    hash: await payerEvm.writeContract({
+      address: token, abi: MockERC20Artifact.abi, functionName: "mint",
+      args: [payerAccount.address, amount],
+    }),
+  });
+  await publicClient.waitForTransactionReceipt({
+    hash: await payerEvm.writeContract({
+      address: token, abi: MockERC20Artifact.abi, functionName: "approve",
+      args: [railAddress, amount],
+    }),
+  });
+  log("", `funded     payer minted ${amount} FLOP, approved the rail`);
+
+  const addressBook = {
+    resolve(did) {
+      if (did === payer.did) return payerAccount.address;
+      if (did === payee.did) return payeeAccount.address;
+      throw new Error(`tclk: no known EVM address for ${did}`);
+    },
+  };
+  const assetBook = {
+    resolve(asset) {
+      if (asset === "FLOP") return getAddress(token);
+      throw new Error(`tclk: no known EVM token for asset ${asset}`);
+    },
+  };
+  const payerRail = new EvmHashRail({
+    publicClient, walletClient: payerEvm, contractAddress: railAddress, addressBook, assetBook,
+  });
+  const payeeRail = new EvmHashRail({
+    publicClient, walletClient: payeeEvm, contractAddress: railAddress, addressBook, assetBook,
+  });
+
+  // 1 — the payer states terms; the payee mints the secret and states only its hash.
+  const now = Date.now();
+  const offer = makeOffer({
+    from: payer.did, role: "payer", lock: "hash", amount: String(amount), asset: "FLOP",
+    rails: ["evm-htlc"],
+    claimByMs: now + 30 * 60_000, refundAfterMs: now + 60 * 60_000, expiresMs: now + 10 * 60_000,
+  });
+  const lock = generateHashLock();
+  const accept = makeAccept(offer, { from: payee.did, statement: lock.hash });
+  log(1, `offer      ${offer.id.slice(0, 18)}…  accept  contract ${accept.contract.slice(0, 18)}…`);
+
+  let payerView = applyFrame(openContract(offer), accept, Date.now()).state;
+  let payeeView = applyFrame(openContract(offer), accept, Date.now()).state;
+
+  // 2 — the payer escrows on-chain.
+  const balanceBefore = {
+    payer: await publicClient.readContract({ address: token, abi: MockERC20Artifact.abi, functionName: "balanceOf", args: [payerAccount.address] }),
+    payee: await publicClient.readContract({ address: token, abi: MockERC20Artifact.abi, functionName: "balanceOf", args: [payeeAccount.address] }),
+  };
+
+  const ref = await payerRail.lock(lockTerms(payerView));
+  const lockFrame = { type: "lock", from: payer.did, contract: accept.contract, rail: "evm-htlc", ref };
+  payerView = applyFrame(payerView, lockFrame, Date.now()).state;
+  payeeView = applyFrame(payeeView, lockFrame, Date.now()).state;
+  log(2, `lock       escrowed on-chain, ref ${ref.slice(0, 18)}…`);
+
+  const held = await payeeRail.verifyLock(lockTerms(payeeView), ref);
+  log("", `payee checked the rail itself → verifyLock ${held}`);
+  if (!held) throw new Error("rail does not hold the lock the frame claims");
+
+  // 3 — the payee reveals and claims. Publishing the secret and calling claim are the
+  // same act here — there is no venue to publish it to, so the on-chain claim tx is the
+  // reveal.
+  const revealFrame = { type: "reveal", from: payee.did, contract: accept.contract, secret: lock.preimage };
+  payerView = applyFrame(payerView, revealFrame, Date.now()).state;
+  payeeView = applyFrame(payeeView, revealFrame, Date.now()).state;
+  await payeeRail.claim(ref, lock.preimage);
+  log(3, `reveal     secret published on-chain, rail record → claimed`);
+
+  const balanceAfter = {
+    payer: await publicClient.readContract({ address: token, abi: MockERC20Artifact.abi, functionName: "balanceOf", args: [payerAccount.address] }),
+    payee: await publicClient.readContract({ address: token, abi: MockERC20Artifact.abi, functionName: "balanceOf", args: [payeeAccount.address] }),
+  };
+
+  console.log();
+  log(4, "balances:");
+  log("", `payer   ${balanceBefore.payer} → ${balanceAfter.payer}  (${balanceAfter.payer - balanceBefore.payer >= 0n ? "+" : ""}${balanceAfter.payer - balanceBefore.payer})`);
+  log("", `payee   ${balanceBefore.payee} → ${balanceAfter.payee}  (+${balanceAfter.payee - balanceBefore.payee})`);
+
+  if (payerView.status !== "claimed" || payeeView.status !== "claimed") {
+    throw new Error(`expected both views claimed, got payer=${payerView.status} payee=${payeeView.status}`);
+  }
+  if (balanceAfter.payee - balanceBefore.payee !== amount) {
+    throw new Error("payee balance did not increase by the locked amount");
+  }
+  if (balanceBefore.payer - balanceAfter.payer !== amount) {
+    throw new Error("payer balance did not decrease by the locked amount");
+  }
+
+  console.log();
+  console.log(`Deal complete. ${amount} FLOP moved payer → payee on-chain, both tclk views agree: claimed.`);
+} finally {
+  stopAnvil();
+}

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "lib/forge-std": {
+    "tag": {
+      "name": "v1.16.2",
+      "rev": "bf647bd6046f2f7da30d0c2bf435e5c76a780c1b"
+    }
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,11 @@
+[profile.default]
+src = "contracts"
+test = "test"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.24"
+optimizer = true
+optimizer_runs = 200
+
+[fmt]
+line_length = 100

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./evm-hash-rail": {
+      "types": "./dist/evm-hash-rail.d.ts",
+      "default": "./dist/evm-hash-rail.js"
     }
   },
   "files": [
@@ -50,9 +54,18 @@
     "@noble/curves": "^2.4.0",
     "@noble/hashes": "^2.4.0"
   },
+  "peerDependencies": {
+    "viem": "^2.56.1"
+  },
+  "peerDependenciesMeta": {
+    "viem": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "typescript": "^7.0.2",
+    "viem": "^2.56.1",
     "vitest": "^4.1.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      viem:
+        specifier: ^2.56.1
+        version: 2.56.1(typescript@7.0.2)(zod@3.25.76)
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@22.20.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.1))
@@ -32,7 +35,7 @@ importers:
         version: link:..
       '@modelcontextprotocol/sdk':
         specifier: ^1.30.0
-        version: 1.30.0(zod@3.25.76)
+        version: 1.30.0(supports-color@10.2.2)(zod@3.25.76)
       '@noble/curves':
         specifier: ^2.4.0
         version: 2.4.0
@@ -60,6 +63,9 @@ importers:
         version: 4.127.1
 
 packages:
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -455,9 +461,21 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@2.4.0':
     resolution: {integrity: sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==}
     engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@2.4.0':
     resolution: {integrity: sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==}
@@ -574,8 +592,17 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
   '@scure/base@2.4.0':
     resolution: {integrity: sha512-thZ1TuJwFwBblOhgsjDKvvGirBxNp+wSvY/DR6tJBJOTDhdAAcHJ8Vbr2eFnqaxeca4+t0i9KBf+uHYGWwZORg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
@@ -748,6 +775,17 @@ packages:
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -886,6 +924,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
   eventsource-parser@3.1.1:
     resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
@@ -991,6 +1032,11 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
 
   jose@6.2.10:
     resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
@@ -1136,6 +1182,14 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  ox@0.14.34:
+    resolution: {integrity: sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -1315,6 +1369,14 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  viem@2.56.1:
+    resolution: {integrity: sha512-D+B87QRiACeWV4VOxn4Kwi4obV0fR2wGpX8bHTUlOnud3O8LTUyXvCqC83otmIww2dDv3vCl3V8a9jWApNP7KA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite@8.2.2:
     resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1454,6 +1516,8 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@adraffy/ens-normalize@1.11.1': {}
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
@@ -1684,7 +1748,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.6.0
 
-  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 2.1.1(hono@4.13.5)
       ajv: 8.20.0
@@ -1694,8 +1758,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.1
-      express: 5.2.1
-      express-rate-limit: 8.7.0(express@5.2.1)
+      express: 5.2.1(supports-color@10.2.2)
+      express-rate-limit: 8.7.0(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)
       hono: 4.13.5
       jose: 6.2.10
       json-schema-typed: 8.0.2
@@ -1706,9 +1770,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/curves@2.4.0':
     dependencies:
       '@noble/hashes': 2.4.0
+
+  '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.4.0': {}
 
@@ -1773,7 +1845,20 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@scure/base@1.2.6': {}
+
   '@scure/base@2.4.0': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@sindresorhus/is@7.2.0': {}
 
@@ -1895,6 +1980,11 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
+  abitype@1.2.3(typescript@7.0.2)(zod@3.25.76):
+    optionalDependencies:
+      typescript: 7.0.2
+      zod: 3.25.76
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -1915,11 +2005,11 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@10.2.2):
     dependencies:
       bytes: 3.1.2
       content-type: 2.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
@@ -1968,9 +2058,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   depd@2.0.0: {}
 
@@ -2035,6 +2127,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter3@5.0.1: {}
+
   eventsource-parser@3.1.1: {}
 
   eventsource@3.0.7:
@@ -2043,28 +2137,28 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express-rate-limit@8.7.0(express@5.2.1):
+  express-rate-limit@8.7.0(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
-      express: 5.2.1
+      debug: 4.4.3(supports-color@10.2.2)
+      express: 5.2.1(supports-color@10.2.2)
       ip-address: 10.7.0
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@10.2.2)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@10.2.2)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -2075,9 +2169,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.16.0
       range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@10.2.2)
+      send: 1.2.1(supports-color@10.2.2)
+      serve-static: 2.2.1(supports-color@10.2.2)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -2092,9 +2186,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.7
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -2161,6 +2255,10 @@ snapshots:
   is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
+
+  isows@1.0.7(ws@8.21.0):
+    dependencies:
+      ws: 8.21.0
 
   jose@6.2.10: {}
 
@@ -2269,6 +2367,21 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  ox@0.14.34(typescript@7.0.2)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@7.0.2)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - zod
+
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
@@ -2333,9 +2446,9 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.6
       '@rolldown/binding-win32-x64-msvc': 1.2.6
 
-  router@2.2.0:
+  router@2.2.0(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -2347,9 +2460,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -2363,12 +2476,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -2508,6 +2621,23 @@ snapshots:
   unpipe@1.0.0: {}
 
   vary@1.1.2: {}
+
+  viem@2.56.1(typescript@7.0.2)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@7.0.2)(zod@3.25.76)
+      isows: 1.0.7(ws@8.21.0)
+      ox: 0.14.34(typescript@7.0.2)(zod@3.25.76)
+      ws: 8.21.0
+    optionalDependencies:
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
 
   vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.1):
     dependencies:

--- a/src/evm-hash-rail.ts
+++ b/src/evm-hash-rail.ts
@@ -12,7 +12,7 @@
 // has no business bridging that. The caller supplies the mapping at construction time, the
 // same way PaperRail takes a NoteStore — a rail's external dependencies are its own concern.
 
-import type { Address, Hex, PublicClient, WalletClient, Account, Chain, Transport } from "viem";
+import { isAddressEqual, type Address, type Hex, type PublicClient, type WalletClient, type Account, type Chain, type Transport } from "viem";
 import type { LockTerms, SettlementRail } from "./rail.js";
 
 export const EVM_HASH_RAIL_ABI = [
@@ -159,9 +159,9 @@ export class EvmHashRail implements SettlementRail {
         });
       return (
         status === OnChainStatus.Locked &&
-        payer === this.addressBook.resolve(terms.payer) &&
-        payee === this.addressBook.resolve(terms.payee) &&
-        token === this.assetBook.resolve(terms.asset) &&
+        isAddressEqual(payer, this.addressBook.resolve(terms.payer)) &&
+        isAddressEqual(payee, this.addressBook.resolve(terms.payee)) &&
+        isAddressEqual(token, this.assetBook.resolve(terms.asset)) &&
         amount === BigInt(terms.amount) &&
         claimByMs === BigInt(terms.claimByMs) &&
         refundAfterMs === BigInt(terms.refundAfterMs)

--- a/src/evm-hash-rail.ts
+++ b/src/evm-hash-rail.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// tclk/1 `evm-htlc` settlement rail (SPEC.md §5) — hash-lock only. Binds LockTerms onto
+// contracts/EvmHashRail.sol. Point-lock (`t*G == Y`) is a separate rail, out of scope here.
+//
+// Not part of the main barrel: this is the package's only dependency on an EVM library, kept
+// behind the "@flop-labs/tclk/evm-hash-rail" subpath so nothing pulls in viem unless it asks
+// to. viem is an optional peerDependency for the same reason.
+//
+// DID -> chain-address mapping is deliberately NOT part of LockTerms: tclk's DIDs (did:key,
+// Ed25519) and an EVM account (secp256k1) are unrelated key material, and the protocol layer
+// has no business bridging that. The caller supplies the mapping at construction time, the
+// same way PaperRail takes a NoteStore — a rail's external dependencies are its own concern.
+
+import type { Address, Hex, PublicClient, WalletClient, Account, Chain, Transport } from "viem";
+import type { LockTerms, SettlementRail } from "./rail.js";
+
+export const EVM_HASH_RAIL_ABI = [
+  {
+    type: "function",
+    name: "lock",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "hashLock", type: "bytes32" },
+      { name: "payee", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "token", type: "address" },
+      { name: "claimByMs", type: "uint256" },
+      { name: "refundAfterMs", type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "claim",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "hashLock", type: "bytes32" },
+      { name: "preimage", type: "bytes32" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "refund",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "hashLock", type: "bytes32" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "locks",
+    stateMutability: "view",
+    inputs: [{ name: "", type: "bytes32" }],
+    outputs: [
+      { name: "payer", type: "address" },
+      { name: "payee", type: "address" },
+      { name: "token", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "claimByMs", type: "uint256" },
+      { name: "refundAfterMs", type: "uint256" },
+      { name: "status", type: "uint8" },
+    ],
+  },
+] as const;
+
+/** Mirrors the Solidity `Status` enum in contracts/EvmHashRail.sol, in declaration order. */
+const enum OnChainStatus {
+  None = 0,
+  Locked = 1,
+  Claimed = 2,
+  Refunded = 3,
+}
+
+/** Resolves a tclk DID to the EVM address it should be paid at, or throws if unknown. */
+export interface AddressBook {
+  resolve(did: string): Address;
+}
+
+/** Resolves a tclk `asset` identifier (e.g. "FLOP") to the ERC20 contract that represents it. */
+export interface AssetBook {
+  resolve(asset: string): Address;
+}
+
+/**
+ * Binds tclk's SettlementRail interface onto contracts/EvmHashRail.sol.
+ *
+ * One instance is bound to one EVM account (`walletClient`) — the same way each party in
+ * examples/live-deal.mjs holds its own rail handle. The party calling `lock`/`refund` must be
+ * this account; `claim` is permissionless on-chain, so any instance can relay it.
+ *
+ * `ref` here is the on-chain lock key, `terms.statement` (the hashLock) — NOT `terms.contract`
+ * like MemoryRail/PaperRail use. The contract has no notion of the tclk contract id; the
+ * hashLock is what it actually indexes locks by.
+ */
+export class EvmHashRail implements SettlementRail {
+  readonly id = "evm-htlc";
+
+  private readonly publicClient: PublicClient;
+  private readonly walletClient: WalletClient<Transport, Chain, Account>;
+  private readonly contractAddress: Address;
+  private readonly addressBook: AddressBook;
+  private readonly assetBook: AssetBook;
+  private readonly clock: () => number;
+
+  constructor(options: {
+    publicClient: PublicClient;
+    walletClient: WalletClient<Transport, Chain, Account>;
+    contractAddress: Address;
+    addressBook: AddressBook;
+    assetBook: AssetBook;
+    clock?: () => number;
+  }) {
+    this.publicClient = options.publicClient;
+    this.walletClient = options.walletClient;
+    this.contractAddress = options.contractAddress;
+    this.addressBook = options.addressBook;
+    this.assetBook = options.assetBook;
+    this.clock = options.clock ?? Date.now;
+  }
+
+  async lock(terms: LockTerms): Promise<string> {
+    if (terms.lock !== "hash") {
+      throw new Error(`tclk: EvmHashRail only supports hash locks, got ${terms.lock}`);
+    }
+    if (this.clock() >= terms.refundAfterMs) {
+      throw new Error("tclk: refusing to lock into an already-open refund window");
+    }
+
+    const hashLock = terms.statement as Hex;
+    const payee = this.addressBook.resolve(terms.payee);
+    const token = this.assetBook.resolve(terms.asset);
+
+    try {
+      const hash = await this.walletClient.writeContract({
+        address: this.contractAddress,
+        abi: EVM_HASH_RAIL_ABI,
+        functionName: "lock",
+        args: [hashLock, payee, BigInt(terms.amount), token, BigInt(terms.claimByMs), BigInt(terms.refundAfterMs)],
+      });
+      await this.publicClient.waitForTransactionReceipt({ hash });
+    } catch (err) {
+      throw new Error(`tclk: ${extractRevertReason(err)}`);
+    }
+
+    // The contract indexes by hashLock, not by the tclk contract id — this IS the ref.
+    return hashLock;
+  }
+
+  async verifyLock(terms: LockTerms, ref: string): Promise<boolean> {
+    if (terms.lock !== "hash" || ref !== terms.statement) return false;
+    try {
+      const [payer, payee, token, amount, claimByMs, refundAfterMs, status] =
+        await this.publicClient.readContract({
+          address: this.contractAddress,
+          abi: EVM_HASH_RAIL_ABI,
+          functionName: "locks",
+          args: [ref as Hex],
+        });
+      return (
+        status === OnChainStatus.Locked &&
+        payer === this.addressBook.resolve(terms.payer) &&
+        payee === this.addressBook.resolve(terms.payee) &&
+        token === this.assetBook.resolve(terms.asset) &&
+        amount === BigInt(terms.amount) &&
+        claimByMs === BigInt(terms.claimByMs) &&
+        refundAfterMs === BigInt(terms.refundAfterMs)
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  async claim(ref: string, secret: string): Promise<void> {
+    try {
+      const hash = await this.walletClient.writeContract({
+        address: this.contractAddress,
+        abi: EVM_HASH_RAIL_ABI,
+        functionName: "claim",
+        args: [ref as Hex, secret as Hex],
+      });
+      await this.publicClient.waitForTransactionReceipt({ hash });
+    } catch (err) {
+      throw new Error(`tclk: ${extractRevertReason(err)}`);
+    }
+  }
+
+  async refund(ref: string): Promise<void> {
+    try {
+      const hash = await this.walletClient.writeContract({
+        address: this.contractAddress,
+        abi: EVM_HASH_RAIL_ABI,
+        functionName: "refund",
+        args: [ref as Hex],
+      });
+      await this.publicClient.waitForTransactionReceipt({ hash });
+    } catch (err) {
+      throw new Error(`tclk: ${extractRevertReason(err)}`);
+    }
+  }
+}
+
+/**
+ * viem surfaces a revert's require() string as `shortMessage` (and nests the same text
+ * through `.walk()` for wrapped errors) — pull that out so callers see "tclk: EvmHashRail:
+ * ..." instead of an ABI-encoding dump. Falls back to the raw error, never throws itself.
+ */
+function extractRevertReason(err: unknown): string {
+  if (err && typeof err === "object") {
+    const withMessage = err as { shortMessage?: unknown; message?: unknown };
+    if (typeof withMessage.shortMessage === "string") return withMessage.shortMessage;
+    if (typeof withMessage.message === "string") return withMessage.message;
+  }
+  return String(err);
+}

--- a/test/EvmHashRail.t.sol
+++ b/test/EvmHashRail.t.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {EvmHashRail} from "../contracts/EvmHashRail.sol";
+import {MockERC20} from "../contracts/mocks/MockERC20.sol";
+
+contract EvmHashRailTest is Test {
+    EvmHashRail rail;
+    MockERC20 token;
+
+    address payer = makeAddr("payer");
+    address payee = makeAddr("payee");
+    address stranger = makeAddr("stranger");
+
+    bytes32 preimage = keccak256("tclk-issue12-and-friends");
+    bytes32 hashLock;
+
+    uint256 amount = 1_000_000;
+    uint256 claimByMs;
+    uint256 refundAfterMs;
+
+    function setUp() public {
+        rail = new EvmHashRail();
+        token = new MockERC20();
+        hashLock = sha256(abi.encodePacked(preimage));
+
+        // Anchor deadlines to the current block time (in ms) so the test doesn't depend on
+        // when it happens to run.
+        claimByMs = block.timestamp * 1000 + 3_600_000;
+        refundAfterMs = block.timestamp * 1000 + 7_200_000;
+
+        token.mint(payer, amount);
+        vm.prank(payer);
+        token.approve(address(rail), amount);
+    }
+
+    function _lock() internal {
+        vm.prank(payer);
+        rail.lock(hashLock, payee, amount, address(token), claimByMs, refundAfterMs);
+    }
+
+    // --- happy path ---
+
+    function test_lockThenClaim_movesFundsToPayee() public {
+        _lock();
+        assertEq(token.balanceOf(address(rail)), amount);
+        assertEq(token.balanceOf(payer), 0);
+
+        rail.claim(hashLock, preimage);
+
+        assertEq(token.balanceOf(payee), amount);
+        assertEq(token.balanceOf(address(rail)), 0);
+        (,,,,,, EvmHashRail.Status status) = rail.locks(hashLock);
+        assertEq(uint8(status), uint8(EvmHashRail.Status.Claimed));
+    }
+
+    function test_claim_isPermissionless() public {
+        _lock();
+        vm.prank(stranger);
+        rail.claim(hashLock, preimage);
+        assertEq(token.balanceOf(payee), amount);
+    }
+
+    // --- claim guards ---
+
+    function test_claim_withWrongPreimage_reverts() public {
+        _lock();
+        vm.expectRevert("EvmHashRail: secret does not open the statement");
+        rail.claim(hashLock, keccak256("wrong secret"));
+    }
+
+    function test_claim_afterRefundWindowOpens_reverts() public {
+        _lock();
+        vm.warp(refundAfterMs / 1000);
+        vm.expectRevert("EvmHashRail: claim after refundAfterMs");
+        rail.claim(hashLock, preimage);
+    }
+
+    function test_claim_onUnknownLock_reverts() public {
+        vm.expectRevert("EvmHashRail: claim on an unknown lock");
+        rail.claim(bytes32(uint256(0xdead)), preimage);
+    }
+
+    function test_claim_afterAlreadyRefunded_reverts() public {
+        _lock();
+        vm.warp(refundAfterMs / 1000);
+        vm.prank(payer);
+        rail.refund(hashLock);
+
+        vm.expectRevert("EvmHashRail: claim on a lock that is not locked");
+        rail.claim(hashLock, preimage);
+    }
+
+    // --- refund guards ---
+
+    function test_refund_beforeWindow_reverts() public {
+        _lock();
+        vm.prank(payer);
+        vm.expectRevert("EvmHashRail: refund before refundAfterMs");
+        rail.refund(hashLock);
+    }
+
+    function test_refund_atBoundary_succeeds() public {
+        _lock();
+        vm.warp(refundAfterMs / 1000);
+        vm.prank(payer);
+        rail.refund(hashLock);
+        assertEq(token.balanceOf(payer), amount);
+    }
+
+    function test_refund_byNonPayer_reverts() public {
+        _lock();
+        vm.warp(refundAfterMs / 1000);
+        vm.expectRevert("EvmHashRail: only the payer refunds");
+        vm.prank(stranger);
+        rail.refund(hashLock);
+    }
+
+    function test_refund_afterAlreadyClaimed_reverts() public {
+        _lock();
+        rail.claim(hashLock, preimage);
+
+        vm.warp(refundAfterMs / 1000);
+        vm.prank(payer);
+        vm.expectRevert("EvmHashRail: refund on a lock that is not locked");
+        rail.refund(hashLock);
+    }
+
+    function test_refund_onUnknownLock_reverts() public {
+        vm.expectRevert("EvmHashRail: refund on an unknown lock");
+        rail.refund(bytes32(uint256(0xdead)));
+    }
+
+    // --- lock guards ---
+
+    function test_lock_duplicateHashLock_reverts() public {
+        _lock();
+        token.mint(payer, amount);
+        vm.prank(payer);
+        token.approve(address(rail), amount);
+
+        vm.prank(payer);
+        vm.expectRevert("EvmHashRail: lock exists");
+        rail.lock(hashLock, payee, amount, address(token), claimByMs, refundAfterMs);
+    }
+
+    function test_lock_intoAlreadyOpenRefundWindow_reverts() public {
+        vm.warp(refundAfterMs / 1000);
+        vm.prank(payer);
+        vm.expectRevert("EvmHashRail: refusing to lock into an already-open refund window");
+        rail.lock(hashLock, payee, amount, address(token), claimByMs, refundAfterMs);
+    }
+
+    function test_lock_withoutAllowance_reverts() public {
+        vm.prank(payer);
+        token.approve(address(rail), 0);
+        vm.prank(payer);
+        vm.expectRevert("MockERC20: insufficient allowance");
+        rail.lock(hashLock, payee, amount, address(token), claimByMs, refundAfterMs);
+    }
+}

--- a/tests/evm-hash-rail.test.ts
+++ b/tests/evm-hash-rail.test.ts
@@ -1,0 +1,86 @@
+/**
+ * verifyLock must not care whether AddressBook/AssetBook and the on-chain read disagree on
+ * casing for the same address — see PR #21 review feedback (string equality on EVM addresses
+ * broke when one side was checksummed and the other wasn't).
+ */
+
+import { describe, it, expect } from "vitest";
+import { getAddress, type Address, type PublicClient, type WalletClient, type Account, type Chain, type Transport } from "viem";
+
+import { EvmHashRail, type AddressBook, type AssetBook } from "../src/evm-hash-rail.js";
+import type { LockTerms } from "../src/rail.js";
+
+const PAYER_LOWER = "0xaaaa1111bbbb2222cccc3333dddd4444eeee5566" as Address;
+const PAYEE_LOWER = "0xbbbb2222cccc3333dddd4444eeee5566aaaa1111" as Address;
+const TOKEN_LOWER = "0xcccc3333dddd4444eeee5566aaaa1111bbbb2222" as Address;
+
+const PAYER_CHECKSUM = getAddress(PAYER_LOWER);
+const PAYEE_CHECKSUM = getAddress(PAYEE_LOWER);
+const TOKEN_CHECKSUM = getAddress(TOKEN_LOWER);
+
+const terms: LockTerms = {
+  contract: "tclk1test",
+  lock: "hash",
+  statement: "0x" + "ab".repeat(32),
+  amount: "1000000",
+  asset: "FLOP",
+  payer: "did:key:zPayer",
+  payee: "did:key:zPayee",
+  claimByMs: 1_756_700_000_000,
+  refundAfterMs: 1_756_707_200_000,
+};
+
+/** locks(hashLock) tuple, with the on-chain addresses in whichever casing the chain returns. */
+function locksResult(payer: Address, payee: Address, token: Address) {
+  return [
+    payer,
+    payee,
+    token,
+    BigInt(terms.amount),
+    BigInt(terms.claimByMs),
+    BigInt(terms.refundAfterMs),
+    1, // OnChainStatus.Locked
+  ] as const;
+}
+
+function railWith(addressBook: AddressBook, assetBook: AssetBook, onChain: ReturnType<typeof locksResult>) {
+  const publicClient = { readContract: async () => onChain } as unknown as PublicClient;
+  const walletClient = {} as unknown as WalletClient<Transport, Chain, Account>;
+  return new EvmHashRail({
+    publicClient,
+    walletClient,
+    contractAddress: "0x0000000000000000000000000000000000dEaD",
+    addressBook,
+    assetBook,
+  });
+}
+
+describe("EvmHashRail.verifyLock — address comparison is case-insensitive", () => {
+  it("matches when AddressBook/AssetBook resolve lowercase but the chain returns checksummed", async () => {
+    const addressBook: AddressBook = {
+      resolve: (did) => (did === terms.payer ? PAYER_LOWER : PAYEE_LOWER),
+    };
+    const assetBook: AssetBook = { resolve: () => TOKEN_LOWER };
+    const rail = railWith(addressBook, assetBook, locksResult(PAYER_CHECKSUM, PAYEE_CHECKSUM, TOKEN_CHECKSUM));
+
+    expect(await rail.verifyLock(terms, terms.statement)).toBe(true);
+  });
+
+  it("matches when AddressBook/AssetBook resolve checksummed and the chain returns lowercase", async () => {
+    const addressBook: AddressBook = {
+      resolve: (did) => (did === terms.payer ? PAYER_CHECKSUM : PAYEE_CHECKSUM),
+    };
+    const assetBook: AssetBook = { resolve: () => TOKEN_CHECKSUM };
+    const rail = railWith(addressBook, assetBook, locksResult(PAYER_LOWER, PAYEE_LOWER, TOKEN_LOWER));
+
+    expect(await rail.verifyLock(terms, terms.statement)).toBe(true);
+  });
+
+  it("still fails closed when the addresses are genuinely different", async () => {
+    const addressBook: AddressBook = { resolve: () => PAYER_LOWER };
+    const assetBook: AssetBook = { resolve: () => TOKEN_LOWER };
+    const rail = railWith(addressBook, assetBook, locksResult(PAYEE_CHECKSUM, PAYEE_CHECKSUM, TOKEN_CHECKSUM));
+
+    expect(await rail.verifyLock(terms, terms.statement)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds `EvmHashRail` (`contracts/EvmHashRail.sol` + `src/evm-hash-rail.ts`, exported as
`@flop-labs/tclk/evm-hash-rail`) — a `SettlementRail` that actually escrows and moves an
ERC20 balance on an EVM chain, hash-lock only. `examples/live-deal-evm.mjs` runs
offer→accept→lock→reveal against a local `anvil` chain and checks the balance moved.

## Why

SPEC.md §5 already names `evm-htlc` as a rail to bind later. Every existing rail either
settles nothing (`PaperRail`) or stays in-process (`MemoryRail`). No wire-format,
state-machine, or `SettlementRail`-interface change, so no prior issue discussion was
needed per CONTRIBUTING.md. `SPEC.md` needed no changes; `README.md`'s "no rail holds
value yet" line did, and is updated.

Money path, since this is new surface:
- `claim` is permissionless on-chain, but funds move only to the `payee` address recorded
  at lock time — a third party relaying the revealed preimage gets nothing for it.
- `refund` is restricted to the payer, and only at/after `refundAfterMs`.
- Locking twice under the same `hashLock` reverts.

Deliberately out of scope: point-lock, native ETH, multiple tokens per rail instance,
fee-on-transfer/rebasing tokens (amount accounting assumes standard ERC20 transfer
semantics).

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` — 124 passed (60 root + 33 mcp + 31 worker)
- [x] Golden vectors untouched — no wire format change
- [x] `CHANGELOG.md` has an `[Unreleased]` entry
- [x] Docs updated: `README.md` Status section + package table (`SPEC.md`/`AGENTS.md`
      needed no changes — `evm-htlc` was already named in SPEC.md §5)
- [x] New surface on the money path: see "Why" above

`forge test`: 14/14 passing (Solidity-side coverage for `EvmHashRail.sol`, not part of the
JS CI pipeline).
