### PR TITLE
fix: enforce even-length hex in SCALAR_HEX and add per-frame timestamps to apply_transcript

### DIFF
--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -200,6 +200,7 @@ export function createServer(options: HandlerOptions = {}): McpServer {
       inputSchema: {
         lines: z.array(z.string()).describe("Room lines, oldest first."),
         nowMs: z.number().int().optional().describe("Wall clock for the deadline guards; defaults to now."),
+        timestamps: z.array(z.number().int()).optional().describe("Per-line wall-clock timestamps (ms); when provided, timestamps[i] is used for line i instead of nowMs."),
       },
     },
     (args) => run(() => h.tclk_apply_transcript(args)),

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -240,7 +240,7 @@ export function createHandlers(options: HandlerOptions = {}) {
      * nothing here throws on a bad one: every line gets an `{ ok, reason }` verdict and
      * money-state only advances on frames that verify.
      */
-    tclk_apply_transcript(input: { lines: string[]; nowMs?: number }) {
+    tclk_apply_transcript(input: { lines: string[]; nowMs?: number; timestamps?: number[] }) {
       const nowMs = input.nowMs ?? Date.now();
       const steps: { index: number; type?: string; ok: boolean; reason?: string }[] = [];
       let state: ContractState | null = null;
@@ -270,7 +270,8 @@ export function createHandlers(options: HandlerOptions = {}) {
           }
           return;
         }
-        const result = applyFrame(state, frame, nowMs);
+        const frameNowMs = input.timestamps?.[index] ?? nowMs;
+        const result = applyFrame(state, frame, frameNowMs);
         state = result.state;
         steps.push({ index, type: frame.type, ok: result.ok, reason: result.reason });
       });

--- a/mcp/worker/src/tool-manifest.generated.ts
+++ b/mcp/worker/src/tool-manifest.generated.ts
@@ -270,6 +270,13 @@ export const TOOLS: readonly ManifestTool[] = [
         "nowMs": {
           "type": "integer",
           "description": "Wall clock for the deadline guards; defaults to now."
+        },
+        "timestamps": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "description": "Per-line wall-clock timestamps (ms); when provided, timestamps[i] is used for line i instead of nowMs."
         }
       },
       "required": [

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -141,7 +141,7 @@ const AMOUNT = /^[1-9][0-9]*$/;
 const ASSET = /^[A-Za-z0-9_-]{1,32}$/;
 const RAIL = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 const NONCE = /^[0-9a-f]{8,64}$/;
-const SCALAR_HEX = /^0x[0-9a-f]{1,64}$/;
+const SCALAR_HEX = /^0x(?:[0-9a-f]{2}){1,32}$/;
 
 function fail(msg: string): never {
   throw new Error(`tclk: ${msg}`);


### PR DESCRIPTION
## Summary

- **SCALAR_HEX** (`src/frames.ts:144`): regex now requires paired hex digits (`{2}` groups), rejecting odd-length values like `"0xabc"` that pass validation but throw in `hexToU8a`. A malicious payer could use this to stall PTLC deals. Fixes #22.
- **tclk_apply_transcript** (`mcp/src/tools.ts:243`): accepts an optional `timestamps[]` array so callers can supply per-frame wall-clock times, enabling accurate transcript replay after `refundAfterMs` has passed. Without this, replaying a completed deal's transcript reports it as incomplete. Fixes #23.

## Test plan

- [ ] Existing `vitest` suite passes (`pnpm test`)
- [ ] Verify `SCALAR_HEX` rejects `"0xabc"` (odd-length) and accepts `"0xabcd"` (even-length)
- [ ] Verify `tclk_apply_transcript` with `timestamps[]` replays a post-deadline transcript correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)