### PR TITLE
fix(adaptor): reject an out-of-range scalar instead of reducing it

### DIFF
--- a/src/adaptor.ts
+++ b/src/adaptor.ts
@@ -31,8 +31,11 @@ const N: bigint = P256.CURVE().n;
 const mod = (a: bigint): bigint => ((a % N) + N) % N;
 
 function toScalar(hex: string): bigint {
-  const v = mod(BigInt(u8aToHex(hexToU8a(hex))));
-  if (v === 0n) throw new Error("scalar is zero / out of range");
+  // Reject out of range rather than reducing: `points.ts` refuses a witness >= n to
+  // mirror the on-chain `Scalar::from_repr`, so reducing here would let `adapt` accept
+  // a witness the same library — and the chain — call invalid.
+  const v = BigInt(u8aToHex(hexToU8a(hex)));
+  if (v === 0n || v >= N) throw new Error("scalar is zero / out of range");
   return v;
 }
 

--- a/tests/adaptor.test.ts
+++ b/tests/adaptor.test.ts
@@ -8,7 +8,13 @@
 
 import { describe, it, expect } from "vitest";
 
-import { generatePointLock, schnorrAdaptor, verifyPointWitness } from "../src/index.js";
+import {
+  generatePointLock,
+  pointLockFromWitness,
+  schnorrAdaptor,
+  verifyPointWitness,
+} from "../src/index.js";
+import { SECP256K1_N } from "../src/points.js";
 
 const { getPublicKey, preSign, adapt, extractWitness, verifyPreSignature, verifySignature } =
   schnorrAdaptor;
@@ -89,5 +95,34 @@ describe("Schnorr adaptor signature", () => {
     expect(adapt({ nonce: "0xbad", s: pre.s }, t)).toBeNull();
     // extractWitness: malformed scalars.
     expect(extractWitness({ nonce: pre.nonce, s: "0xzz" }, { nonce: pre.nonce, s: pre.s })).toBeNull();
+  });
+});
+
+describe("scalar range", () => {
+  const OVER_ORDER = "0x" + (SECP256K1_N + 1n).toString(16).padStart(64, "0");
+
+  it("adapt refuses a witness the point lock refuses", () => {
+    // pointLockFromWitness rejects a scalar >= n, so no statement can ever carry this as
+    // its witness. Completing a pre-signature with it must fail rather than quietly adapt
+    // under `witness mod n`.
+    expect(() => pointLockFromWitness(OVER_ORDER)).toThrow();
+
+    const lock = generatePointLock();
+    const pre = preSign(SK, MSG, lock.statement);
+    expect(pre).not.toBeNull();
+    expect(adapt(pre!, OVER_ORDER)).toBeNull();
+  });
+
+  it("a secret key out of range has no public key", () => {
+    expect(getPublicKey(OVER_ORDER)).toBeNull();
+  });
+
+  it("a pre-signature scalar out of range does not verify", () => {
+    const lock = generatePointLock();
+    const publicKey = getPublicKey(SK)!;
+    const pre = preSign(SK, MSG, lock.statement)!;
+    expect(verifyPreSignature(publicKey, MSG, lock.statement, { ...pre, s: OVER_ORDER })).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## What

`toScalar` reduces before it checks:

```ts
const v = mod(BigInt(u8aToHex(hexToU8a(hex))));
if (v === 0n) throw new Error("scalar is zero / out of range");
```

So a scalar `>= n` is not refused, it is accepted as `value mod n`. The error string already promises the range half; only the zero half was implemented.

`points.ts` refuses exactly that value, and says why:

```ts
// Witnesses must be a scalar in [1, n). Off-chain validation mirrors the on-chain
// `Scalar::from_repr` (rejects y >= n) and the explicit `y != 0` guard.
```

## The two halves disagree

`pointLockFromWitness(n + 1)` throws, so no statement can ever carry that as its witness. `adapt(pre, n + 1)` returns a signature anyway, having completed under the witness `1`.

Measured on `main`:

```
points.ts accepts:  false
adaptor.ts accepts: true
```

The module header names that linkage as the load-bearing property:

> completing an adaptor signature reveals the witness `t`, and that exact `t` opens the on-chain `Point(T=t·G)` escrow leaf (`verifyPointWitness`). That is the PTLC atomic-linkage guarantee.

"That exact `t`" is what the reduction breaks: the caller hands `adapt` one witness and the chain is opened by a different one. The same gap makes `getPublicKey` return a key for a secret key the curve does not have.

## Change

Drop the reduction, reject `v >= n`. Every call site is already inside a `try { … } catch { return null / false }`, so a malformed scalar now fails closed the way the doc comments say it does — `adapt` documents "or `null` if `pre` or `witness` is malformed", and this is what makes that true.

Nothing valid changes: scalars the library produces come out of `scalarHex`, which reduces, so they are always in range.

## Tests

Three cases added to `tests/adaptor.test.ts`.

Two of them fail against `main`:

```
× adapt refuses a witness the point lock refuses
× a secret key out of range has no public key
```

The third — a pre-signature scalar out of range must not verify — passes either way, because the reduced scalar fails the group equation for an unrelated reason. It is kept as a regression guard rather than as evidence.

With the change, `vitest run` is 63/63 and `tsc -p tsconfig.json --noEmit` is clean.

## Not in scope

`points.ts` also requires a witness to be exactly 32 bytes; `toScalar` accepts any length, so `0x01` is scalar 1. That is a second difference between the two modules and I have left it alone — tightening it would reject inputs the current tests pass, and it is a separate decision from the range check.