### PR TITLE
Reject malformed PaperRail statements during decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `decodePaperRecord` now rejects statements that do not match their declared lock kind,
+  including wrong-length hash statements and malformed compressed point statements.
 - `SPEC.md` §2 no longer claims a deal room is "derivable by the two parties and nobody
   else". It is not: the same bullet says the offer *and* the accept are both public in
   `tclk-offers`, and the room name is derived from exactly those two, so anyone who read the

--- a/src/paper-rail.ts
+++ b/src/paper-rail.ts
@@ -19,7 +19,7 @@
 // so this is not a weaker escrow — it is not escrow. A rail that holds value needs an
 // arbiter, which is what the on-chain rails in SPEC.md §5 are for.
 
-import type { LockKind } from "./frames.js";
+import { isValidStatement, type LockKind } from "./frames.js";
 import { verifySecret } from "./locks.js";
 import type { LockTerms, SettlementRail } from "./rail.js";
 
@@ -77,7 +77,7 @@ export function decodePaperRecord(value: string): PaperRecord | null {
   if (prefix !== PAPER_RECORD_PREFIX) return null;
   if (status !== "locked" && status !== "claimed" && status !== "refunded") return null;
   if (lock !== "hash" && lock !== "point") return null;
-  if (!/^0x[0-9a-f]{64,66}$/.test(statement)) return null;
+  if (!isValidStatement(lock, statement)) return null;
   const refundAfterMs = Number(refundAfter);
   if (!Number.isSafeInteger(refundAfterMs) || refundAfterMs <= 0) return null;
   if (secret !== undefined && !/^0x[0-9a-f]{64}$/.test(secret)) return null;

--- a/tests/paper-rail.test.ts
+++ b/tests/paper-rail.test.ts
@@ -156,6 +156,18 @@ describe("paper rail — reads are anonymous input", () => {
     }
   });
 
+  it("rejects statements that do not fit their declared lock kind", () => {
+    for (const malformed of [
+      `tclkpaper1 locked hash 0x${"ab".repeat(33)} ${REFUND_AFTER}`,
+      `tclkpaper1 locked hash 0x${"a".repeat(65)} ${REFUND_AFTER}`,
+      `tclkpaper1 locked point 0x${"ab".repeat(32)} ${REFUND_AFTER}`,
+      `tclkpaper1 locked point 0x04${"11".repeat(32)} ${REFUND_AFTER}`,
+      `tclkpaper1 locked point 0x02${"ff".repeat(32)} ${REFUND_AFTER}`,
+    ]) {
+      expect(decodePaperRecord(malformed), malformed).toBeNull();
+    }
+  });
+
   it("round-trips every record shape it emits", () => {
     const statement = "0x" + "ab".repeat(32);
     for (const record of [


### PR DESCRIPTION
## Summary

- Reject malformed PaperRail lock statements during decoding.
- Reuse the existing statement validator so decoding follows the same lock-format rules as the rest of the protocol.

## Problem

`decodePaperRecord` previously accepted some malformed hash and point statements that do not satisfy the format defined by the specification.

## Fix

Validate the decoded statement with the existing `isValidStatement` helper before returning a `PaperRecord`.

## Tests

- Add regression coverage for representative malformed hash and point statements.
- Full test suite: 125 passed, 0 failed.

## Compatibility

Valid hash and compressed-point statements continue to decode. The public API and wire format are unchanged.