### PR TITLE
fix: bind a frame's `from` to the sender of the record that carried it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- The rule `SPEC.md` §2 states as a MUST is now something the code can enforce: a frame's
+  `from` must be the transport-verified sender of the record that carried it. Nothing
+  checked it. `applyFrame` and `openContract` take an optional `sender`, and a frame whose
+  `from` differs is rejected like any other bad frame; omitting it keeps the previous
+  behaviour, so no existing caller changes. Without this every party guard in the machine
+  (`only the payer locks`, `only the payee reveals`, `cancel from a non-party`) compares
+  one attacker-writable field against another: `frame.from` is a key in a JSON body, and
+  the identities it is matched against were themselves read out of earlier bodies. A
+  stranger who can write into the room could post a well-formed `lock` naming the payer
+  and every reader would fold it to `locked`, with no escrow behind it.
+- `tclk_read_room` reported the venue's verified sender and the frame's claimed one side
+  by side without ever comparing them. Each frame now carries `signed` and `attributed`,
+  the response carries an `unattributed` count and a `senders` array, and nothing is
+  dropped — an unattributed frame is evidence, not noise. `tclk_apply_transcript` takes
+  that `senders` array positionally, which is what the pipeline was missing: its input was
+  `lines` alone, so the documented read-then-fold path could not have enforced §2 no
+  matter how carefully a caller used it.
+- `tclk_apply_transcript` no longer reports "transcript contains no offer frame to open a
+  contract from" when a transcript's offer frame was found and rejected. It names the
+  rejection instead.
 - `SPEC.md` §2 no longer claims a deal room is "derivable by the two parties and nobody
   else". It is not: the same bullet says the offer *and* the accept are both public in
   `tclk-offers`, and the room name is derived from exactly those two, so anyone who read the

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -195,11 +195,20 @@ export function createServer(options: HandlerOptions = {}): McpServer {
       description:
         "Fold room lines into one contract view: opens from the first offer frame and " +
         "applies the rest fail-closed, with a per-line verdict. Reports only WHETHER a " +
-        "secret was revealed, never its value.",
+        "secret was revealed, never its value. Pass `senders` from tclk_read_room to " +
+        "enforce that each frame's `from` is the identity that actually signed it.",
       annotations: READS,
       inputSchema: {
         lines: z.array(z.string()).describe("Room lines, oldest first."),
         nowMs: z.number().int().optional().describe("Wall clock for the deadline guards; defaults to now."),
+        senders: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Transport-verified sender of each line, positionally aligned with `lines` " +
+              "(tclk_read_room returns it as `senders`). A line whose frame `from` differs " +
+              "is rejected. Omit an entry to leave that line unchecked.",
+          ),
       },
     },
     (args) => run(() => h.tclk_apply_transcript(args)),
@@ -299,7 +308,10 @@ export function createServer(options: HandlerOptions = {}): McpServer {
     {
       description:
         "Read a room and return only its decodable tclk/1 frames, with a count of the " +
-        "lines skipped. Content is untrusted input from strangers.",
+        "lines skipped. Content is untrusted input from strangers: each frame carries " +
+        "`from` (the sender the venue verified a signature against), `signed`, and " +
+        "`attributed` (whether the frame's own `from` matches that sender), plus a " +
+        "`senders` array to hand to tclk_apply_transcript.",
       annotations: NETWORK_READS,
       inputSchema: { room, since: z.number().int().optional().describe("The last seq you saw.") },
     },

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -239,11 +239,23 @@ export function createHandlers(options: HandlerOptions = {}) {
      * Fold a room transcript into one contract view. Lines are anonymous input, so
      * nothing here throws on a bad one: every line gets an `{ ok, reason }` verdict and
      * money-state only advances on frames that verify.
+     *
+     * `senders[i]` is the transport-verified `from` of the record that carried `lines[i]`
+     * — `tclk_read_room` returns it as `from` on every frame. Supplying it is what makes
+     * the party guards mean anything: SPEC §2 requires a frame's own `from` to match the
+     * signed-lane sender, and a fold over bare lines cannot check that, because the only
+     * two identities it can see both came out of the same attacker-writable JSON body.
+     * A mismatch is a per-line rejection like any other, never a throw. Sparse arrays are
+     * fine: an absent entry leaves that line unchecked.
      */
-    tclk_apply_transcript(input: { lines: string[]; nowMs?: number }) {
+    tclk_apply_transcript(input: { lines: string[]; nowMs?: number; senders?: string[] }) {
       const nowMs = input.nowMs ?? Date.now();
       const steps: { index: number; type?: string; ok: boolean; reason?: string }[] = [];
       let state: ContractState | null = null;
+      // Why the first offer frame did not open a contract, if one was tried. Without it
+      // a transcript whose offer was rejected reports "contains no offer frame", which
+      // is the one thing that is not true about it.
+      let openFailure: string | null = null;
 
       input.lines.forEach((line, index) => {
         const frame = tryDecodeFrame(line);
@@ -263,19 +275,27 @@ export function createHandlers(options: HandlerOptions = {}) {
             return;
           }
           try {
-            state = openContract(frame);
+            state = openContract(frame, input.senders?.[index]);
             steps.push({ index, type: "offer", ok: true });
           } catch (error) {
-            steps.push({ index, type: "offer", ok: false, reason: errorMessage(error) });
+            const reason = errorMessage(error);
+            openFailure ??= reason;
+            steps.push({ index, type: "offer", ok: false, reason });
           }
           return;
         }
-        const result = applyFrame(state, frame, nowMs);
+        const result = applyFrame(state, frame, nowMs, input.senders?.[index]);
         state = result.state;
         steps.push({ index, type: frame.type, ok: result.ok, reason: result.reason });
       });
 
-      if (state === null) fail("transcript contains no offer frame to open a contract from");
+      if (state === null) {
+        fail(
+          openFailure === null
+            ? "transcript contains no offer frame to open a contract from"
+            : `no contract could be opened: ${openFailure}`,
+        );
+      }
       const open: ContractState = state;
 
       return {
@@ -422,19 +442,51 @@ export function createHandlers(options: HandlerOptions = {}) {
       };
     },
 
+    /**
+     * Read a room and return its decodable frames, each carrying the venue's own verdict
+     * on who sent it.
+     *
+     * `from` is the record's transport-verified sender; `frame.from` is a field inside a
+     * body anyone with a socket can write. They are different things, and SPEC §2 requires
+     * them to match, so this reports the comparison rather than leaving a caller to notice
+     * that it never happened: `signed` says the venue carried a signature at all (the
+     * unsigned lane carries none, and its `from` is a nickname that can never be a
+     * did:key), and `attributed` says the frame is what its own `from` claims. Nothing is
+     * dropped — an unattributed frame is still a fact about the room, and hiding it would
+     * lose the evidence that someone tried. Feed `senders` to `tclk_apply_transcript` to
+     * have the fold enforce it.
+     */
     async tclk_read_room(input: { room: string; since?: number }) {
       const view = await client.readRoom(input.room, input.since);
-      const frames: { seq: number; ts: string; from: string; frame: TclkFrame }[] = [];
+      const frames: {
+        seq: number;
+        ts: string;
+        from: string;
+        signed: boolean;
+        attributed: boolean;
+        frame: TclkFrame;
+      }[] = [];
       let skipped = 0;
+      let unattributed = 0;
       for (const message of view.messages) {
         const frame = typeof message.text === "string" ? tryDecodeFrame(message.text) : null;
         if (frame === null) {
           skipped += 1;
           continue;
         }
-        frames.push({ seq: message.seq, ts: message.ts, from: message.from, frame });
+        const signed = typeof message.sig === "string" && message.sig.length > 0;
+        const attributed = signed && message.from === frame.from;
+        if (!attributed) unattributed += 1;
+        frames.push({ seq: message.seq, ts: message.ts, from: message.from, signed, attributed, frame });
       }
-      return { room: view.room, frames, skipped, lastSeq: view.last_seq };
+      return {
+        room: view.room,
+        frames,
+        senders: frames.map((f) => f.from),
+        skipped,
+        unattributed,
+        lastSeq: view.last_seq,
+      };
     },
 
     tclk_whoami() {

--- a/mcp/tests/fixtures.ts
+++ b/mcp/tests/fixtures.ts
@@ -17,6 +17,10 @@ export const PAYEE_SEED = "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf
 export const PAYER_DID = signerFromSeed(hexToBytes(PAYER_SEED)).did;
 export const PAYEE_DID = signerFromSeed(hexToBytes(PAYEE_SEED)).did;
 
+/** A third identity: party to nothing, able to write into any room the two parties use. */
+export const STRANGER_SEED = "c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7";
+export const STRANGER_DID = signerFromSeed(hexToBytes(STRANGER_SEED)).did;
+
 /** A 32-byte secp256k1 scalar, valid for `TCLK_PAYMENT_KEY`. */
 export const PAYMENT_KEY = "1111111111111111111111111111111111111111111111111111111111111111";
 

--- a/mcp/tests/transcript.test.ts
+++ b/mcp/tests/transcript.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, it } from "vitest";
 
 import { createHandlers } from "../src/tools.js";
-import { HASH_OFFER, NOW, PAYEE_DID, PAYER_DID } from "./fixtures.js";
+import { HASH_OFFER, NOW, PAYEE_DID, PAYER_DID, STRANGER_DID } from "./fixtures.js";
 
 const h = createHandlers({ env: {} });
 
@@ -136,5 +136,72 @@ describe("fail-closed folding", () => {
     expect(() => h.tclk_apply_transcript({ lines: ["gm", "still not a frame"] })).toThrow(
       /no offer frame/,
     );
+  });
+});
+
+describe("sender binding (SPEC §2)", () => {
+  it("rejects a frame whose `from` is not the identity that signed the record", () => {
+    const { offer, accept } = openDeal();
+    // A stranger reads the public board, copies the contract id, and posts a lock frame
+    // claiming to be the payer. The line itself is well-formed and the party guard is
+    // satisfied — both identities it compares came out of attacker-writable JSON.
+    const forgedLock = h.tclk_make_lock({
+      from: PAYER_DID,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-does-not-exist",
+    });
+    const lines = [offer.line, accept.line, forgedLock.line];
+
+    const unbound = h.tclk_apply_transcript({ lines, nowMs: NOW + 1 });
+    expect(unbound.status).toBe("locked");
+
+    const bound = h.tclk_apply_transcript({
+      lines,
+      nowMs: NOW + 1,
+      senders: [PAYER_DID, PAYEE_DID, STRANGER_DID],
+    });
+    expect(bound.status).toBe("accepted");
+    expect(bound.steps[2]).toMatchObject({ index: 2, ok: false });
+    expect(bound.steps[2].reason).toMatch(/lock\.from is not the sender/);
+  });
+
+  it("a truthful transcript folds identically with senders supplied", () => {
+    const { offer, accept } = openDeal();
+    const lock = h.tclk_make_lock({
+      from: PAYER_DID,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-42",
+    });
+    const reveal = h.tclk_make_reveal({
+      from: PAYEE_DID,
+      contract: accept.contract,
+      secret: accept.secret,
+    });
+    const lines = [offer.line, accept.line, lock.line, reveal.line];
+    const senders = [PAYER_DID, PAYEE_DID, PAYER_DID, PAYEE_DID];
+
+    const bound = h.tclk_apply_transcript({ lines, nowMs: NOW + 1, senders });
+    expect(bound.steps.map((s) => s.ok)).toEqual([true, true, true, true]);
+    expect(bound.status).toBe("claimed");
+  });
+
+  it("a forged offer cannot open a contract under someone else's identity", () => {
+    const { offer } = openDeal();
+    expect(() =>
+      h.tclk_apply_transcript({ lines: [offer.line], nowMs: NOW, senders: [STRANGER_DID] }),
+    ).toThrow(/no contract could be opened: .*not the sender of the record/);
+  });
+
+  it("a short `senders` array leaves the remaining lines unchecked", () => {
+    const { offer, accept } = openDeal();
+    const bound = h.tclk_apply_transcript({
+      lines: [offer.line, accept.line],
+      nowMs: NOW + 1,
+      senders: [PAYER_DID],
+    });
+    expect(bound.steps.map((s) => s.ok)).toEqual([true, true]);
+    expect(bound.status).toBe("accepted");
   });
 });

--- a/mcp/tests/transport.test.ts
+++ b/mcp/tests/transport.test.ts
@@ -7,7 +7,7 @@ import { ed25519 } from "@noble/curves/ed25519.js";
 
 import { canonicalMessage, signerFromSeed } from "../src/signing.js";
 import { createHandlers } from "../src/tools.js";
-import { HASH_OFFER, PAYER_SEED, fakeFetch, hexToBytes } from "./fixtures.js";
+import { HASH_OFFER, PAYER_SEED, STRANGER_DID, fakeFetch, hexToBytes } from "./fixtures.js";
 
 const ROOM = "mb-p-tclk-deadbeefdeadbeef";
 const signer = signerFromSeed(hexToBytes(PAYER_SEED));
@@ -113,7 +113,7 @@ describe("tclk_read_room", () => {
           last_seq: 13,
           messages: [
             { seq: 10, ts: "2026-01-01T00:00:00Z", from: "~stranger", text: "gm" },
-            { seq: 11, ts: "2026-01-01T00:00:01Z", from: signer.did, text: line },
+            { seq: 11, ts: "2026-01-01T00:00:01Z", from: signer.did, sig: "s".repeat(86), text: line },
             { seq: 12, ts: "2026-01-01T00:00:02Z", from: "~spoofer", text: 'tclk1 {"type":"offer"}' },
             { seq: 13, ts: "2026-01-01T00:00:03Z", from: "~stranger", text: "tclk1 not-json" },
           ],
@@ -127,8 +127,43 @@ describe("tclk_read_room", () => {
     expect(result.lastSeq).toBe(13);
     expect(result.skipped).toBe(3);
     expect(result.frames).toHaveLength(1);
-    expect(result.frames[0]).toMatchObject({ seq: 11, from: signer.did });
+    expect(result.frames[0]).toMatchObject({ seq: 11, from: signer.did, signed: true, attributed: true });
     expect(result.frames[0].frame.type).toBe("offer");
+    expect(result.unattributed).toBe(0);
+    expect(result.senders).toEqual([signer.did]);
+  });
+
+  it("reports a well-formed frame that its record did not sign for", async () => {
+    // The line is a valid offer claiming PAYER_DID, but the venue verified the signature
+    // of somebody else. `skipped` will never catch this: nothing is malformed.
+    const line = offerLine();
+    const { fetchLike } = fakeFetch([
+      {
+        body: "",
+        json: {
+          room: "tclk-offers",
+          count: 2,
+          last_seq: 21,
+          messages: [
+            { seq: 20, ts: "2026-01-01T00:00:00Z", from: STRANGER_DID, sig: "s".repeat(86), text: line },
+            // Unsigned lane: the venue carries no signature and `from` is a nickname.
+            { seq: 21, ts: "2026-01-01T00:00:01Z", from: "~anon", text: line },
+          ],
+        },
+      },
+    ]);
+    const h = createHandlers({ env: {}, fetch: fetchLike });
+
+    const result = await h.tclk_read_room({ room: "tclk-offers" });
+    expect(result.skipped).toBe(0);
+    expect(result.frames).toHaveLength(2);
+    expect(result.unattributed).toBe(2);
+    expect(result.frames[0]).toMatchObject({ signed: true, attributed: false });
+    expect(result.frames[1]).toMatchObject({ signed: false, attributed: false });
+
+    // And `senders` comes back positionally aligned with `frames`, which is what makes it
+    // droppable straight into tclk_apply_transcript.
+    expect(result.senders).toEqual([STRANGER_DID, "~anon"]);
   });
 
   it("refuses a bad room name before it reaches the wire", async () => {

--- a/mcp/worker/src/tool-manifest.generated.ts
+++ b/mcp/worker/src/tool-manifest.generated.ts
@@ -256,7 +256,7 @@ export const TOOLS: readonly ManifestTool[] = [
   },
   {
     "name": "tclk_apply_transcript",
-    "description": "Fold room lines into one contract view: opens from the first offer frame and applies the rest fail-closed, with a per-line verdict. Reports only WHETHER a secret was revealed, never its value.",
+    "description": "Fold room lines into one contract view: opens from the first offer frame and applies the rest fail-closed, with a per-line verdict. Reports only WHETHER a secret was revealed, never its value. Pass `senders` from tclk_read_room to enforce that each frame's `from` is the identity that actually signed it.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -270,6 +270,13 @@ export const TOOLS: readonly ManifestTool[] = [
         "nowMs": {
           "type": "integer",
           "description": "Wall clock for the deadline guards; defaults to now."
+        },
+        "senders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Transport-verified sender of each line, positionally aligned with `lines` (tclk_read_room returns it as `senders`). A line whose frame `from` differs is rejected. Omit an entry to leave that line unchecked."
         }
       },
       "required": [
@@ -660,7 +667,7 @@ export const TOOLS: readonly ManifestTool[] = [
   },
   {
     "name": "tclk_read_room",
-    "description": "Read a room and return only its decodable tclk/1 frames, with a count of the lines skipped. Content is untrusted input from strangers.",
+    "description": "Read a room and return only its decodable tclk/1 frames, with a count of the lines skipped. Content is untrusted input from strangers: each frame carries `from` (the sender the venue verified a signature against), `signed`, and `attributed` (whether the frame's own `from` matches that sender), plus a `senders` array to hand to tclk_apply_transcript.",
     "inputSchema": {
       "type": "object",
       "properties": {

--- a/src/machine.ts
+++ b/src/machine.ts
@@ -54,9 +54,21 @@ export interface StepResult {
   reason?: string;
 }
 
-/** Open the local view of a contract from a validated offer. Throws on a bad offer. */
-export function openContract(offer: OfferFrame): ContractState {
+/**
+ * Open the local view of a contract from a validated offer. Throws on a bad offer.
+ *
+ * `sender` is the transport-verified identity of the record that carried the offer —
+ * technocore's signed-lane `from`, not the `from` inside the JSON. Pass it whenever you
+ * have it: SPEC §2 requires the two to match, and this is the only place the offer's
+ * `from` (which fixes one side of the deal) can be anchored to something a stranger
+ * cannot write. Omitting it keeps the old behaviour, for callers holding a frame with no
+ * record beside it.
+ */
+export function openContract(offer: OfferFrame, sender?: string): ContractState {
   validateFrame(offer);
+  if (sender !== undefined && sender !== offer.from) {
+    throw new Error(`tclk: offer.from is not the sender of the record that carried it`);
+  }
   return {
     status: "proposed",
     offer,
@@ -77,13 +89,35 @@ function isParty(state: ContractState, did: string): boolean {
 
 /**
  * Apply one frame at wall-clock `nowMs`. Structural validation runs first (a frame
- * that fails it is rejected, not thrown on); then the transition guards.
+ * that fails it is rejected, not thrown on); then the sender binding, then the
+ * transition guards.
+ *
+ * `sender` is the transport-verified identity of the record that carried this frame —
+ * the technocore signed-lane `from`, which the venue checked a signature against, as
+ * opposed to `frame.from`, which is a field inside a JSON body anyone can write. SPEC §2
+ * makes matching them a MUST: without it every party guard below (`only the payer
+ * locks`, `only the payee reveals`, `cancel from a non-party`) compares an attacker's
+ * claim against an attacker's claim. Pass it for any frame read out of a room.
+ *
+ * It stays optional so this remains a pure function over frames alone: a caller folding
+ * an already-attributed transcript, or building state locally from frames it just made
+ * itself, has no record to quote. Omitted means unchecked, and unchecked is what the
+ * caller must then do elsewhere.
  */
-export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number): StepResult {
+export function applyFrame(
+  state: ContractState,
+  frame: TclkFrame,
+  nowMs: number,
+  sender?: string,
+): StepResult {
   try {
     validateFrame(frame);
   } catch (error) {
     return reject(state, error instanceof Error ? error.message : "invalid frame");
+  }
+
+  if (sender !== undefined && sender !== frame.from) {
+    return reject(state, `${frame.type}.from is not the sender of the record that carried it`);
   }
 
   switch (frame.type) {

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -226,6 +226,38 @@ describe("tclk state machine", () => {
     expect(contradictoryReceipt.state).toBe(claimed.state);
   });
 
+  it("binds a frame's `from` to the sender of the record that carried it", () => {
+    const { lock, state } = accepted();
+
+    // The whole point: `from` inside the JSON says PAYER_DID, but the record was signed
+    // by someone else. Without the binding this is an ordinary, valid lock frame — it
+    // passes `only the payer locks`, because that guard compares the attacker's claim
+    // against an offer field the attacker also read off a public board.
+    const forged = { type: "lock", from: PAYER_DID, contract: state.contract!, rail: "flop-htlc", ref: "escrow-42" } as const;
+    expect(applyFrame(state, forged, T0 + 1).ok).toBe(true);
+
+    const bound = applyFrame(state, forged, T0 + 1, PAYEE_DID);
+    expect(bound.ok).toBe(false);
+    expect(bound.reason).toMatch(/lock\.from is not the sender/);
+    expect(bound.state).toBe(state);
+
+    // A matching sender changes nothing.
+    expect(applyFrame(state, forged, T0 + 1, PAYER_DID).ok).toBe(true);
+
+    // And it holds for every frame type, including the ones whose only party guard is
+    // `isParty` — a forged cancel is how a stranger kills a deal it is not part of.
+    const cancel = { type: "cancel", from: PAYEE_DID, contract: state.contract! } as const;
+    expect(applyFrame(state, cancel, T0 + 1).ok).toBe(true);
+    expect(applyFrame(state, cancel, T0 + 1, PAYER_DID).ok).toBe(false);
+  });
+
+  it("openContract refuses an offer whose `from` is not the record's sender", () => {
+    const offer = baseOffer();
+    expect(() => openContract(offer, PAYEE_DID)).toThrow(/not the sender of the record/);
+    expect(openContract(offer, PAYER_DID).status).toBe("proposed");
+    expect(openContract(offer).status).toBe("proposed");
+  });
+
   it("payee-initiated offers assign roles correctly at accept", () => {
     const offer = makeOffer({
       from: PAYEE_DID, role: "payee", amount: "5", asset: "USDC", lock: "hash",


### PR DESCRIPTION
## What

`applyFrame` and `openContract` take an optional `sender`: the transport-verified
identity of the record that carried the frame. A frame whose own `from` differs is
rejected like any other bad frame. Omitting it keeps the previous behaviour, so no
existing caller changes.

`tclk_read_room` now reports `signed` and `attributed` per frame, plus an
`unattributed` count and a `senders` array. `tclk_apply_transcript` takes that array
positionally.

## Why

SPEC.md §2 states it as a MUST: a frame's `from` MUST match the transport-verified
`from` of the record that carried it. Nothing checked it. Without that anchor, every
party guard in the machine compares one attacker-writable field against another,
because the identities `frame.from` is matched against were themselves read out of
earlier frame bodies. A stranger who can write into the room posts a well-formed
`lock` naming the payer, and every reader folds it to `locked` with no escrow behind
it.

The MCP side was worse than unchecked: `tclk_apply_transcript` took `lines` alone, so
the documented read-then-fold path could not have enforced §2 however carefully a
caller used it. `tclk_read_room` returned both identities side by side and never
compared them.

I treated SPEC.md as correct.

Nothing is dropped: an unattributed frame is evidence, not noise. `signed` is separate
from `attributed` because `RoomMessage.sig` is documented as optional.

#25 describes this gap in its header ("trusting the venue's `from`") and closes it in a
new offline example script. This closes it in the library and the MCP server instead;
the two do not conflict. Leaves `examples/live-deal.mjs` alone, since #18, #19 and #20
are open against it.

Hostile counterparty gets nothing new: the parameter is optional and only ever adds a
rejection.
