### PR TITLE
fix(machine): bind proposed-state cancel to offer id and permit receipt (#5, #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,8 @@ All notable changes to this project are documented here. Format follows
   `claimed` / `refunded` / `cancelled` acknowledgment.
 - In `proposed` status, bind `cancel` frames to the targeted offer's `id`, preventing
   a single signed cancel from terminating all pending offers from that sender, and
-  permit `receipt` frames to verify against `offer.id` on proposed-stage cancellations
+  record that exact target so a later `receipt` can acknowledge a proposed-stage
+  cancellation without treating a missing contract id in any other state as an offer id
   (#5, #17).
 
 ## [0.1.0] - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,10 @@ All notable changes to this project are documented here. Format follows
 - Reject receipt frames whose claimed outcome contradicts the contract's terminal state,
   preventing a later reputation or spend-accounting consumer from accepting a false
   `claimed` / `refunded` / `cancelled` acknowledgment.
+- In `proposed` status, bind `cancel` frames to the targeted offer's `id`, preventing
+  a single signed cancel from terminating all pending offers from that sender, and
+  permit `receipt` frames to verify against `offer.id` on proposed-stage cancellations
+  (#5, #17).
 
 ## [0.1.0] - 2026-09-01
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -209,9 +209,11 @@ late — the payee gambles against the refund; the rail arbitrates.
 - `refund`: payer, while locked, at/after `refundAfterMs`; new senders SHOULD include `ref`, and
   when present it MUST equal the preceding `lock.ref`. As for `reveal`, it is optional on the
   tclk/1 wire solely for replay compatibility.
-- `cancel`: either party, before any lock exists (proposed/accepted).
+- `cancel`: either party, before any lock exists (proposed/accepted). While `proposed`, `contract`
+  carries the offer `id`; from `accepted` on, the contract id.
 - `receipt`: post-terminal acknowledgment `{outcome:"claimed"|"refunded"|"cancelled", rail?,
-  ref?}` — `outcome` must match the contract's terminal state. This is the line a
+  ref?}` — `outcome` must match the contract's terminal state; `contract` carries the contract id
+  (or the offer `id` if cancelled while `proposed`). This is the line a
   reputation/spend-accounting layer would consume later; it makes no transition and MUST NOT
   be used as a liveness signal.
 

--- a/src/machine.ts
+++ b/src/machine.ts
@@ -41,6 +41,8 @@ export interface ContractState {
   /** Set at accept. */
   contract?: string;
   statement?: string;
+  /** Set at cancel to the exact identifier a later receipt must acknowledge. */
+  cancelTarget?: string;
   /** Set at lock. */
   rail?: string;
   railRef?: string;
@@ -196,12 +198,12 @@ export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number
       if (state.status !== "proposed" && state.status !== "accepted") {
         return reject(state, `cancel in status ${state.status}`);
       }
-      const target = state.contract ?? state.offer.id;
-      if (frame.contract !== target) {
+      const target = state.status === "proposed" ? state.offer.id : state.contract;
+      if (target === undefined || frame.contract !== target) {
         return reject(state, "cancel names a different contract");
       }
       if (!isParty(state, frame.from)) return reject(state, "cancel from a non-party");
-      return { ok: true, state: { ...state, status: "cancelled" } };
+      return { ok: true, state: { ...state, status: "cancelled", cancelTarget: target } };
     }
 
     case "receipt": {
@@ -209,8 +211,10 @@ export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number
       if (!TCLK_TERMINAL_STATUSES.has(state.status)) {
         return reject(state, "receipt before a terminal status");
       }
-      const target = state.contract ?? state.offer.id;
-      if (frame.contract !== target) return reject(state, "receipt names a different contract");
+      const target = state.status === "cancelled" ? state.cancelTarget : state.contract;
+      if (target === undefined || frame.contract !== target) {
+        return reject(state, "receipt names a different contract");
+      }
       if (!isParty(state, frame.from)) return reject(state, "receipt from a non-party");
       if (frame.outcome !== state.status) {
         return reject(state, `receipt outcome ${frame.outcome} does not match ${state.status}`);

--- a/src/machine.ts
+++ b/src/machine.ts
@@ -196,7 +196,8 @@ export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number
       if (state.status !== "proposed" && state.status !== "accepted") {
         return reject(state, `cancel in status ${state.status}`);
       }
-      if (state.status === "accepted" && frame.contract !== state.contract) {
+      const target = state.contract ?? state.offer.id;
+      if (frame.contract !== target) {
         return reject(state, "cancel names a different contract");
       }
       if (!isParty(state, frame.from)) return reject(state, "cancel from a non-party");
@@ -208,7 +209,8 @@ export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number
       if (!TCLK_TERMINAL_STATUSES.has(state.status)) {
         return reject(state, "receipt before a terminal status");
       }
-      if (frame.contract !== state.contract) return reject(state, "receipt names a different contract");
+      const target = state.contract ?? state.offer.id;
+      if (frame.contract !== target) return reject(state, "receipt names a different contract");
       if (!isParty(state, frame.from)) return reject(state, "receipt from a non-party");
       if (frame.outcome !== state.status) {
         return reject(state, `receipt outcome ${frame.outcome} does not match ${state.status}`);

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -377,6 +377,10 @@ describe("tclk state machine", () => {
     expect(applyFrame(state, { type: "cancel", from: STRANGER_DID, contract: state.contract! }, T0).ok).toBe(false);
     const cancelled = applyFrame(state, { type: "cancel", from: PAYEE_DID, contract: state.contract! }, T0);
     expect(cancelled.state.status).toBe("cancelled");
+    expect(cancelled.state.cancelTarget).toBe(state.contract);
+    expect(applyFrame(cancelled.state, {
+      type: "receipt", from: PAYER_DID, contract: state.contract!, outcome: "cancelled",
+    }, T0).ok).toBe(true);
     const locked = applyFrame(state, { type: "lock", from: PAYER_DID, contract: state.contract!, rail: "x402", ref: "r" }, T0).state;
     expect(applyFrame(locked, { type: "cancel", from: PAYER_DID, contract: state.contract! }, T0).ok).toBe(false);
   });
@@ -410,6 +414,7 @@ describe("tclk state machine", () => {
     const cancelled = applyFrame(firstProposed, cancelFirst, T0);
     expect(cancelled.ok).toBe(true);
     expect(cancelled.state.status).toBe("cancelled");
+    expect(cancelled.state.cancelTarget).toBe(offer.id);
 
     // Receipt following proposed-state cancel validates against offer id
     const validReceipt = applyFrame(
@@ -427,6 +432,39 @@ describe("tclk state machine", () => {
     );
     expect(invalidReceipt.ok).toBe(false);
     expect(invalidReceipt.reason).toBe("receipt names a different contract");
+  });
+
+  it("does not infer an offer target for malformed post-accept states", () => {
+    const { offer, state } = accepted();
+    const missingContract = { ...state, contract: undefined };
+
+    const cancel = applyFrame(
+      missingContract,
+      { type: "cancel", from: PAYER_DID, contract: offer.id },
+      T0,
+    );
+    expect(cancel.ok).toBe(false);
+    expect(cancel.state).toBe(missingContract);
+
+    for (const status of ["claimed", "refunded"] as const) {
+      const malformed: ContractState = { ...missingContract, status };
+      const receipt = applyFrame(
+        malformed,
+        { type: "receipt", from: PAYER_DID, contract: offer.id, outcome: status },
+        T0,
+      );
+      expect(receipt.ok).toBe(false);
+      expect(receipt.state).toBe(malformed);
+    }
+
+    const cancelled: ContractState = { ...missingContract, status: "cancelled" };
+    const receipt = applyFrame(
+      cancelled,
+      { type: "receipt", from: PAYER_DID, contract: offer.id, outcome: "cancelled" },
+      T0,
+    );
+    expect(receipt.ok).toBe(false);
+    expect(receipt.state).toBe(cancelled);
   });
 
   it("rejects hostile/malformed frames without throwing", () => {

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -372,12 +372,61 @@ describe("tclk state machine", () => {
 
   it("cancel works pre-lock for parties only, and never after lock", () => {
     const { offer, state } = accepted();
-    expect(applyFrame(openContract(offer), { type: "cancel", from: PAYER_DID, contract: "0x" + "00".repeat(32) }, T0).state.status).toBe("cancelled");
+    expect(applyFrame(openContract(offer), { type: "cancel", from: PAYER_DID, contract: offer.id }, T0).state.status).toBe("cancelled");
+    expect(applyFrame(openContract(offer), { type: "cancel", from: PAYER_DID, contract: "0x" + "00".repeat(32) }, T0).ok).toBe(false);
     expect(applyFrame(state, { type: "cancel", from: STRANGER_DID, contract: state.contract! }, T0).ok).toBe(false);
     const cancelled = applyFrame(state, { type: "cancel", from: PAYEE_DID, contract: state.contract! }, T0);
     expect(cancelled.state.status).toBe("cancelled");
     const locked = applyFrame(state, { type: "lock", from: PAYER_DID, contract: state.contract!, rail: "x402", ref: "r" }, T0).state;
     expect(applyFrame(locked, { type: "cancel", from: PAYER_DID, contract: state.contract! }, T0).ok).toBe(false);
+  });
+
+  it("cancel while proposed binds to the specific offer and permits receipt (#5, #17)", () => {
+    const { offer } = accepted();
+    const otherOffer = makeOffer({
+      from: PAYER_DID,
+      role: "payer",
+      amount: "2000000",
+      asset: "FLOP",
+      lock: "hash",
+      rails: ["flop-htlc"],
+      claimByMs: 1756703600000,
+      refundAfterMs: 1756707200000,
+      expiresMs: 1756700600000,
+      nonce: "1122334455667788",
+    });
+    const cancelFirst = { type: "cancel" as const, from: PAYER_DID, contract: offer.id };
+
+    const firstProposed = openContract(offer);
+    const otherProposed = openContract(otherOffer);
+
+    // Cancel naming offer does not cancel otherOffer
+    const crossCancel = applyFrame(otherProposed, cancelFirst, T0);
+    expect(crossCancel.ok).toBe(false);
+    expect(crossCancel.reason).toBe("cancel names a different contract");
+    expect(crossCancel.state.status).toBe("proposed");
+
+    // Cancel naming offer cancels the intended offer
+    const cancelled = applyFrame(firstProposed, cancelFirst, T0);
+    expect(cancelled.ok).toBe(true);
+    expect(cancelled.state.status).toBe("cancelled");
+
+    // Receipt following proposed-state cancel validates against offer id
+    const validReceipt = applyFrame(
+      cancelled.state,
+      { type: "receipt", from: PAYER_DID, contract: offer.id, outcome: "cancelled" },
+      T0,
+    );
+    expect(validReceipt.ok).toBe(true);
+
+    // Receipt with mismatched contract is rejected
+    const invalidReceipt = applyFrame(
+      cancelled.state,
+      { type: "receipt", from: PAYER_DID, contract: otherOffer.id, outcome: "cancelled" },
+      T0,
+    );
+    expect(invalidReceipt.ok).toBe(false);
+    expect(invalidReceipt.reason).toBe("receipt names a different contract");
   });
 
   it("rejects hostile/malformed frames without throwing", () => {


### PR DESCRIPTION
### Summary

Fixes #5 and #17.

In `proposed` status:
1. `applyFrame` now checks `cancel` frames against `state.offer.id` (via `state.contract ?? state.offer.id`). Previously, `proposed` skipped comparing `frame.contract`, meaning one signed cancel from a sender would cancel every pending offer from that sender regardless of which id the frame named.
2. `receipt` verification now checks against `state.contract ?? state.offer.id`. Previously, cancelling in `proposed` left `state.contract` undefined, causing any subsequent receipt to fail `frame.contract !== state.contract`, making it impossible to produce a valid receipt after a proposed-stage cancellation.

### Spec and Code Agreement

`SPEC.md` §3.5 has been updated to explicitly specify that while `proposed`, `contract` carries the offer `id` (matching the convention `accept.ref` already uses), and that post-terminal `receipt` carries the contract id or the offer `id` if cancelled while `proposed`. Both `SPEC.md` and `src/machine.ts` are in agreement.

### Money path impact

What a hostile counterparty gets: **nothing**. Cancelling an offer still requires being a party to the contract/offer (`from` must match the offer party). Furthermore, this eliminates cross-contract cancellation where a party with multiple pending offers could have all of them cancelled by spraying a single cancel frame.

### Verification

- Regression tests added in `tests/tclk.test.ts` verifying:
  - Cancelling an offer in `proposed` with an invalid contract id / mismatched offer id fails with `"cancel names a different contract"`.
  - A cancel naming offer A does not cancel offer B from the same sender.
  - A valid `receipt` frame acknowledging a proposed-stage cancellation succeeds when naming `offer.id`, and rejects mismatched ids.
- All existing tests including golden vectors pass (61/61 root tests, 33/33 mcp tests).
