### PR TITLE
fix(locks): reject malformed deadline inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `validateDeadlines` now rejects malformed clocks, non-finite safety margins, and
+  unvalidated offer timestamps before doing arithmetic. A negative-infinite clock or an
+  infinite refund deadline could previously manufacture a safe-looking window even though
+  the helper promises to fail closed.
 - `SPEC.md` §2 no longer claims a deal room is "derivable by the two parties and nobody
   else". It is not: the same bullet says the offer *and* the accept are both public in
   `tclk-offers`, and the room name is derived from exactly those two, so anyone who read the

--- a/src/locks.ts
+++ b/src/locks.ts
@@ -60,7 +60,25 @@ export function validateDeadlines(
   minClaimWindowMs: number,
   minRefundGapMs: number,
 ): boolean {
-  if (minClaimWindowMs < 1 || minRefundGapMs < 1) return false;
+  // This helper is a trust boundary for callers that have not necessarily passed an
+  // offer through validateFrame first. JavaScript comparisons with NaN are false in both
+  // directions, while subtracting -Infinity manufactures an infinite "safe" window.
+  // Validate every operand before doing deadline arithmetic so malformed clocks and
+  // hand-built offers fail closed rather than widening the caller's safety margin.
+  if (
+    !Number.isSafeInteger(offer.claimByMs) ||
+    offer.claimByMs <= 0 ||
+    !Number.isSafeInteger(offer.refundAfterMs) ||
+    offer.refundAfterMs <= 0 ||
+    !Number.isFinite(nowMs) ||
+    nowMs < 0 ||
+    !Number.isFinite(minClaimWindowMs) ||
+    minClaimWindowMs < 1 ||
+    !Number.isFinite(minRefundGapMs) ||
+    minRefundGapMs < 1
+  ) {
+    return false;
+  }
   return (
     offer.claimByMs - nowMs >= minClaimWindowMs &&
     offer.refundAfterMs - offer.claimByMs >= minRefundGapMs

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -190,6 +190,15 @@ describe("tclk locks", () => {
     expect(validateDeadlines(offer, T0, 3_600_000, 3_600_001)).toBe(false); // refund gap too short
     expect(validateDeadlines(offer, T0, 0, 1)).toBe(false); // degenerate margins refused
   });
+
+  it("validateDeadlines rejects malformed clocks and unvalidated offer times", () => {
+    const offer = { claimByMs: CLAIM_BY, refundAfterMs: REFUND_AFTER };
+    expect(validateDeadlines(offer, -Infinity, 1, 1)).toBe(false);
+    expect(validateDeadlines(offer, -1, 1, 1)).toBe(false);
+    expect(validateDeadlines({ ...offer, refundAfterMs: Infinity }, T0, 1, 1)).toBe(false);
+    expect(validateDeadlines({ ...offer, claimByMs: 1.5 }, 0, 1, 1)).toBe(false);
+    expect(validateDeadlines(offer, T0, Infinity, 1)).toBe(false);
+  });
 });
 
 describe("tclk state machine", () => {


### PR DESCRIPTION
## Summary

- Validate every operand before `validateDeadlines` performs deadline arithmetic.
- Reject non-safe offer timestamps, a negative or non-finite clock, and non-finite safety margins.
- Add regression coverage and an Unreleased changelog entry.

## Why

The helper promises to fail closed, but JavaScript arithmetic could manufacture a safe-looking window from malformed input. For example, a valid offer with `nowMs = -Infinity`, or a hand-built offer with `refundAfterMs = Infinity`, returned `true`. A caller using this guard before accepting work could therefore treat an invalid deadline set as safe.

## Spec and compatibility

The existing fail-closed contract in `src/locks.ts` and the deadline safety intent in `SPEC.md` are treated as correct. This closes the implementation gap without changing the wire format, state machine, rail interface, or golden vectors.

Money-path impact: a hostile counterparty gets nothing new. The change only turns malformed local inputs from an unsafe `true` into `false`.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -r --include-workspace-root build`
- `pnpm -r --include-workspace-root test`
  - root: 61 passed
  - MCP: 33 passed
  - Worker: 31 passed
- `git diff --check`
- commit-message privacy check

No secrets, credentials, personal information, or signing material are included.