### PR TITLE
fix(technocore): reject malformed note metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- Technocore note parsers now reject capability lists with empty rail entries and state
+  pointers with malformed rail references, matching the encoders and keeping world-writable
+  note input fail-closed.
 - `SPEC.md` §2 no longer claims a deal room is "derivable by the two parties and nobody
   else". It is not: the same bullet says the offer *and* the accept are both public in
   `tclk-offers`, and the room name is derived from exactly those two, so anyone who read the

--- a/src/technocore.ts
+++ b/src/technocore.ts
@@ -11,6 +11,8 @@
 import type { TclkStatus } from "./machine.js";
 
 const CONTRACT_ID = /^0x[0-9a-f]{64}$/;
+const RAIL = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const RAIL_REF = /^[\x21-\x7e]{1,256}$/;
 const STATUSES: ReadonlySet<string> = new Set([
   "proposed", "accepted", "locked", "claimed", "refunded", "cancelled",
 ]);
@@ -37,7 +39,7 @@ export const OFFER_ROOM = "tclk-offers";
 export function capabilityToken(rails: readonly string[]): string {
   if (rails.length === 0) throw new Error("tclk: capability token needs at least one rail");
   for (const rail of rails) {
-    if (!/^[a-z0-9][a-z0-9._-]{0,63}$/.test(rail)) throw new Error(`tclk: malformed rail: ${rail}`);
+    if (!RAIL.test(rail)) throw new Error(`tclk: malformed rail: ${rail}`);
   }
   return `tclk1:${rails.join(",")}`;
 }
@@ -46,9 +48,8 @@ export function capabilityToken(rails: readonly string[]): string {
 export function parseCapabilityToken(note: string): string[] | null {
   const token = note.split(/\s+/).find((part) => part.startsWith("tclk1:"));
   if (token === undefined) return null;
-  const rails = token.slice("tclk1:".length).split(",").filter(Boolean);
-  if (rails.length === 0) return null;
-  return rails.every((rail) => /^[a-z0-9][a-z0-9._-]{0,63}$/.test(rail)) ? rails : null;
+  const rails = token.slice("tclk1:".length).split(",");
+  return rails.every((rail) => RAIL.test(rail)) ? rails : null;
 }
 
 /**
@@ -72,7 +73,7 @@ export function stateNote(contract: string): { ns: string; key: string } {
 /** Serialize a status (plus optional rail ref) as the state-note value. Single line. */
 export function stateNoteValue(status: TclkStatus, railRef?: string): string {
   if (railRef !== undefined) {
-    if (!/^[\x21-\x7e]{1,256}$/.test(railRef)) {
+    if (!RAIL_REF.test(railRef)) {
       throw new Error("tclk: rail ref must be printable ASCII without spaces (max 256 chars)");
     }
     return `${status} ${railRef}`;
@@ -84,5 +85,6 @@ export function stateNoteValue(status: TclkStatus, railRef?: string): string {
 export function parseStateNoteValue(value: string): { status: TclkStatus; railRef?: string } | null {
   const [status, railRef, ...rest] = value.split(" ");
   if (rest.length > 0 || !STATUSES.has(status)) return null;
-  return railRef === undefined ? { status: status as TclkStatus } : { status: status as TclkStatus, railRef };
+  if (railRef === undefined) return { status: status as TclkStatus };
+  return RAIL_REF.test(railRef) ? { status: status as TclkStatus, railRef } : null;
 }

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -416,6 +416,9 @@ describe("tclk venue binding", () => {
     expect(parseCapabilityToken(`did:key:z6Mk${"f".repeat(44)} mailbox:mb-p-abc123`)).toBeNull();
     expect(parseCapabilityToken("tclk1:")).toBeNull();
     expect(parseCapabilityToken("tclk1:BAD RAIL")).toBeNull();
+    expect(parseCapabilityToken("tclk1:,flop-htlc")).toBeNull();
+    expect(parseCapabilityToken("tclk1:flop-htlc,,x402")).toBeNull();
+    expect(parseCapabilityToken("tclk1:flop-htlc,")).toBeNull();
     // A space ends the token: the DID note is whitespace-delimited, so a rail list
     // cannot contain one and everything after it is a different token entirely.
     expect(parseCapabilityToken("tclk1:flop-htlc x402")).toEqual(["flop-htlc"]);
@@ -424,10 +427,16 @@ describe("tclk venue binding", () => {
   });
 
   it("state-note values round-trip and parse fail-closed", () => {
+    const maxRailRef = "x".repeat(256);
     expect(parseStateNoteValue(stateNoteValue("locked", "escrow-42"))).toEqual({ status: "locked", railRef: "escrow-42" });
+    expect(parseStateNoteValue(stateNoteValue("locked", maxRailRef))).toEqual({ status: "locked", railRef: maxRailRef });
     expect(parseStateNoteValue(stateNoteValue("claimed"))).toEqual({ status: "claimed" });
     expect(parseStateNoteValue("owned by nobody at all")).toBeNull();
     expect(parseStateNoteValue("exploded")).toBeNull();
+    expect(parseStateNoteValue("locked ")).toBeNull();
+    expect(parseStateNoteValue("locked \n")).toBeNull();
+    expect(parseStateNoteValue("locked \u2603")).toBeNull();
+    expect(parseStateNoteValue(`locked ${"x".repeat(257)}`)).toBeNull();
     expect(() => stateNoteValue("locked", "has space")).toThrow(/printable ASCII/);
   });
 });


### PR DESCRIPTION
## What

Reject malformed Technocore capability lists containing empty rail entries, and reject parsed state-note rail references that the encoder would refuse. The parser now uses the same rail/ref grammar as the encoder, with regression coverage for empty, control, non-ASCII, and overlong values.

## Why

Technocore notes are world-writable input and both parsers document fail-closed behavior. Before this change, the decoders accepted values their corresponding encoders could not emit.

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` — all 124 tests pass
- [x] Golden vectors untouched
- [x] `CHANGELOG.md` has an `[Unreleased]` entry
- [x] Existing docs remain accurate
- [x] New surface on the money path: nothing new