### PR TITLE
fix(frames): reject odd-length presig.s at decode, not only at verify (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `SCALAR_HEX` in `src/frames.ts` now requires even-length hex (`{1,32}` byte pairs)
+  instead of `{1,64}` hex digits. Odd-length values like `0xabc` passed the old
+  pattern and were stored on a lock frame; the failure only surfaced later inside
+  `verifyPreSignature` → `toScalar` → `hexToU8a`, which threw and surfaced as a
+  silent `false`. A hostile payer could exploit that gap to stall a PTLC deal
+  after locking funds. The wire boundary now rejects odd-length scalars at
+  `decodeFrame`, with a regression test pinning that the malformed lock frame is
+  skipped by `tryDecodeFrame` and never enters a transcript. (#22)
 - `SPEC.md` §2 no longer claims a deal room is "derivable by the two parties and nobody
   else". It is not: the same bullet says the offer *and* the accept are both public in
   `tclk-offers`, and the room name is derived from exactly those two, so anyone who read the

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -141,7 +141,7 @@ const AMOUNT = /^[1-9][0-9]*$/;
 const ASSET = /^[A-Za-z0-9_-]{1,32}$/;
 const RAIL = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 const NONCE = /^[0-9a-f]{8,64}$/;
-const SCALAR_HEX = /^0x[0-9a-f]{1,64}$/;
+const SCALAR_HEX = /^0x(?:[0-9a-f]{2}){1,32}$/;
 
 function fail(msg: string): never {
   throw new Error(`tclk: ${msg}`);

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -295,6 +295,28 @@ describe("tclk state machine", () => {
     expect(step.ok).toBe(false);
     expect(step.state).toBe(state);
   });
+
+  it("rejects an odd-length scalar hex in a lock's presig at decode, not only at verify (#22)", () => {
+    // The odd-length form "0xabc" passes the old /^[0-9a-f]{1,64}$/ pattern and would
+    // be stored on a lock frame; the failure only surfaced later inside
+    // verifyPreSignature → toScalar → hexToU8a, where it turned into a silent
+    // `false`. A hostile payer could use that gap to stall a PTLC deal after
+    // locking funds. SCALAR_HEX must reject it at the wire boundary, so the frame
+    // never enters a room-looking transcript and no state is half-applied.
+    const { accept, state } = accepted();
+    const ptlc = generatePointLock();
+    const payerKey = schnorrAdaptor.getPublicKey("0x" + "11".repeat(32))!;
+    const forgedLine = TCLK_PREFIX + JSON.stringify({
+      type: "lock", from: PAYER_DID, contract: accept.contract,
+      rail: "flop-htlc", ref: "escrow-x",
+      presig: { nonce: ptlc.statement, s: "0xabc" },
+    });
+    expect(() => decodeFrame(forgedLine)).toThrow(/presig\.s is malformed/);
+    expect(tryDecodeFrame(forgedLine)).toBeNull();
+    // The state machine is untouched: without a valid frame, nothing to apply.
+    const step = applyFrame(state, { type: "lock", from: PAYER_DID } as never, T0);
+    expect(step.ok).toBe(false);
+  });
 });
 
 describe("tclk PTLC path (adaptor cycle)", () => {


### PR DESCRIPTION
Fixes #22.

`SCALAR_HEX` in `src/frames.ts` was `/^0x[0-9a-f]{1,64}$/`, which accepts odd-length values like `0xabc`. A lock frame carrying such a `presig.s` was stored on the room, the failure only surfacing later inside `verifyPreSignature` -> `toScalar` -> `hexToU8a` (which throws on odd length and surfaces as a silent `false`).

A hostile payer can use that gap to stall a PTLC deal after the lock frame is committed and funds are escrowed. The wire boundary must reject it instead, so the malformed frame never enters a transcript in the first place.

Tighten `SCALAR_HEX` to enforce even-length byte pairs (`/^0x(?:[0-9a-f]{2}){1,32}$/`) - at most 32 bytes, always even - and add a regression test pinning both the throw at `decodeFrame` and the `null` at `tryDecodeFrame`.

Note: #24 touches the same regex with the same fix; the difference is this PR also adds the regression test the issue asks for. Happy to close if #24 is preferred - the test would still be valuable.

Verified: tsc builds clean; manual probe confirms odd-length throws at decodeFrame, null at tryDecodeFrame; even-length still decodes. pnpm chain not run end-to-end (sandbox lacks pnpm + rollup native binding) - CI is the final word. CHANGELOG entry added under [Unreleased] / Fixed.