### PR TITLE
chore: align changelog and required CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,8 @@ permissions:
   contents: read
 
 jobs:
-  # Separate job so it can be made a required check on its own once branch protection is
-  # available: a session link is a history problem, and history is the one thing a green
-  # build does not let you fix later.
+  # Keep this as a separate required check: a session link is a history problem, and history
+  # is the one thing a green build does not let you fix later.
   commit-messages:
     name: "commit messages carry no session links"
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,6 @@ All notable changes to this project are documented here. Format follows
 
 ## [Unreleased]
 
-### Fixed
-
-- `examples/live-deal.mjs` no longer leaves an unset `TECHNOCORE_URL` to blend into
-  ordinary output. Unset means the run writes to the shared production venue, and it now
-  says so in a warning a reader cannot miss before the first write — with working
-  bash/zsh, PowerShell, and cmd.exe override syntax, since the POSIX-only line in the
-  file's header was silently wrong on Windows (#6).
-
 ### Added
 
 - A hosted deployment of the MCP server at `https://tclk.technocore.chat/mcp`, streamable
@@ -27,6 +19,14 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- Adaptor scalar parsing now rejects zero and out-of-range values instead of reducing them
+  modulo the curve order, matching point-lock witness validation and preventing distinct
+  byte strings from being treated as the same scalar (#27).
+- `examples/live-deal.mjs` no longer leaves an unset `TECHNOCORE_URL` to blend into
+  ordinary output. Unset means the run writes to the shared production venue, and it now
+  says so in a warning a reader cannot miss before the first write — with working
+  bash/zsh, PowerShell, and cmd.exe override syntax, since the POSIX-only line in the
+  file's header was silently wrong on Windows (#6).
 - Technocore note parsers now reject capability lists with empty rail entries and state
   pointers with malformed rail references, matching the encoders and keeping world-writable
   note input fail-closed.


### PR DESCRIPTION
## Summary

- consolidate the duplicate Unreleased Fixed sections
- add the missing changelog entry for #27
- update the CI comment now that both jobs are required checks

## Verification

- pnpm install --frozen-lockfile
- pnpm -r --include-workspace-root build
- pnpm -r --include-workspace-root test

This is the cleanup prerequisite for the protocol/transcript work.