### PR TITLE
feat: authenticate complete transcript records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- Pre-signature scalar validation now accepts only whole-byte hex encodings, rejecting
+  odd-length strings before they reach cryptographic parsing (#24).
 - Technocore note parsers now reject capability lists with empty rail entries and state
   pointers with malformed rail references, matching the encoders and keeping world-writable
   note input fail-closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ All notable changes to this project are documented here. Format follows
   documents what a shared instance costs, including that frames leave from its IP and share
   one rate budget.
 
+### Changed
+
+- Transcript folding now consumes complete signed records instead of bare `lines` plus
+  optional positional metadata. A record keeps its exact line, room, sequence, venue
+  timestamp, sender, nonce and signature together; `foldTranscript` verifies the signature
+  and sender binding and applies each frame at that record's timestamp. The MCP
+  `tclk_read_room` tool returns this shape directly and supports `full: true` for strict,
+  byte-exact `/export` history, while `tclk_apply_transcript` accepts only `records` and has
+  no fallback clock. `examples/audit-export.mjs` performs the same audit offline; sender,
+  room, nonce and line are signature-covered, while timestamp and sequence remain explicitly
+  trusted venue/export metadata (#11, #23).
+
 ### Fixed
 
 - Technocore note parsers now reject capability lists with empty rail entries and state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- Transcript folds now reject otherwise-valid frames outside their protocol-mandated room,
+  and the offline/live auditors select offer/accept pairs without reversing the board's
+  append order.
 - Pre-signature scalar validation now accepts only whole-byte hex encodings, rejecting
   odd-length strings before they reach cryptographic parsing (#24).
 - Adaptor scalar parsing now rejects zero and out-of-range values instead of reducing them

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Bitcoin today. "PTLC" here means the protocol shape, not Bitcoin compatibility.
 | [`src/`](src) (`@flop-labs/tclk`) | The core library: frames, contract ids, hash/point locks, the state machine, the `SettlementRail` interface, A2A/ACP mappings. No network calls. |
 | [`mcp/`](mcp) (`@flop-labs/tclk-mcp`) | An MCP server exposing the protocol as tool calls, for agents whose only outbound path is a tool call. Stateless — see below. |
 | [`examples/live-deal.mjs`](examples/live-deal.mjs) | One complete deal against a real technocore deployment, ending with a third-party audit of it. Runs a realistic content job: `node examples/live-deal.mjs [x\|ig\|tiktok\|youtube]`. |
+| [`examples/audit-export.mjs`](examples/audit-export.mjs) | Offline audit of a finished deal from full JSONL exports: verifies record signatures and attribution, then folds at each venue timestamp. |
 
 ## Quickstart
 
@@ -96,6 +97,13 @@ state = applyFrame(state, revealFrame, Date.now()).state;         // → claimed
 `applyFrame` is pure and fail-closed: it returns `{ state, ok, reason }`, and a frame that
 fails a guard (wrong party, wrong secret, out of turn, replayed) leaves the state untouched
 rather than throwing — so you can fold it over every line of a world-writable room.
+
+For records read from a venue, use `foldTranscript(records)`. A `TranscriptRecord` keeps
+the exact line, room, sequence, venue timestamp, sender, nonce and signature together. The
+fold authenticates every record, requires `frame.from` to match its signed sender, and uses
+that record's timestamp for deadline guards; unsigned or malformed records get a verdict
+and cannot advance state. Technocore's timestamp and sequence are venue metadata rather than
+fields in the sender's signature, so an offline audit still trusts its export file for them.
 
 Exact frame shapes and field rules: [`SPEC.md` §3](SPEC.md#3-wire-format).
 
@@ -141,11 +149,11 @@ refuses outright. Prefer the local build wherever your runtime can run it;
 | `tclk_make_cancel` | Build a `cancel` frame. |
 | `tclk_make_receipt` | Build a terminal `receipt` frame. |
 | `tclk_decode` | Parse and validate a raw `tclk1 …` frame line. |
-| `tclk_apply_transcript` | Replay a list of frames through the state machine, return the resulting contract state. |
+| `tclk_apply_transcript` | Authenticate complete room records, then fold them at their venue timestamps with a per-record verdict. |
 | `tclk_verify_secret` | Check a preimage/witness against a hash or point statement. |
 | `tclk_adaptor_presign` / `_adapt` / `_extract` / `_verify` | The PTLC adaptor-signature primitives (§7 — unaudited reference crypto). |
 | `tclk_post_frame` | Post a frame line to a technocore room. Three tiers: a caller-supplied signature is passed through as-is; with no signature but `TECHNOCORE_SIGNING_KEY` set, the server signs locally; with neither, it returns the canonical signing challenge for the caller to sign itself. |
-| `tclk_read_room` | Read frames back out of a technocore room. |
+| `tclk_read_room` | Read complete records from a room window, or the retained `/export` history with `full: true`. |
 | `tclk_whoami` | Report the server's configured did:key / payment key (if any), and which of the above tiers are active. |
 
 ### Environment

--- a/SPEC.md
+++ b/SPEC.md
@@ -62,7 +62,9 @@ the public manual (`/llms.txt`), and any self-hosted deployment works identicall
   `<room>|<nonce>|<text>`; `seq` and `ts` are venue metadata, not sender-signed fields. Deadline
   guards replay at that record's `ts`, so a live reader trusts the venue for time and an
   offline reader trusts the export file for it. Missing or malformed time fails closed — it
-  never falls back to the auditor's current clock.
+  never falls back to the auditor's current clock. A fold also enforces the room binding below:
+  offer/accept records belong to `tclk-offers`; post-accept records belong to the contract's
+  derived deal room. A valid signature in the wrong room cannot advance state.
 - **Rendezvous**: public offers rest in the room `tclk-offers` — an ordinary world-writable
   room with no class prefix, so the venue lists and announces it like any other. Two agents who
   have never met have nowhere else to find each other, so a deal cannot start without a

--- a/SPEC.md
+++ b/SPEC.md
@@ -57,6 +57,12 @@ the public manual (`/llms.txt`), and any self-hosted deployment works identicall
   match the transport-verified `from` of the record that carried it. An unsigned frame is
   data, not a commitment — readers ignore it. (Payment-key crypto is separate and lives *inside*
   frames; the transport lane stays Ed25519 `did:key`, the only thing the server verifies.)
+- **Fold records, not detached lines.** The record keeps `room`, `seq`, `ts`, transport `from`,
+  `nonce`, `sig`, and the exact stored text together. The Ed25519 signature covers
+  `<room>|<nonce>|<text>`; `seq` and `ts` are venue metadata, not sender-signed fields. Deadline
+  guards replay at that record's `ts`, so a live reader trusts the venue for time and an
+  offline reader trusts the export file for it. Missing or malformed time fails closed — it
+  never falls back to the auditor's current clock.
 - **Rendezvous**: public offers rest in the room `tclk-offers` — an ordinary world-writable
   room with no class prefix, so the venue lists and announces it like any other. Two agents who
   have never met have nowhere else to find each other, so a deal cannot start without a

--- a/examples/audit-export.mjs
+++ b/examples/audit-export.mjs
@@ -10,10 +10,9 @@ import { readFileSync } from "node:fs";
 import {
   OFFER_ROOM,
   dealRoom,
+  findContractHandshake,
   foldTranscript,
   parseTranscriptExport,
-  tryDecodeFrame,
-  verifyTranscriptRecord,
 } from "../dist/index.js";
 
 const [offersFile, dealFile, contract] = process.argv.slice(2);
@@ -26,31 +25,19 @@ const room = dealRoom(contract);
 const board = parseTranscriptExport(OFFER_ROOM, readFileSync(offersFile, "utf8"));
 const deal = parseTranscriptExport(room, readFileSync(dealFile, "utf8"));
 
-const authenticatedFrame = (record) => {
-  const verification = verifyTranscriptRecord(record);
-  if (!verification.ok) return null;
-  const frame = tryDecodeFrame(record.line);
-  return frame !== null && frame.from === record.sender ? frame : null;
-};
-
-const acceptRecord = board.find((record) => {
-  const frame = authenticatedFrame(record);
-  return frame?.type === "accept" && frame.contract === contract;
-});
-const accept = acceptRecord && authenticatedFrame(acceptRecord);
-const offerRecord = accept?.type === "accept"
-  ? board.find((record) => {
-      const frame = authenticatedFrame(record);
-      return frame?.type === "offer" && frame.id === accept.ref;
-    })
-  : undefined;
-
-if (!offerRecord || !acceptRecord) {
+let handshake;
+try {
+  handshake = findContractHandshake(board, contract);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : "invalid offer/accept ordering");
+  process.exit(1);
+}
+if (handshake === null) {
   console.error(`no authenticated offer/accept pair for ${contract}`);
   process.exit(1);
 }
 
-const folded = foldTranscript([offerRecord, acceptRecord, ...deal]);
+const folded = foldTranscript([handshake.offer, handshake.accept, ...deal]);
 for (const step of folded.steps) {
   const verdict = step.ok ? "ok " : "BAD";
   console.log(`${verdict} ${step.room}#${step.seq} ${step.type ?? "record"}${step.reason ? ` — ${step.reason}` : ""}`);

--- a/examples/audit-export.mjs
+++ b/examples/audit-export.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// Reproduce a deal from two byte-exact technocore exports, with no network access.
+//
+//   node examples/audit-export.mjs offers.jsonl deal.jsonl 0x<contract-id>
+
+import { readFileSync } from "node:fs";
+
+import {
+  OFFER_ROOM,
+  dealRoom,
+  foldTranscript,
+  parseTranscriptExport,
+  tryDecodeFrame,
+  verifyTranscriptRecord,
+} from "../dist/index.js";
+
+const [offersFile, dealFile, contract] = process.argv.slice(2);
+if (!offersFile || !dealFile || !/^0x[0-9a-f]{64}$/.test(contract ?? "")) {
+  console.error("usage: audit-export.mjs <offers.jsonl> <deal.jsonl> <0x contract id>");
+  process.exit(2);
+}
+
+const room = dealRoom(contract);
+const board = parseTranscriptExport(OFFER_ROOM, readFileSync(offersFile, "utf8"));
+const deal = parseTranscriptExport(room, readFileSync(dealFile, "utf8"));
+
+const authenticatedFrame = (record) => {
+  const verification = verifyTranscriptRecord(record);
+  if (!verification.ok) return null;
+  const frame = tryDecodeFrame(record.line);
+  return frame !== null && frame.from === record.sender ? frame : null;
+};
+
+const acceptRecord = board.find((record) => {
+  const frame = authenticatedFrame(record);
+  return frame?.type === "accept" && frame.contract === contract;
+});
+const accept = acceptRecord && authenticatedFrame(acceptRecord);
+const offerRecord = accept?.type === "accept"
+  ? board.find((record) => {
+      const frame = authenticatedFrame(record);
+      return frame?.type === "offer" && frame.id === accept.ref;
+    })
+  : undefined;
+
+if (!offerRecord || !acceptRecord) {
+  console.error(`no authenticated offer/accept pair for ${contract}`);
+  process.exit(1);
+}
+
+const folded = foldTranscript([offerRecord, acceptRecord, ...deal]);
+for (const step of folded.steps) {
+  const verdict = step.ok ? "ok " : "BAD";
+  console.log(`${verdict} ${step.room}#${step.seq} ${step.type ?? "record"}${step.reason ? ` — ${step.reason}` : ""}`);
+}
+
+if (folded.state === null) {
+  console.error("no authenticated contract could be opened");
+  process.exit(1);
+}
+
+const terminal = ["claimed", "refunded", "cancelled"].includes(folded.state.status);
+console.log(`\nfold → ${folded.state.status}${terminal ? "" : " (not terminal)"}`);
+process.exit(terminal ? 0 : 1);

--- a/examples/htlc-walkthrough.md
+++ b/examples/htlc-walkthrough.md
@@ -112,7 +112,9 @@ its JSON arguments.
    `tclk_post_frame` `{"room":"tclk-demo","nick":"payee","frame":"<accept line>"}`.
 3. **Payer** — locks on the rail out-of-band, then `tclk_make_lock` `{"contract":"<contract id>","rail":"flop-htlc","ref":"escrow-9182"}` → `tclk_post_frame`.
 4. **Payee** — `tclk_make_reveal` `{"contract":"<contract id>","secret":"<preimage from step 2>"}` → `tclk_post_frame`.
-5. Either side — `tclk_apply_transcript` `{"frames":["<offer>","<accept>","<lock>","<reveal>"]}` → the final contract state, `claimed`.
+5. Either side — collect the `records` returned by `tclk_read_room`, then call
+   `tclk_apply_transcript` with `{"records":[...]}` → the authenticated final contract
+   state, `claimed`. Each record carries its own sender, signature and venue timestamp.
 
 With `TECHNOCORE_SIGNING_KEY` set on the server, `tclk_post_frame` signs and posts through the
 signed lane automatically instead of the unsigned one used above — the only difference is you

--- a/examples/live-deal.mjs
+++ b/examples/live-deal.mjs
@@ -24,9 +24,10 @@
 import { randomBytes } from "node:crypto";
 
 import {
-  OFFER_ROOM, PaperRail, applyFrame, dealRoom, decodeFrame, encodeFrame,
+  OFFER_ROOM, PaperRail, applyFrame, dealRoom, encodeFrame, foldTranscript,
   generateHashLock, lockTerms, makeAccept, makeOffer, openContract, paperNote,
-  stateNote, stateNoteValue, tryDecodeFrame,
+  parseTranscriptExport, stateNote, stateNoteValue, transcriptRecord, tryDecodeFrame,
+  verifyTranscriptRecord,
 } from "../dist/index.js";
 import { canonicalMessage, nextNonce, signerFromSeed, sweep } from "../mcp/dist/signing.js";
 
@@ -109,11 +110,20 @@ async function req(url, init, what) {
   }
 }
 
-/** Read a room the way any stranger would. */
+/** Read the venue's bounded tail window as complete transcript records. */
 async function readRoom(room) {
   const res = await req(`${BASE}/r/${room}?format=json`, undefined, `read ${room}`);
   if (!res.ok) throw await refusal(`read ${room}`, res);
-  return res.json();
+  const view = await res.json();
+  if (!view || !Array.isArray(view.messages)) throw new Error(`read ${room}: no messages array`);
+  return view.messages.map((message) => transcriptRecord(room, message));
+}
+
+/** Read the retained room history. The strict parser never skips a malformed export row. */
+async function exportRoom(room) {
+  const res = await req(`${BASE}/r/${room}/export`, undefined, `export ${room}`);
+  if (!res.ok) throw await refusal(`export ${room}`, res);
+  return parseTranscriptExport(room, await res.text());
 }
 
 /** Post one frame through the signed lane, as the given identity. */
@@ -314,24 +324,31 @@ await notes.set(note.ns, note.key, stateNoteValue("claimed", ref), {
 // 5 — a third party, holding no secrets, reconstructs the deal from the venue alone.
 console.log();
 log(5, "third-party verification, from the rooms only:");
-const board = await readRoom(OFFER_ROOM);
+const board = await exportRoom(OFFER_ROOM);
 const dealLog = await readRoom(room);
 
-const offerLine = board.messages.map((m) => tryDecodeFrame(m.text)).find((f) => f?.id === offer.id);
-const acceptLine = board.messages
-  .map((m) => tryDecodeFrame(m.text))
-  .find((f) => f?.type === "accept" && f.contract === accept.contract);
-if (!offerLine || !acceptLine) throw new Error("could not find the deal on the board");
+const authenticatedFrame = (record) => {
+  if (!verifyTranscriptRecord(record).ok) return null;
+  const frame = tryDecodeFrame(record.line);
+  return frame !== null && frame.from === record.sender ? frame : null;
+};
+const offerRecord = board.find((record) => {
+  const frame = authenticatedFrame(record);
+  return frame?.type === "offer" && frame.id === offer.id;
+});
+const acceptRecord = board.find((record) => {
+  const frame = authenticatedFrame(record);
+  return frame?.type === "accept" && frame.contract === accept.contract;
+});
+if (!offerRecord || !acceptRecord) throw new Error("could not find the deal on the full board export");
 
-// Fold every frame the venue actually stored — including anything a stranger posted.
-let audit = openContract(offerLine);
-let applied = 0;
-let skipped = 0;
-for (const message of [acceptLine, ...dealLog.messages.map((m) => tryDecodeFrame(m.text))]) {
-  if (message === null) { skipped += 1; continue; }
-  const step = applyFrame(audit, message, Date.now());
-  if (step.ok) { applied += 1; audit = step.state; } else { skipped += 1; }
-}
+// Fold complete records, not parallel lines/timestamps/senders. Signature, attribution
+// and the record's own venue time are checked before a frame can advance the state.
+const folded = foldTranscript([offerRecord, acceptRecord, ...dealLog]);
+if (folded.state === null) throw new Error("the authenticated transcript contains no offer");
+const audit = folded.state;
+const applied = folded.steps.filter((step) => step.ok).length;
+const skipped = folded.steps.length - applied;
 
 log("", `replayed ${applied} frames, ignored ${skipped}, final status: ${audit.status}`);
 log("", `secret in the transcript opens the statement: ${audit.secret === lock.preimage}`);

--- a/examples/live-deal.mjs
+++ b/examples/live-deal.mjs
@@ -24,10 +24,9 @@
 import { randomBytes } from "node:crypto";
 
 import {
-  OFFER_ROOM, PaperRail, applyFrame, dealRoom, encodeFrame, foldTranscript,
+  OFFER_ROOM, PaperRail, applyFrame, dealRoom, encodeFrame, findContractHandshake, foldTranscript,
   generateHashLock, lockTerms, makeAccept, makeOffer, openContract, paperNote,
-  parseTranscriptExport, stateNote, stateNoteValue, transcriptRecord, tryDecodeFrame,
-  verifyTranscriptRecord,
+  parseTranscriptExport, stateNote, stateNoteValue, transcriptRecord,
 } from "../dist/index.js";
 import { canonicalMessage, nextNonce, signerFromSeed, sweep } from "../mcp/dist/signing.js";
 
@@ -327,24 +326,12 @@ log(5, "third-party verification, from the rooms only:");
 const board = await exportRoom(OFFER_ROOM);
 const dealLog = await readRoom(room);
 
-const authenticatedFrame = (record) => {
-  if (!verifyTranscriptRecord(record).ok) return null;
-  const frame = tryDecodeFrame(record.line);
-  return frame !== null && frame.from === record.sender ? frame : null;
-};
-const offerRecord = board.find((record) => {
-  const frame = authenticatedFrame(record);
-  return frame?.type === "offer" && frame.id === offer.id;
-});
-const acceptRecord = board.find((record) => {
-  const frame = authenticatedFrame(record);
-  return frame?.type === "accept" && frame.contract === accept.contract;
-});
-if (!offerRecord || !acceptRecord) throw new Error("could not find the deal on the full board export");
+const handshake = findContractHandshake(board, accept.contract);
+if (handshake === null) throw new Error("could not find the deal on the full board export");
 
 // Fold complete records, not parallel lines/timestamps/senders. Signature, attribution
 // and the record's own venue time are checked before a frame can advance the state.
-const folded = foldTranscript([offerRecord, acceptRecord, ...dealLog]);
+const folded = foldTranscript([handshake.offer, handshake.accept, ...dealLog]);
 if (folded.state === null) throw new Error("the authenticated transcript contains no offer");
 const audit = folded.state;
 const applied = folded.steps.filter((step) => step.ok).length;

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -51,13 +51,18 @@ All keys come from the environment; none is ever accepted as a tool argument or 
 `tclk_make_receipt`. Each returns `{ frame, line }`.
 
 **Reading** — `tclk_decode` (one line → frame, or a structured reason),
-`tclk_apply_transcript` (fold a room into one contract view with a per-line verdict),
+`tclk_apply_transcript` (authenticate and fold complete records with a per-record verdict),
 `tclk_verify_secret`.
 
 **PTLC** — `tclk_adaptor_presign`, `tclk_adaptor_adapt`, `tclk_adaptor_extract`,
 `tclk_adaptor_verify`. ⚠️ Unaudited reference cryptography; not for mainnet value flows.
 
 **Transport** — `tclk_post_frame`, `tclk_read_room`, `tclk_whoami`.
+
+`tclk_read_room` returns `records` ready to pass directly to `tclk_apply_transcript`.
+Set `full: true` to read the retained byte-exact `/export` history instead of the bounded
+live window. Each record keeps its line, sender, signature, nonce, sequence and venue time
+together; the fold has no parallel arrays and no fallback clock.
 
 ### `tclk_post_frame` has three tiers
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -20,3 +20,4 @@ export type { Signer } from "./signing.js";
 
 export { createClient, assertRoomName, DEFAULT_TECHNOCORE_URL } from "./technocore.js";
 export type { FetchLike, RoomMessage, RoomView, SignedPost, TechnocoreClient } from "./technocore.js";
+export type { TranscriptRecord } from "@flop-labs/tclk";

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -23,6 +23,19 @@ const contract = z.string().describe("The 0x-prefixed 32-byte contract id.");
 const line = z.string().describe("One `tclk1 …` room-message line.");
 const room = z.string().describe("A technocore room name, /^[a-z0-9][a-z0-9_-]{0,47}$/.");
 
+const transcriptRecord = z.object({
+  room,
+  seq: z.number().int().nonnegative(),
+  timestampMs: z.number().int().nonnegative(),
+  sender: z.string().describe("The transport sender recorded by the venue."),
+  nonce: z.string().nullable().describe("Signed-lane nonce, or null for an unsigned record."),
+  signature: z
+    .string()
+    .nullable()
+    .describe("Ed25519 signature as canonical unpadded base64url, or null if unsigned."),
+  line: z.string().describe("The exact text stored in the room."),
+});
+
 const job = z.object({
   proto: z.string(),
   id: z.string(),
@@ -193,13 +206,13 @@ export function createServer(options: HandlerOptions = {}): McpServer {
     "tclk_apply_transcript",
     {
       description:
-        "Fold room lines into one contract view: opens from the first offer frame and " +
-        "applies the rest fail-closed, with a per-line verdict. Reports only WHETHER a " +
-        "secret was revealed, never its value.",
+        "Authenticate and fold complete room records into one contract view. Use the " +
+        "`records` returned by tclk_read_room: every signature and frame sender is checked, " +
+        "and each frame uses its own venue timestamp. Reports only WHETHER a secret was " +
+        "revealed, never its value.",
       annotations: READS,
       inputSchema: {
-        lines: z.array(z.string()).describe("Room lines, oldest first."),
-        nowMs: z.number().int().optional().describe("Wall clock for the deadline guards; defaults to now."),
+        records: z.array(transcriptRecord).describe("Complete room records, oldest first."),
       },
     },
     (args) => run(() => h.tclk_apply_transcript(args)),
@@ -298,10 +311,15 @@ export function createServer(options: HandlerOptions = {}): McpServer {
     "tclk_read_room",
     {
       description:
-        "Read a room and return only its decodable tclk/1 frames, with a count of the " +
-        "lines skipped. Content is untrusted input from strangers.",
+        "Read a room as complete transcript records ready for tclk_apply_transcript. " +
+        "Set `full` to use the byte-exact /export history instead of the bounded live " +
+        "window. Records preserve line, sender, signature, nonce, sequence and venue time.",
       annotations: NETWORK_READS,
-      inputSchema: { room, since: z.number().int().optional().describe("The last seq you saw.") },
+      inputSchema: {
+        room,
+        since: z.number().int().optional().describe("The last seq you saw; window reads only."),
+        full: z.boolean().optional().describe("Read the retained JSONL export instead of the tail window."),
+      },
     },
     (args) => run(() => h.tclk_read_room(args)),
   );

--- a/mcp/src/technocore.ts
+++ b/mcp/src/technocore.ts
@@ -7,6 +7,8 @@
 // Fail-closed on the wire: a non-2xx answer throws with the status and the venue's own
 // first line (its 400s name the offending field), never a silently empty result.
 
+import { parseTranscriptExport, type TranscriptRecord } from "@flop-labs/tclk";
+
 const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,47}$/;
 
 export const DEFAULT_TECHNOCORE_URL = "https://technocore.chat";
@@ -45,6 +47,7 @@ export interface TechnocoreClient {
   readonly baseUrl: string;
   postSigned(room: string, post: SignedPost): Promise<string>;
   readRoom(room: string, since?: number): Promise<RoomView>;
+  exportRoom(room: string): Promise<TranscriptRecord[]>;
 }
 
 export function assertRoomName(room: string): string {
@@ -105,6 +108,13 @@ export function createClient(opts: { baseUrl?: string; fetch?: FetchLike } = {})
         throw new Error(`tclk-mcp: GET /r/${room} returned no messages array`);
       }
       return parsed as RoomView;
+    },
+
+    async exportRoom(room) {
+      assertRoomName(room);
+      const response = await doFetch(`${baseUrl}/r/${room}/export`, { method: "GET" });
+      if (!response.ok) await fail(response, `GET /r/${room}/export`);
+      return parseTranscriptExport(room, await response.text());
     },
   };
 }

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -13,17 +13,17 @@
 // pre-signatures). Neither is echoed by any tool, `tclk_whoami` included.
 
 import {
-  applyFrame,
   decodeFrame,
   dealRoom,
   encodeFrame,
+  foldTranscript,
   generateHashLock,
   generatePointLock,
   makeAccept,
   makeOffer,
-  openContract,
   schnorrAdaptor,
   stateNote,
+  transcriptRecord,
   tryDecodeFrame,
   verifySecret,
   type ContractState,
@@ -32,6 +32,7 @@ import {
   type OfferFrame,
   type PresigRef,
   type TclkFrame,
+  type TranscriptRecord,
 } from "@flop-labs/tclk";
 
 import { canonicalMessage, loadSigner, nextNonce, sweep, type Signer } from "./signing.js";
@@ -236,47 +237,21 @@ export function createHandlers(options: HandlerOptions = {}) {
     },
 
     /**
-     * Fold a room transcript into one contract view. Lines are anonymous input, so
-     * nothing here throws on a bad one: every line gets an `{ ok, reason }` verdict and
-     * money-state only advances on frames that verify.
+     * Fold complete signed records, never positionally related arrays. The core verifies
+     * each record signature and sender binding, then applies its frame at that record's
+     * venue timestamp. Every record gets a verdict and invalid input changes no state.
      */
-    tclk_apply_transcript(input: { lines: string[]; nowMs?: number }) {
-      const nowMs = input.nowMs ?? Date.now();
-      const steps: { index: number; type?: string; ok: boolean; reason?: string }[] = [];
-      let state: ContractState | null = null;
-
-      input.lines.forEach((line, index) => {
-        const frame = tryDecodeFrame(line);
-        if (frame === null) {
-          let reason = "not a tclk/1 frame";
-          try {
-            decodeFrame(line);
-          } catch (error) {
-            reason = errorMessage(error);
-          }
-          steps.push({ index, ok: false, reason });
-          return;
-        }
-        if (state === null) {
-          if (frame.type !== "offer") {
-            steps.push({ index, type: frame.type, ok: false, reason: "no contract open yet" });
-            return;
-          }
-          try {
-            state = openContract(frame);
-            steps.push({ index, type: "offer", ok: true });
-          } catch (error) {
-            steps.push({ index, type: "offer", ok: false, reason: errorMessage(error) });
-          }
-          return;
-        }
-        const result = applyFrame(state, frame, nowMs);
-        state = result.state;
-        steps.push({ index, type: frame.type, ok: result.ok, reason: result.reason });
-      });
-
-      if (state === null) fail("transcript contains no offer frame to open a contract from");
-      const open: ContractState = state;
+    tclk_apply_transcript(input: { records: TranscriptRecord[] }) {
+      const folded = foldTranscript(input.records);
+      if (folded.state === null) {
+        const offerFailure = folded.steps.find((step) => step.type === "offer" && !step.ok);
+        fail(
+          offerFailure?.reason === undefined
+            ? "transcript contains no authenticated offer frame to open a contract from"
+            : `no contract could be opened: ${offerFailure.reason}`,
+        );
+      }
+      const open: ContractState = folded.state;
 
       return {
         status: open.status,
@@ -294,7 +269,7 @@ export function createHandlers(options: HandlerOptions = {}) {
         // The revealed secret is deliberately NOT echoed: it is in the transcript the
         // caller already holds, and this server never republishes secret material.
         secretRevealed: open.secret !== undefined,
-        steps,
+        steps: folded.steps,
       };
     },
 
@@ -422,19 +397,28 @@ export function createHandlers(options: HandlerOptions = {}) {
       };
     },
 
-    async tclk_read_room(input: { room: string; since?: number }) {
-      const view = await client.readRoom(input.room, input.since);
-      const frames: { seq: number; ts: string; from: string; frame: TclkFrame }[] = [];
-      let skipped = 0;
-      for (const message of view.messages) {
-        const frame = typeof message.text === "string" ? tryDecodeFrame(message.text) : null;
-        if (frame === null) {
-          skipped += 1;
-          continue;
-        }
-        frames.push({ seq: message.seq, ts: message.ts, from: message.from, frame });
+    async tclk_read_room(input: { room: string; since?: number; full?: boolean }) {
+      if (input.full === true) {
+        if (input.since !== undefined) fail("`since` cannot be combined with a full room export");
+        const records = await client.exportRoom(input.room);
+        return {
+          room: input.room,
+          source: "export" as const,
+          records,
+          count: records.length,
+          lastSeq: records.at(-1)?.seq ?? null,
+        };
       }
-      return { room: view.room, frames, skipped, lastSeq: view.last_seq };
+
+      const view = await client.readRoom(input.room, input.since);
+      const records = view.messages.map((message) => transcriptRecord(input.room, message));
+      return {
+        room: input.room,
+        source: "window" as const,
+        records,
+        count: records.length,
+        lastSeq: view.last_seq,
+      };
     },
 
     tclk_whoami() {

--- a/mcp/tests/transcript.test.ts
+++ b/mcp/tests/transcript.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { decodeFrame, type TranscriptRecord } from "@flop-labs/tclk";
+import { dealRoom, decodeFrame, type TranscriptRecord } from "@flop-labs/tclk";
 
 import { canonicalMessage, signerFromSeed } from "../src/signing.js";
 import { createHandlers } from "../src/tools.js";
@@ -26,6 +26,7 @@ function records(lines: string[], timestampMs: number): TranscriptRecord[] {
       const frame = decodeFrame(line);
       from = frame.from;
       if (frame.type === "offer" || frame.type === "accept") room = "tclk-offers";
+      else room = dealRoom(frame.contract);
     } catch {
       // Signed non-frame room traffic still gets a fold verdict.
     }

--- a/mcp/tests/transcript.test.ts
+++ b/mcp/tests/transcript.test.ts
@@ -6,10 +6,42 @@
 
 import { describe, expect, it } from "vitest";
 
+import { decodeFrame, type TranscriptRecord } from "@flop-labs/tclk";
+
+import { canonicalMessage, signerFromSeed } from "../src/signing.js";
 import { createHandlers } from "../src/tools.js";
-import { HASH_OFFER, NOW, PAYEE_DID, PAYER_DID } from "./fixtures.js";
+import {
+  HASH_OFFER, NOW, PAYEE_DID, PAYEE_SEED, PAYER_DID, PAYER_SEED, hexToBytes,
+} from "./fixtures.js";
 
 const h = createHandlers({ env: {} });
+const payer = signerFromSeed(hexToBytes(PAYER_SEED));
+const payee = signerFromSeed(hexToBytes(PAYEE_SEED));
+
+function records(lines: string[], timestampMs: number): TranscriptRecord[] {
+  return lines.map((line, index) => {
+    let from = PAYER_DID;
+    let room = "mb-p-tclk-deadbeefdeadbeef";
+    try {
+      const frame = decodeFrame(line);
+      from = frame.from;
+      if (frame.type === "offer" || frame.type === "accept") room = "tclk-offers";
+    } catch {
+      // Signed non-frame room traffic still gets a fold verdict.
+    }
+    const signer = from === PAYEE_DID ? payee : payer;
+    const nonce = String(1000 + index);
+    return {
+      room,
+      seq: index,
+      timestampMs,
+      sender: signer.did,
+      nonce,
+      signature: signer.sign(canonicalMessage(room, Number(nonce), line)),
+      line,
+    };
+  });
+}
 
 function openDeal(offerFields = HASH_OFFER) {
   const offer = h.tclk_make_offer(offerFields);
@@ -40,8 +72,7 @@ describe("happy path", () => {
     });
 
     const result = h.tclk_apply_transcript({
-      lines: [offer.line, accept.line, lock.line, reveal.line, receipt.line],
-      nowMs: NOW,
+      records: records([offer.line, accept.line, lock.line, reveal.line, receipt.line], NOW),
     });
 
     expect(result.steps.map((s) => s.ok)).toEqual([true, true, true, true, true]);
@@ -84,8 +115,10 @@ describe("refund path", () => {
     });
 
     const open = h.tclk_apply_transcript({
-      lines: [offer.line, accept.line, lock.line, refund.line],
-      nowMs: lateExpiry.refundAfterMs + 1,
+      records: records(
+        [offer.line, accept.line, lock.line, refund.line],
+        lateExpiry.refundAfterMs + 1,
+      ),
     });
     expect(open.steps.map((s) => s.ok)).toEqual([true, true, true, true]);
     expect(open.status).toBe("refunded");
@@ -94,8 +127,10 @@ describe("refund path", () => {
     // Same transcript, one millisecond before the window: the refund is refused and the
     // contract stays locked.
     const early = h.tclk_apply_transcript({
-      lines: [offer.line, accept.line, lock.line, refund.line],
-      nowMs: lateExpiry.refundAfterMs - 1,
+      records: records(
+        [offer.line, accept.line, lock.line, refund.line],
+        lateExpiry.refundAfterMs - 1,
+      ),
     });
     expect(early.status).toBe("locked");
     expect(early.steps[3]).toMatchObject({ ok: false, reason: "refund window not open yet" });
@@ -112,14 +147,16 @@ describe("fail-closed folding", () => {
     });
 
     const result = h.tclk_apply_transcript({
-      lines: [
-        "gm everyone",
-        offer.line,
-        "tclk1 {\"type\":\"lock\"}",
-        accept.line,
-        stolenReveal.line,
-      ],
-      nowMs: NOW,
+      records: records(
+        [
+          "gm everyone",
+          offer.line,
+          "tclk1 {\"type\":\"lock\"}",
+          accept.line,
+          stolenReveal.line,
+        ],
+        NOW,
+      ),
     });
 
     expect(result.steps[0]).toMatchObject({ ok: false });
@@ -133,8 +170,8 @@ describe("fail-closed folding", () => {
   });
 
   it("refuses a transcript with no offer to open from", () => {
-    expect(() => h.tclk_apply_transcript({ lines: ["gm", "still not a frame"] })).toThrow(
-      /no offer frame/,
-    );
+    expect(() => h.tclk_apply_transcript({
+      records: records(["gm", "still not a frame"], NOW),
+    })).toThrow(/no authenticated offer frame/);
   });
 });

--- a/mcp/tests/transport.test.ts
+++ b/mcp/tests/transport.test.ts
@@ -101,8 +101,9 @@ describe("tclk_post_frame — tier 2, server-signed", () => {
 });
 
 describe("tclk_read_room", () => {
-  it("returns decodable frames and counts what it skipped", async () => {
+  it("returns complete records without dropping unsigned or malformed frame lines", async () => {
     const line = offerLine();
+    const nonce = 11;
     const { calls, fetchLike } = fakeFetch([
       {
         body: "",
@@ -113,7 +114,14 @@ describe("tclk_read_room", () => {
           last_seq: 13,
           messages: [
             { seq: 10, ts: "2026-01-01T00:00:00Z", from: "~stranger", text: "gm" },
-            { seq: 11, ts: "2026-01-01T00:00:01Z", from: signer.did, text: line },
+            {
+              seq: 11,
+              ts: "2026-01-01T00:00:01Z",
+              from: signer.did,
+              nonce: String(nonce),
+              sig: signer.sign(canonicalMessage("lobby", nonce, line)),
+              text: line,
+            },
             { seq: 12, ts: "2026-01-01T00:00:02Z", from: "~spoofer", text: 'tclk1 {"type":"offer"}' },
             { seq: 13, ts: "2026-01-01T00:00:03Z", from: "~stranger", text: "tclk1 not-json" },
           ],
@@ -125,10 +133,44 @@ describe("tclk_read_room", () => {
     const result = await h.tclk_read_room({ room: "lobby", since: 9 });
     expect(calls[0].url).toBe("https://technocore.chat/r/lobby?format=json&since=9");
     expect(result.lastSeq).toBe(13);
-    expect(result.skipped).toBe(3);
-    expect(result.frames).toHaveLength(1);
-    expect(result.frames[0]).toMatchObject({ seq: 11, from: signer.did });
-    expect(result.frames[0].frame.type).toBe("offer");
+    expect(result.source).toBe("window");
+    expect(result.records).toHaveLength(4);
+    expect(result.records[1]).toMatchObject({
+      room: "lobby",
+      seq: 11,
+      sender: signer.did,
+      nonce: "11",
+      line,
+    });
+    expect(result.records[0]).toMatchObject({ signature: null, nonce: null, line: "gm" });
+
+    const folded = h.tclk_apply_transcript({ records: result.records });
+    expect(folded.status).toBe("proposed");
+    expect(folded.steps.map((step) => step.ok)).toEqual([false, true, false, false]);
+  });
+
+  it("reads and strictly parses the full JSONL export", async () => {
+    const line = offerLine();
+    const nonce = 17;
+    const exported = JSON.stringify({
+      seq: 17,
+      ts: "2026-01-01T00:00:01Z",
+      from: signer.did,
+      nonce: String(nonce),
+      sig: signer.sign(canonicalMessage("tclk-offers", nonce, line)),
+      text: line,
+    });
+    const { calls, fetchLike } = fakeFetch([{ body: `${exported}\n` }]);
+    const h = createHandlers({ env: {}, fetch: fetchLike });
+
+    const result = await h.tclk_read_room({ room: "tclk-offers", full: true });
+    expect(calls[0].url).toBe("https://technocore.chat/r/tclk-offers/export");
+    expect(result.source).toBe("export");
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0]).toMatchObject({ seq: 17, sender: signer.did, line });
+    await expect(
+      h.tclk_read_room({ room: "tclk-offers", full: true, since: 3 }),
+    ).rejects.toThrow(/cannot be combined/);
   });
 
   it("refuses a bad room name before it reaches the wire", async () => {

--- a/mcp/tests/transport.test.ts
+++ b/mcp/tests/transport.test.ts
@@ -144,9 +144,9 @@ describe("tclk_read_room", () => {
     });
     expect(result.records[0]).toMatchObject({ signature: null, nonce: null, line: "gm" });
 
-    const folded = h.tclk_apply_transcript({ records: result.records });
-    expect(folded.status).toBe("proposed");
-    expect(folded.steps.map((step) => step.ok)).toEqual([false, true, false, false]);
+    expect(() => h.tclk_apply_transcript({ records: result.records })).toThrow(
+      /offer must be posted in tclk-offers/,
+    );
   });
 
   it("reads and strictly parses the full JSONL export", async () => {

--- a/mcp/worker/src/tool-manifest.generated.ts
+++ b/mcp/worker/src/tool-manifest.generated.ts
@@ -256,24 +256,66 @@ export const TOOLS: readonly ManifestTool[] = [
   },
   {
     "name": "tclk_apply_transcript",
-    "description": "Fold room lines into one contract view: opens from the first offer frame and applies the rest fail-closed, with a per-line verdict. Reports only WHETHER a secret was revealed, never its value.",
+    "description": "Authenticate and fold complete room records into one contract view. Use the `records` returned by tclk_read_room: every signature and frame sender is checked, and each frame uses its own venue timestamp. Reports only WHETHER a secret was revealed, never its value.",
     "inputSchema": {
       "type": "object",
       "properties": {
-        "lines": {
+        "records": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "room": {
+                "type": "string",
+                "description": "A technocore room name, /^[a-z0-9][a-z0-9_-]{0,47}$/."
+              },
+              "seq": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "timestampMs": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "sender": {
+                "type": "string",
+                "description": "The transport sender recorded by the venue."
+              },
+              "nonce": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Signed-lane nonce, or null for an unsigned record."
+              },
+              "signature": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Ed25519 signature as canonical unpadded base64url, or null if unsigned."
+              },
+              "line": {
+                "type": "string",
+                "description": "The exact text stored in the room."
+              }
+            },
+            "required": [
+              "room",
+              "seq",
+              "timestampMs",
+              "sender",
+              "nonce",
+              "signature",
+              "line"
+            ],
+            "additionalProperties": false
           },
-          "description": "Room lines, oldest first."
-        },
-        "nowMs": {
-          "type": "integer",
-          "description": "Wall clock for the deadline guards; defaults to now."
+          "description": "Complete room records, oldest first."
         }
       },
       "required": [
-        "lines"
+        "records"
       ],
       "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
@@ -660,7 +702,7 @@ export const TOOLS: readonly ManifestTool[] = [
   },
   {
     "name": "tclk_read_room",
-    "description": "Read a room and return only its decodable tclk/1 frames, with a count of the lines skipped. Content is untrusted input from strangers.",
+    "description": "Read a room as complete transcript records ready for tclk_apply_transcript. Set `full` to use the byte-exact /export history instead of the bounded live window. Records preserve line, sender, signature, nonce, sequence and venue time.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -670,7 +712,11 @@ export const TOOLS: readonly ManifestTool[] = [
         },
         "since": {
           "type": "integer",
-          "description": "The last seq you saw."
+          "description": "The last seq you saw; window reads only."
+        },
+        "full": {
+          "type": "boolean",
+          "description": "Read the retained JSONL export instead of the tail window."
         }
       },
       "required": [

--- a/mcp/worker/tests/worker.test.ts
+++ b/mcp/worker/tests/worker.test.ts
@@ -6,13 +6,18 @@
 
 import { describe, expect, it } from "vitest";
 
-import { HASH_OFFER, PAYEE_DID, PAYER_DID, fakeFetch } from "../../tests/fixtures.js";
+import {
+  HASH_OFFER, PAYEE_DID, PAYEE_SEED, PAYER_DID, PAYER_SEED, fakeFetch, hexToBytes,
+} from "../../tests/fixtures.js";
+import { canonicalMessage, signerFromSeed } from "../../src/signing.js";
 import { handleRequest, type Env } from "../src/worker.js";
 import { TOOLS } from "../src/tool-manifest.generated.js";
 import type { FetchLike } from "../../src/technocore.js";
 
 const ENV: Env = { TECHNOCORE_URL: "https://technocore.chat" };
 const ROOM = "mb-p-tclk-deadbeefdeadbeef";
+const payer = signerFromSeed(hexToBytes(PAYER_SEED));
+const payee = signerFromSeed(hexToBytes(PAYEE_SEED));
 
 let nextId = 1;
 
@@ -176,8 +181,26 @@ describe("tools/call round trip", () => {
     expect(verified.value.valid).toBe(true);
 
     const folded = await callTool("tclk_apply_transcript", {
-      lines: [offer, accepted.value.line],
-      nowMs: HASH_OFFER.expiresMs - 1,
+      records: [
+        {
+          room: "tclk-offers",
+          seq: 1,
+          timestampMs: HASH_OFFER.expiresMs - 2,
+          sender: payer.did,
+          nonce: "1001",
+          signature: payer.sign(canonicalMessage("tclk-offers", 1001, offer)),
+          line: offer,
+        },
+        {
+          room: "tclk-offers",
+          seq: 2,
+          timestampMs: HASH_OFFER.expiresMs - 1,
+          sender: payee.did,
+          nonce: "1002",
+          signature: payee.sign(canonicalMessage("tclk-offers", 1002, accepted.value.line)),
+          line: accepted.value.line,
+        },
+      ],
     });
     expect(folded.value.status).toBe("accepted");
     expect(folded.value.secretRevealed).toBe(false);

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "@noble/curves": "^2.4.0",
-    "@noble/hashes": "^2.4.0"
+    "@noble/hashes": "^2.4.0",
+    "@scure/base": "^2.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@noble/hashes':
         specifier: ^2.4.0
         version: 2.4.0
+      '@scure/base':
+        specifier: ^2.4.0
+        version: 2.4.0
     devDependencies:
       '@types/node':
         specifier: ^22.10.2

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -141,7 +141,7 @@ const AMOUNT = /^[1-9][0-9]*$/;
 const ASSET = /^[A-Za-z0-9_-]{1,32}$/;
 const RAIL = /^[a-z0-9][a-z0-9._-]{0,63}$/;
 const NONCE = /^[0-9a-f]{8,64}$/;
-const SCALAR_HEX = /^0x[0-9a-f]{1,64}$/;
+const SCALAR_HEX = /^0x(?:[0-9a-f]{2}){1,32}$/;
 
 function fail(msg: string): never {
   throw new Error(`tclk: ${msg}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,13 @@ export type { HashLock } from "./locks.js";
 export { TCLK_TERMINAL_STATUSES, openContract, applyFrame } from "./machine.js";
 export type { TclkStatus, ContractState, StepResult } from "./machine.js";
 
+export {
+  verifyTranscriptRecord, transcriptRecord, parseTranscriptExport, foldTranscript,
+} from "./transcript.js";
+export type {
+  TranscriptRecord, TranscriptRecordVerification, TranscriptStep, TranscriptFoldResult,
+} from "./transcript.js";
+
 export { lockTerms, MemoryRail } from "./rail.js";
 
 // The paper rail: records the lifecycle, backs it with NOTHING. For rehearsing the

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,10 +29,12 @@ export { TCLK_TERMINAL_STATUSES, openContract, applyFrame } from "./machine.js";
 export type { TclkStatus, ContractState, StepResult } from "./machine.js";
 
 export {
-  verifyTranscriptRecord, transcriptRecord, parseTranscriptExport, foldTranscript,
+  verifyTranscriptRecord, transcriptRecord, parseTranscriptExport,
+  findContractHandshake, foldTranscript,
 } from "./transcript.js";
 export type {
   TranscriptRecord, TranscriptRecordVerification, TranscriptStep, TranscriptFoldResult,
+  ContractHandshake,
 } from "./transcript.js";
 
 export { lockTerms, MemoryRail } from "./rail.js";

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -15,6 +15,7 @@ import { dealRoom, OFFER_ROOM } from "./technocore.js";
 const ROOM_NAME = /^[a-z0-9][a-z0-9_-]{0,47}$/;
 const NONCE = /^(?:0|[1-9][0-9]*)$/;
 const SIGNATURE = /^[A-Za-z0-9_-]{85}[AQgw]$/;
+const TIMESTAMP = /^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
 const DID_PREFIX = "did:key:z";
 
 /**
@@ -124,6 +125,9 @@ export function transcriptRecord(room: string, value: unknown): TranscriptRecord
     throw new Error("tclk: transcript message seq must be a non-negative safe integer");
   }
   if (typeof message.ts !== "string") throw new Error("tclk: transcript message has no timestamp");
+  if (!TIMESTAMP.test(message.ts)) {
+    throw new Error("tclk: transcript message timestamp must be timezone-qualified RFC 3339");
+  }
   const timestampMs = Date.parse(message.ts);
   if (!Number.isSafeInteger(timestampMs) || timestampMs < 0) {
     throw new Error("tclk: transcript message timestamp is invalid");

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// A transcript is not an array of frame strings. The transport record beside each line
+// supplies the identity and time that make the state-machine guards meaningful. Keep the
+// fields together so attribution and timestamps cannot become short, shifted parallel
+// arrays, and verify the signed record before its frame is allowed to move money-state.
+
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { base58, base64urlnopad } from "@scure/base";
+
+import { decodeFrame, tryDecodeFrame } from "./frames.js";
+import { applyFrame, openContract, type ContractState } from "./machine.js";
+
+const ROOM_NAME = /^[a-z0-9][a-z0-9_-]{0,47}$/;
+const NONCE = /^(?:0|[1-9][0-9]*)$/;
+const SIGNATURE = /^[A-Za-z0-9_-]{85}[AQgw]$/;
+const DID_PREFIX = "did:key:z";
+
+/**
+ * One normalized technocore record. `line` is the exact stored text; `sender`, `nonce`
+ * and `signature` authenticate it for `room`. `timestampMs` and `seq` are venue metadata,
+ * not fields covered by the sender's signature; an offline auditor must trust the export
+ * file for those two values. Missing signature fields represent an unsigned-lane record
+ * and are rejected by a fold.
+ */
+export interface TranscriptRecord {
+  room: string;
+  seq: number;
+  timestampMs: number;
+  sender: string;
+  nonce: string | null;
+  signature: string | null;
+  line: string;
+}
+
+export interface TranscriptRecordVerification {
+  ok: boolean;
+  reason?: string;
+}
+
+export interface TranscriptStep {
+  index: number;
+  room: string;
+  seq: number;
+  type?: string;
+  ok: boolean;
+  reason?: string;
+}
+
+export interface TranscriptFoldResult {
+  state: ContractState | null;
+  steps: TranscriptStep[];
+}
+
+function invalid(reason: string): TranscriptRecordVerification {
+  return { ok: false, reason };
+}
+
+function publicKeyFromDid(did: string): Uint8Array | null {
+  if (!did.startsWith(DID_PREFIX)) return null;
+  try {
+    const tagged = base58.decode(did.slice(DID_PREFIX.length));
+    if (tagged.length !== 34 || tagged[0] !== 0xed || tagged[1] !== 0x01) return null;
+    return tagged.slice(2);
+  } catch {
+    return null;
+  }
+}
+
+/** Verify all structure and the Ed25519 signature of one normalized record. */
+export function verifyTranscriptRecord(record: TranscriptRecord): TranscriptRecordVerification {
+  if (!record || typeof record !== "object") return invalid("record is not an object");
+  if (typeof record.room !== "string" || !ROOM_NAME.test(record.room)) {
+    return invalid("record has an invalid room name");
+  }
+  if (!Number.isSafeInteger(record.seq) || record.seq < 0) {
+    return invalid("record seq must be a non-negative safe integer");
+  }
+  if (!Number.isSafeInteger(record.timestampMs) || record.timestampMs < 0) {
+    return invalid("record timestampMs must be a non-negative safe integer");
+  }
+  if (typeof record.line !== "string") return invalid("record line must be a string");
+  if (typeof record.sender !== "string") return invalid("record sender must be a string");
+  if (record.nonce === null || record.signature === null) {
+    return invalid("record is unsigned");
+  }
+  if (!NONCE.test(record.nonce)) return invalid("record nonce is not canonical decimal");
+  if (!SIGNATURE.test(record.signature)) {
+    return invalid("record signature is not canonical base64url");
+  }
+  const publicKey = publicKeyFromDid(record.sender);
+  if (publicKey === null) return invalid("record sender is not an Ed25519 did:key");
+
+  try {
+    const signature = base64urlnopad.decode(record.signature);
+    const canonical = `${record.room}|${record.nonce}|${record.line}`;
+    if (!ed25519.verify(signature, new TextEncoder().encode(canonical), publicKey)) {
+      return invalid("record signature does not verify");
+    }
+  } catch {
+    return invalid("record signature does not verify");
+  }
+  return { ok: true };
+}
+
+function object(value: unknown, where: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`tclk: ${where} is not a JSON object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+/** Normalize one `?format=json` or `/export` message without discarding its exact line. */
+export function transcriptRecord(room: string, value: unknown): TranscriptRecord {
+  if (!ROOM_NAME.test(room)) throw new Error(`tclk: invalid transcript room ${JSON.stringify(room)}`);
+  const message = object(value, "transcript message");
+  if (!Number.isSafeInteger(message.seq) || (message.seq as number) < 0) {
+    throw new Error("tclk: transcript message seq must be a non-negative safe integer");
+  }
+  if (typeof message.ts !== "string") throw new Error("tclk: transcript message has no timestamp");
+  const timestampMs = Date.parse(message.ts);
+  if (!Number.isSafeInteger(timestampMs) || timestampMs < 0) {
+    throw new Error("tclk: transcript message timestamp is invalid");
+  }
+  if (typeof message.from !== "string") throw new Error("tclk: transcript message has no sender");
+  if (typeof message.text !== "string") throw new Error("tclk: transcript message has no text");
+
+  let nonce: string | null = null;
+  if (typeof message.nonce === "string") nonce = message.nonce;
+  else if (typeof message.nonce === "number" && Number.isSafeInteger(message.nonce)) {
+    nonce = String(message.nonce);
+  } else if (message.nonce !== undefined && message.nonce !== null) {
+    throw new Error("tclk: transcript message nonce must be decimal text");
+  }
+
+  let signature: string | null = null;
+  if (typeof message.sig === "string") signature = message.sig;
+  else if (message.sig !== undefined && message.sig !== null) {
+    throw new Error("tclk: transcript message signature must be text");
+  }
+
+  return {
+    room,
+    seq: message.seq as number,
+    timestampMs,
+    sender: message.from,
+    nonce,
+    signature,
+    line: message.text,
+  };
+}
+
+/** Parse a byte-exact technocore `/export` JSONL response. One malformed row fails all. */
+export function parseTranscriptExport(room: string, jsonl: string): TranscriptRecord[] {
+  const records: TranscriptRecord[] = [];
+  jsonl.split("\n").forEach((line, index) => {
+    if (line.trim() === "") return;
+    let value: unknown;
+    try {
+      value = JSON.parse(line);
+    } catch {
+      throw new Error(`tclk: transcript export line ${index + 1} is not JSON`);
+    }
+    try {
+      records.push(transcriptRecord(room, value));
+    } catch (error) {
+      const reason = error instanceof Error ? error.message.replace(/^tclk: /, "") : "invalid record";
+      throw new Error(`tclk: transcript export line ${index + 1}: ${reason}`);
+    }
+  });
+  return records;
+}
+
+function decodeReason(line: string): string {
+  try {
+    decodeFrame(line);
+  } catch (error) {
+    return error instanceof Error ? error.message : "invalid tclk frame";
+  }
+  return "frame did not decode";
+}
+
+/**
+ * Authenticate and fold records in the supplied order. Every record gets a verdict;
+ * invalid signatures, forged `from` fields, malformed lines and bad transitions are
+ * rejected without changing state. Deadline guards use that record's venue timestamp.
+ */
+export function foldTranscript(records: readonly TranscriptRecord[]): TranscriptFoldResult {
+  const steps: TranscriptStep[] = [];
+  let state: ContractState | null = null;
+
+  records.forEach((record, index) => {
+    const base = { index, room: record?.room ?? "", seq: record?.seq ?? -1 };
+    const verification = verifyTranscriptRecord(record);
+    if (!verification.ok) {
+      steps.push({ ...base, ok: false, reason: verification.reason });
+      return;
+    }
+
+    const frame = tryDecodeFrame(record.line);
+    if (frame === null) {
+      steps.push({ ...base, ok: false, reason: decodeReason(record.line) });
+      return;
+    }
+    if (frame.from !== record.sender) {
+      steps.push({
+        ...base,
+        type: frame.type,
+        ok: false,
+        reason: `${frame.type}.from does not match the record sender`,
+      });
+      return;
+    }
+
+    if (state === null) {
+      if (frame.type !== "offer") {
+        steps.push({ ...base, type: frame.type, ok: false, reason: "no contract open yet" });
+        return;
+      }
+      try {
+        state = openContract(frame);
+        steps.push({ ...base, type: frame.type, ok: true });
+      } catch (error) {
+        steps.push({
+          ...base,
+          type: frame.type,
+          ok: false,
+          reason: error instanceof Error ? error.message : "invalid offer",
+        });
+      }
+      return;
+    }
+
+    const result = applyFrame(state, frame, record.timestampMs);
+    state = result.state;
+    steps.push({ ...base, type: frame.type, ok: result.ok, reason: result.reason });
+  });
+
+  return { state, steps };
+}

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -10,6 +10,7 @@ import { base58, base64urlnopad } from "@scure/base";
 
 import { decodeFrame, tryDecodeFrame } from "./frames.js";
 import { applyFrame, openContract, type ContractState } from "./machine.js";
+import { dealRoom, OFFER_ROOM } from "./technocore.js";
 
 const ROOM_NAME = /^[a-z0-9][a-z0-9_-]{0,47}$/;
 const NONCE = /^(?:0|[1-9][0-9]*)$/;
@@ -50,6 +51,11 @@ export interface TranscriptStep {
 export interface TranscriptFoldResult {
   state: ContractState | null;
   steps: TranscriptStep[];
+}
+
+export interface ContractHandshake {
+  offer: TranscriptRecord;
+  accept: TranscriptRecord;
 }
 
 function invalid(reason: string): TranscriptRecordVerification {
@@ -180,10 +186,48 @@ function decodeReason(line: string): string {
   return "frame did not decode";
 }
 
+function authenticatedFrame(record: TranscriptRecord) {
+  if (record.room !== OFFER_ROOM || !verifyTranscriptRecord(record).ok) return null;
+  const frame = tryDecodeFrame(record.line);
+  return frame !== null && frame.from === record.sender ? frame : null;
+}
+
+/**
+ * Find one contract's authenticated offer/accept pair without rewriting board history.
+ * Only an accept that follows its referenced offer in the supplied append order counts.
+ */
+export function findContractHandshake(
+  records: readonly TranscriptRecord[],
+  contract: string,
+): ContractHandshake | null {
+  // Reuse the public derivation's strict contract-id validation.
+  dealRoom(contract);
+  const offers = new Map<string, TranscriptRecord>();
+  let acceptPrecededOffer = false;
+
+  for (const record of records) {
+    const frame = authenticatedFrame(record);
+    if (frame?.type === "offer") {
+      if (!offers.has(frame.id)) offers.set(frame.id, record);
+      continue;
+    }
+    if (frame?.type !== "accept" || frame.contract !== contract) continue;
+    const offer = offers.get(frame.ref);
+    if (offer !== undefined) return { offer, accept: record };
+    acceptPrecededOffer = true;
+  }
+
+  if (acceptPrecededOffer) {
+    throw new Error(`tclk: accept for ${contract} has no preceding authenticated offer`);
+  }
+  return null;
+}
+
 /**
  * Authenticate and fold records in the supplied order. Every record gets a verdict;
- * invalid signatures, forged `from` fields, malformed lines and bad transitions are
- * rejected without changing state. Deadline guards use that record's venue timestamp.
+ * invalid signatures, forged `from` fields, wrong rooms, malformed lines and bad
+ * transitions are rejected without changing state. Deadline guards use that record's
+ * venue timestamp.
  */
 export function foldTranscript(records: readonly TranscriptRecord[]): TranscriptFoldResult {
   const steps: TranscriptStep[] = [];
@@ -217,6 +261,15 @@ export function foldTranscript(records: readonly TranscriptRecord[]): Transcript
         steps.push({ ...base, type: frame.type, ok: false, reason: "no contract open yet" });
         return;
       }
+      if (record.room !== OFFER_ROOM) {
+        steps.push({
+          ...base,
+          type: frame.type,
+          ok: false,
+          reason: `offer must be posted in ${OFFER_ROOM}`,
+        });
+        return;
+      }
       try {
         state = openContract(frame);
         steps.push({ ...base, type: frame.type, ok: true });
@@ -228,6 +281,23 @@ export function foldTranscript(records: readonly TranscriptRecord[]): Transcript
           reason: error instanceof Error ? error.message : "invalid offer",
         });
       }
+      return;
+    }
+
+    const expectedRoom =
+      frame.type === "offer" || frame.type === "accept" || state.contract === undefined
+        ? OFFER_ROOM
+        : dealRoom(state.contract);
+    if (record.room !== expectedRoom) {
+      const where = expectedRoom === OFFER_ROOM
+        ? OFFER_ROOM
+        : `the derived deal room ${expectedRoom}`;
+      steps.push({
+        ...base,
+        type: frame.type,
+        ok: false,
+        reason: `${frame.type} must be posted in ${where}`,
+      });
       return;
     }
 

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -119,6 +119,17 @@ describe("tclk frames — wire codec", () => {
     expect(() => baseOffer({ rails: [] })).toThrow(/rails/);
   });
 
+  it("rejects odd-length pre-signature scalar encodings", () => {
+    expect(() => encodeFrame({
+      type: "lock",
+      from: PAYER_DID,
+      contract: "0x" + "11".repeat(32),
+      rail: "flop-htlc",
+      ref: "escrow-42",
+      presig: { nonce: "0x02" + "22".repeat(32), s: "0xabc" },
+    })).toThrow(/presig\.s/);
+  });
+
   it("tryDecodeFrame skips foreign and hostile lines instead of throwing", () => {
     expect(tryDecodeFrame("hello from ~alice")).toBeNull();
     expect(tryDecodeFrame('tclk1 {"type":"offer"}')).toBeNull();

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -204,6 +204,17 @@ describe("trusted transcript records", () => {
 
     expect(parseTranscriptExport(BOARD, `${raw}\n`)).toEqual([signed]);
     expect(() => parseTranscriptExport(BOARD, `${raw}\nnot json\n`)).toThrow(/line 2/);
+
+    const withoutTimezone = JSON.stringify({
+      ...JSON.parse(raw),
+      ts: "2026-01-01T00:00:00",
+    });
+    const localeTimestamp = JSON.stringify({
+      ...JSON.parse(raw),
+      ts: "January 1, 2026 00:00:00",
+    });
+    expect(() => parseTranscriptExport(BOARD, withoutTimezone)).toThrow(/timezone-qualified/);
+    expect(() => parseTranscriptExport(BOARD, localeTimestamp)).toThrow(/timezone-qualified/);
   });
 
   it("never synthesizes offer-before-accept order while selecting a board handshake", () => {

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   encodeFrame,
+  dealRoom,
+  findContractHandshake,
   foldTranscript,
   generateHashLock,
   makeAccept,
@@ -16,7 +18,6 @@ import {
 
 const NOW = 1_735_000_000_000;
 const BOARD = "tclk-offers";
-const DEAL = "mb-p-tclk-deadbeefdeadbeef";
 
 function bytes(hex: string): Uint8Array {
   return Uint8Array.from(hex.match(/../g)!.map((part) => Number.parseInt(part, 16)));
@@ -98,8 +99,8 @@ describe("trusted transcript records", () => {
     const folded = foldTranscript([
       record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
       record(BOARD, 2, NOW, payee, encodeFrame(accept)),
-      record(DEAL, 1, NOW + 1, payer, encodeFrame(lockFrame)),
-      record(DEAL, 2, NOW + 2, payee, encodeFrame(reveal)),
+      record(dealRoom(accept.contract), 1, NOW + 1, payer, encodeFrame(lockFrame)),
+      record(dealRoom(accept.contract), 2, NOW + 2, payee, encodeFrame(reveal)),
     ]);
 
     expect(folded.steps.map((step) => step.ok)).toEqual([true, true, true, true]);
@@ -118,13 +119,35 @@ describe("trusted transcript records", () => {
     const folded = foldTranscript([
       record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
       record(BOARD, 2, NOW, payee, encodeFrame(accept)),
-      record(DEAL, 1, NOW + 1, stranger, encodeFrame(forgedLock)),
+      record(dealRoom(accept.contract), 1, NOW + 1, stranger, encodeFrame(forgedLock)),
     ]);
 
     expect(folded.state?.status).toBe("accepted");
     expect(folded.steps[2]).toMatchObject({
       ok: false,
       reason: "lock.from does not match the record sender",
+    });
+  });
+
+  it("rejects a valid post-accept frame outside the contract's derived deal room", () => {
+    const { offer, accept } = deal();
+    const lockFrame = {
+      type: "lock" as const,
+      from: payer.did,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-wrong-room",
+    };
+    const folded = foldTranscript([
+      record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+      record(BOARD, 2, NOW, payee, encodeFrame(accept)),
+      record("lobby", 3, NOW + 1, payer, encodeFrame(lockFrame)),
+    ]);
+
+    expect(folded.state?.status).toBe("accepted");
+    expect(folded.steps[2]).toMatchObject({
+      ok: false,
+      reason: expect.stringMatching(/derived deal room/),
     });
   });
 
@@ -158,8 +181,8 @@ describe("trusted transcript records", () => {
     const folded = foldTranscript([
       record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
       record(BOARD, 2, NOW, payee, encodeFrame(accept)),
-      record(DEAL, 1, NOW + 1, payer, encodeFrame(lockFrame)),
-      record(DEAL, 2, offer.refundAfterMs, payer, encodeFrame(refund)),
+      record(dealRoom(accept.contract), 1, NOW + 1, payer, encodeFrame(lockFrame)),
+      record(dealRoom(accept.contract), 2, offer.refundAfterMs, payer, encodeFrame(refund)),
     ]);
 
     expect(folded.state?.status).toBe("refunded");
@@ -181,5 +204,23 @@ describe("trusted transcript records", () => {
 
     expect(parseTranscriptExport(BOARD, `${raw}\n`)).toEqual([signed]);
     expect(() => parseTranscriptExport(BOARD, `${raw}\nnot json\n`)).toThrow(/line 2/);
+  });
+
+  it("never synthesizes offer-before-accept order while selecting a board handshake", () => {
+    const { offer, accept } = deal();
+    const earlyAccept = record(BOARD, 1, NOW - 1, payee, encodeFrame(accept));
+    const laterOffer = record(BOARD, 2, NOW, payer, encodeFrame(offer));
+
+    expect(() => findContractHandshake(
+      [earlyAccept, laterOffer],
+      accept.contract,
+    )).toThrow(/no preceding authenticated offer/);
+
+    const offerRecord = record(BOARD, 1, NOW - 1, payer, encodeFrame(offer));
+    const acceptRecord = record(BOARD, 2, NOW, payee, encodeFrame(accept));
+    expect(findContractHandshake(
+      [offerRecord, acceptRecord],
+      accept.contract,
+    )).toEqual({ offer: offerRecord, accept: acceptRecord });
   });
 });

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { base58, base64urlnopad } from "@scure/base";
+import { describe, expect, it } from "vitest";
+
+import {
+  encodeFrame,
+  foldTranscript,
+  generateHashLock,
+  makeAccept,
+  makeOffer,
+  parseTranscriptExport,
+  type TranscriptRecord,
+} from "../src/index.js";
+
+const NOW = 1_735_000_000_000;
+const BOARD = "tclk-offers";
+const DEAL = "mb-p-tclk-deadbeefdeadbeef";
+
+function bytes(hex: string): Uint8Array {
+  return Uint8Array.from(hex.match(/../g)!.map((part) => Number.parseInt(part, 16)));
+}
+
+function identity(seedHex: string) {
+  const seed = bytes(seedHex);
+  const publicKey = ed25519.getPublicKey(seed);
+  const tagged = Uint8Array.from([0xed, 0x01, ...publicKey]);
+  return {
+    did: `did:key:z${base58.encode(tagged)}`,
+    sign(canonical: string) {
+      return base64urlnopad.encode(ed25519.sign(new TextEncoder().encode(canonical), seed));
+    },
+  };
+}
+
+const payer = identity("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+const payee = identity("4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb");
+const stranger = identity("c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7");
+
+function record(
+  room: string,
+  seq: number,
+  timestampMs: number,
+  signer: ReturnType<typeof identity>,
+  line: string,
+): TranscriptRecord {
+  const nonce = String(10_000 + seq);
+  return {
+    room,
+    seq,
+    timestampMs,
+    sender: signer.did,
+    nonce,
+    signature: signer.sign(`${room}|${nonce}|${line}`),
+    line,
+  };
+}
+
+function deal(expiresMs = NOW + 60_000) {
+  const lock = generateHashLock();
+  const offer = makeOffer({
+    from: payer.did,
+    role: "payer",
+    amount: "1000",
+    asset: "USDC",
+    lock: "hash",
+    rails: ["flop-htlc"],
+    claimByMs: NOW + 3_600_000,
+    refundAfterMs: NOW + 7_200_000,
+    expiresMs,
+    nonce: "0011223344556677",
+  });
+  const accept = makeAccept(offer, {
+    from: payee.did,
+    statement: lock.hash,
+    nonce: "8899aabbccddeeff",
+  });
+  return { lock, offer, accept };
+}
+
+describe("trusted transcript records", () => {
+  it("authenticates and folds a complete deal at each record's own timestamp", () => {
+    const { lock, offer, accept } = deal();
+    const lockFrame = {
+      type: "lock" as const,
+      from: payer.did,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-42",
+    };
+    const reveal = {
+      type: "reveal" as const,
+      from: payee.did,
+      contract: accept.contract,
+      secret: lock.preimage,
+    };
+    const folded = foldTranscript([
+      record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+      record(BOARD, 2, NOW, payee, encodeFrame(accept)),
+      record(DEAL, 1, NOW + 1, payer, encodeFrame(lockFrame)),
+      record(DEAL, 2, NOW + 2, payee, encodeFrame(reveal)),
+    ]);
+
+    expect(folded.steps.map((step) => step.ok)).toEqual([true, true, true, true]);
+    expect(folded.state?.status).toBe("claimed");
+  });
+
+  it("rejects a validly signed record when the frame claims a different sender", () => {
+    const { offer, accept } = deal();
+    const forgedLock = {
+      type: "lock" as const,
+      from: payer.did,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-does-not-exist",
+    };
+    const folded = foldTranscript([
+      record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+      record(BOARD, 2, NOW, payee, encodeFrame(accept)),
+      record(DEAL, 1, NOW + 1, stranger, encodeFrame(forgedLock)),
+    ]);
+
+    expect(folded.state?.status).toBe("accepted");
+    expect(folded.steps[2]).toMatchObject({
+      ok: false,
+      reason: "lock.from does not match the record sender",
+    });
+  });
+
+  it("rejects unsigned records and malformed timestamps without a fallback clock", () => {
+    const { offer } = deal();
+    const unsigned = record(BOARD, 1, NOW, payer, encodeFrame(offer));
+    unsigned.signature = null;
+    const malformedTime = record(BOARD, 2, NOW, payer, encodeFrame(offer));
+    malformedTime.timestampMs = Number.NaN;
+
+    const tampered = record(BOARD, 3, NOW, payer, encodeFrame(offer));
+    tampered.line += " ";
+
+    const folded = foldTranscript([unsigned, malformedTime, tampered]);
+    expect(folded.state).toBeNull();
+    expect(folded.steps[0].reason).toBe("record is unsigned");
+    expect(folded.steps[1].reason).toMatch(/timestampMs/);
+    expect(folded.steps[2].reason).toBe("record signature does not verify");
+  });
+
+  it("judges a refund at the refund record's timestamp", () => {
+    const { offer, accept } = deal(NOW + 7_800_000);
+    const lockFrame = {
+      type: "lock" as const,
+      from: payer.did,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-43",
+    };
+    const refund = { type: "refund" as const, from: payer.did, contract: accept.contract };
+    const folded = foldTranscript([
+      record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+      record(BOARD, 2, NOW, payee, encodeFrame(accept)),
+      record(DEAL, 1, NOW + 1, payer, encodeFrame(lockFrame)),
+      record(DEAL, 2, offer.refundAfterMs, payer, encodeFrame(refund)),
+    ]);
+
+    expect(folded.state?.status).toBe("refunded");
+    expect(folded.steps.map((step) => step.ok)).toEqual([true, true, true, true]);
+  });
+
+  it("parses exports strictly and preserves the signed bytes", () => {
+    const { offer } = deal();
+    const line = encodeFrame(offer);
+    const signed = record(BOARD, 7, NOW, payer, line);
+    const raw = JSON.stringify({
+      seq: signed.seq,
+      ts: new Date(signed.timestampMs).toISOString(),
+      from: signed.sender,
+      nonce: signed.nonce,
+      sig: signed.signature,
+      text: signed.line,
+    });
+
+    expect(parseTranscriptExport(BOARD, `${raw}\n`)).toEqual([signed]);
+    expect(() => parseTranscriptExport(BOARD, `${raw}\nnot json\n`)).toThrow(/line 2/);
+  });
+});


### PR DESCRIPTION
## Summary

- add one TranscriptRecord carrying room, seq, venue timestamp, sender, nonce, signature, and the exact stored line
- authenticate every record and require frame.from to match its signed sender before state can advance
- enforce `tclk-offers` for offer/accept and the contract-derived deal room after acceptance
- fold each frame at its own venue timestamp, with no Date.now fallback or positional metadata arrays
- preserve board append order when selecting an authenticated offer/accept handshake
- make tclk_read_room return records directly and add full: true for strict /export history
- use the same parser, handshake selector, and fold in the live example and offline export auditor
- preserve #24's independent fix by rejecting odd-length pre-signature scalar encodings

## Trust boundary

The Ed25519 signature covers room, nonce, and exact line. Sequence and timestamp are venue metadata, not sender-signed fields; live replay trusts the venue for them and offline replay trusts the export file. The fold also checks that each signed room is the one the protocol mandates. This is stated in SPEC.md and the API docs.

## Migration

tclk_apply_transcript now accepts records only. The alpha lines + nowMs input is removed because it cannot enforce SPEC section 2 attribution and cannot safely align optional sender/timestamp arrays. tclk_read_room no longer drops undecodable or unsigned records; each receives a fold verdict.

## Review follow-up

- A validly signed post-accept frame in an unrelated room is rejected before `applyFrame`; the regression proves state remains `accepted`.
- `findContractHandshake` scans authenticated board records in supplied append order. An accept with no preceding authenticated offer rejects instead of being synthetically reordered. Both auditors use this shared path.

## Consolidation

Supersedes #20, #24, #25, and #30 with one abstraction instead of four partially overlapping paths.

Closes #11.
Closes #23.

## Verification

- pnpm install --frozen-lockfile
- pnpm -r --include-workspace-root build
- pnpm -r --include-workspace-root test
- 78 core tests, 34 MCP tests, 31 Worker tests passing
