### PR TITLE
fix(machine): refuse lock once refund window is open (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `applyFrame` now rejects `lock` frames when the refund window is already open
+  (`nowMs >= refundAfterMs`), matching the settlement rail's own refusing-to-lock
+  invariant and preventing contracts from transitioning to a phantom `locked` state
+  where payee claim is impossible and parties cannot cancel.
+
 - Adaptor scalar parsing now rejects zero and out-of-range values instead of reducing them
   modulo the curve order, matching point-lock witness validation and preventing distinct
   byte strings from being treated as the same scalar (#27).

--- a/src/machine.ts
+++ b/src/machine.ts
@@ -136,6 +136,7 @@ export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number
       if (state.status !== "accepted") return reject(state, `lock in status ${state.status}`);
       if (frame.contract !== state.contract) return reject(state, "lock names a different contract");
       if (frame.from !== state.payerDid) return reject(state, "only the payer locks");
+      if (nowMs >= state.offer.refundAfterMs) return reject(state, "refund window is already open");
       if (!state.offer.rails.includes(frame.rail)) {
         return reject(state, `rail ${frame.rail} was not offered`);
       }

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -303,9 +303,18 @@ describe("tclk state machine", () => {
     ).toBe(false);
 
     const contract = state.contract!;
-    // Only the payer locks; only an offered rail counts.
+    // Only the payer locks; only an offered rail counts; refund window must not be open.
     expect(applyFrame(state, { type: "lock", from: PAYEE_DID, contract, rail: "flop-htlc", ref: "r" }, T0).ok).toBe(false);
     expect(applyFrame(state, { type: "lock", from: PAYER_DID, contract, rail: "evm-htlc", ref: "r" }, T0).ok).toBe(false);
+    const lateLock = applyFrame(
+      state,
+      { type: "lock", from: PAYER_DID, contract, rail: "x402", ref: "r" },
+      REFUND_AFTER,
+    );
+    expect(lateLock.ok).toBe(false);
+    expect(lateLock.reason).toMatch(/refund window is already open/);
+    expect(lateLock.state.status).toBe("accepted");
+    expect(lateLock.state).toBe(state);
 
     const locked = applyFrame(state, { type: "lock", from: PAYER_DID, contract, rail: "x402", ref: "r" }, T0).state;
     // Only the payee reveals, only with the right secret, only before the refund window.


### PR DESCRIPTION
Fixes #43

### Motivation

In `src/machine.ts`, `case "lock"` currently advances a contract to `"locked"` without checking `nowMs`. If a payer submits a `lock` frame at or after `refundAfterMs`:
1. Both settlement rails (`MemoryRail` in `src/rail.ts:86` and `PaperRail` in `src/paper-rail.ts:114`) explicitly reject the lock (`"tclk: refusing to lock into an already-open refund window"`).
2. In the transcript, the payee cannot claim via `reveal` (`nowMs >= refundAfterMs` rejects reveal).
3. Neither party can `cancel` because status transitioned to `"locked"`.
4. The contract is trapped in a phantom locked state until the payer sends a refund for funds never held on the rail.

### Changes

1. In `src/machine.ts`: reject `lock` frames with `"refund window is already open"` when `nowMs >= state.offer.refundAfterMs`. Contract state remains `accepted`.
2. In `tests/tclk.test.ts`: add unit test verifying that `lock` at `REFUND_AFTER` fails closed, preserves the `accepted` state, and keeps the state intact.
3. In `CHANGELOG.md`: document the fix under `[Unreleased]`.
