### PR TITLE
fix(examples): bound each attempt at the venue, and report a hang as the venue's silence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `examples/live-deal.mjs` bounds each attempt at the venue to 25 s. `fetch` inherited
+  undici's 300 s `headersTimeout`, so an attempt the venue accepted and never answered held the
+  run for five minutes and then surfaced as a thrown error rather than a response — through
+  `reportAndExit`'s catch-all, printed as "a bug in this script or the library" with a stack,
+  during a venue incident. A hung attempt is now a `VenueSilent`, reported as the venue's
+  silence, and it says the one thing that matters: the write may still have landed, so read
+  the venue back before repeating it. The bound lives in `examples/attempt.mjs` with unit
+  cover in `tests/attempt.test.ts` ([#2]).
+
 - Transcript folds now reject otherwise-valid frames outside their protocol-mandated room,
   and the offline/live auditors select offer/accept pairs without reversing the board's
   append order.
@@ -125,3 +134,5 @@ module is unaudited reference cryptography. Published as
   restated, so the two deployments cannot drift.
 - Both packages ship `NOTICE` alongside `LICENSE`, as Apache-2.0 §4(d) requires — npm
   includes the licence automatically but not the notice it points at.
+
+[#2]: https://github.com/flop-labs/tclk/issues/2

--- a/examples/attempt.mjs
+++ b/examples/attempt.mjs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// One bounded attempt at the venue. `fetch` here inherits undici's `headersTimeout`, which is
+// 300 s: an attempt the venue accepts and never answers holds the run for five minutes, and
+// then rejects with `UND_ERR_HEADERS_TIMEOUT` — a thrown error, not a response, so it never
+// reaches a `res.status` check. It surfaces through the module-level `await` into
+// `reportAndExit`'s catch-all branch and prints as "a bug in this script or the library",
+// with a stack, during a venue incident in which the library did nothing wrong.
+//
+// Measured on issue #2: a hung attempt rejected after 301.1 s. Successful KV round-trips just
+// before onset ran 1.6–19.4 s, so the bound sits above that; below ~20 s slow successes start
+// turning into timeouts.
+//
+// Pure apart from the timer, and the fetch is passed in, so a test can hang one.
+
+/** Per-attempt bound. Above the slowest observed success, far below the 300 s default. */
+export const ATTEMPT_MS = 25_000;
+
+/**
+ * The venue took the request and did not answer within the bound. Distinct from VenueError
+ * on purpose: a refusal carries the venue's verdict; this carries none, and the write it
+ * was making may still have landed — which is the thing a caller must know before retrying.
+ */
+export class VenueSilent extends Error {
+  constructor(what, ms) {
+    super(
+      `${what}: no response within ${ms / 1000}s. The request may still have been ` +
+        "committed — read the venue back before repeating a write.",
+    );
+    this.name = "VenueSilent";
+    this.what = what;
+    this.ms = ms;
+  }
+}
+
+/**
+ * Run one attempt under `ms`. A timeout becomes VenueSilent; every other failure — a refused
+ * connection, a user abort, a bug — is rethrown untouched, because only the timeout is the
+ * venue's silence and only the timeout carries the "may have landed" ambiguity.
+ *
+ * The bound is enforced HERE, by racing a timer, not delegated to the fetch. A real fetch
+ * honours `signal` and tears the socket down, which is why it is still passed; but a bound
+ * that only holds when the callee cooperates is not a bound, and the test's hung fetch is
+ * exactly a callee that does not.
+ */
+export async function attempt(fetchImpl, url, init, ms, what) {
+  let timer;
+  const expired = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new VenueSilent(what, ms)), ms);
+  });
+  try {
+    return await Promise.race([fetchImpl(url, { ...init, signal: AbortSignal.timeout(ms) }), expired]);
+  } catch (error) {
+    if (error instanceof VenueSilent) throw error;
+    if (error && error.name === "TimeoutError") throw new VenueSilent(what, ms);
+    throw error;
+  } finally {
+    clearTimeout(timer); // a fast answer must not keep the process alive for the full bound
+  }
+}

--- a/examples/live-deal.mjs
+++ b/examples/live-deal.mjs
@@ -29,6 +29,7 @@ import {
   parseTranscriptExport, stateNote, stateNoteValue, transcriptRecord,
 } from "../dist/index.js";
 import { canonicalMessage, nextNonce, signerFromSeed, sweep } from "../mcp/dist/signing.js";
+import { ATTEMPT_MS, VenueSilent, attempt } from "./attempt.mjs";
 
 const DEFAULT_VENUE = "https://technocore.chat";
 const BASE = process.env.TECHNOCORE_URL ?? DEFAULT_VENUE;
@@ -62,6 +63,12 @@ async function refusal(what, res) {
 // purpose: a rejected top-level await surfaces as an uncaught exception (module evaluation
 // failed), not as an unhandled rejection, so listening for only the latter catches nothing.
 function reportAndExit(error) {
+  if (error instanceof VenueSilent) {
+    // Not a refusal and not a bug: the venue took the request and never answered. Say
+    // that, and say the one thing that matters about it — the write may still have landed.
+    console.error(`\nThe venue did not answer. ${error.message}`);
+    process.exit(1);
+  }
   if (!(error instanceof VenueError)) {
     console.error(error);
     process.exit(1);
@@ -98,10 +105,12 @@ process.on("unhandledRejection", reportAndExit);
  * spends about nine of it.
  */
 async function req(url, init, what) {
-  for (let attempt = 0; ; attempt += 1) {
-    const res = await fetch(url, init);
+  for (let tries = 0; ; tries += 1) {
+    // Bounded: an attempt the venue accepts and never answers ends in ATTEMPT_MS as a
+    // VenueSilent, not in undici's 300 s default as a stack trace — see attempt.mjs.
+    const res = await attempt(fetch, url, init, ATTEMPT_MS, what);
     if (res.status !== 429) return res;
-    if (attempt >= 3) throw new Error(`${what}: still rate limited after ${attempt} waits`);
+    if (tries >= 3) throw new Error(`${what}: still rate limited after ${tries} waits`);
     const stated = Number(res.headers.get("retry-after"));
     const waitMs = (Number.isFinite(stated) && stated > 0 ? stated : 5) * 1000;
     log("", `rate limited — waiting ${waitMs / 1000}s, as the venue asked`);

--- a/tests/attempt.test.ts
+++ b/tests/attempt.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// A hung attempt at the venue is bounded, and is reported as the venue's silence rather than
+// as a bug in this repository. Regression cover for the 301 s hang measured on #2.
+
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error - examples/ is plain ESM and carries no declarations; tsc builds only src/.
+import { ATTEMPT_MS, VenueSilent, attempt } from "../examples/attempt.mjs";
+
+const hang = () => new Promise<never>(() => {});
+const answer = async () => ({ status: 200 });
+
+describe("attempt", () => {
+  it("bounds an attempt the venue never answers, and names it the venue's silence", async () => {
+    const started = Date.now();
+    await expect(attempt(hang, "u", undefined, 50, "post to r")).rejects.toBeInstanceOf(
+      VenueSilent,
+    );
+    // The bound, not undici's 300 s default, is what ended it.
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  it("says the one thing a caller must know: the write may still have landed", async () => {
+    const error = await attempt(hang, "u", undefined, 20, "kv set x").catch((e) => e);
+    expect(error.name).toBe("VenueSilent");
+    expect(error.message).toContain("kv set x");
+    expect(error.message).toContain("may still have been committed");
+  });
+
+  it("passes an answered attempt through untouched", async () => {
+    await expect(attempt(answer, "u", undefined, 50, "read")).resolves.toEqual({ status: 200 });
+  });
+
+  it("rethrows anything that is not the timeout, including a caller's own abort", async () => {
+    const refused = async () => {
+      throw Object.assign(new Error("ECONNREFUSED"), { name: "FetchError" });
+    };
+    await expect(attempt(refused, "u", undefined, 50, "read")).rejects.toThrow("ECONNREFUSED");
+    const userAbort = async () => {
+      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+    };
+    const e = await attempt(userAbort, "u", undefined, 50, "read").catch((x) => x);
+    expect(e).not.toBeInstanceOf(VenueSilent);
+  });
+
+  it("keeps the bound above the slowest success measured before onset", () => {
+    // 1.6–19.4 s on #2; below ~20 s slow successes convert into timeouts.
+    expect(ATTEMPT_MS).toBeGreaterThan(20_000);
+    expect(ATTEMPT_MS).toBeLessThan(300_000);
+  });
+});


### PR DESCRIPTION
Refs #2. Composes with #10 rather than competing with it — see below.

## The bug

`fetch` in `examples/live-deal.mjs` inherits undici's `headersTimeout` of **300 s**. An attempt the venue accepts and never answers holds the run for five minutes, then rejects with `UND_ERR_HEADERS_TIMEOUT` — a *thrown error*, not a response, so it never reaches any `res.status` check. It surfaces through the module-level `await` into `reportAndExit`'s catch-all branch and prints as *"a bug in this script or the library"*, with a stack, during a venue incident in which the library did nothing wrong.

@kenmori measured exactly this on #2: a hung attempt rejected after **301.1 s**; @Elfet confirmed the attribution path against `81a8346` in the same thread. *(Corrected — an earlier version of this body credited the 301.1 s figure to Elfet; it is kenmori's.)*

Two things wrong, in order of harm: the misattribution, then the wall clock. A newcomer reading the example's own output during an outage is told the repository is broken.

## The fix

Each attempt runs under a **25 s** bound. A timeout becomes a `VenueSilent`, a class kept distinct from `VenueError` on purpose: a refusal carries the venue's verdict; this carries none, and the write it was making **may still have landed**. `reportAndExit` prints it as *"The venue did not answer"* with that one fact, because it is the thing a caller must know before repeating a write.

```
The venue did not answer. post to r/tclk-offers: no response within 25s. The request may
still have been committed — read the venue back before repeating a write.
```

Every other failure — a refused connection, a caller's own abort, a bug — is rethrown untouched. Only the timeout is the venue's silence.

**Why 25 s:** Elfet's datum — successful KV round-trips ran 1.6–19.4 s just before onset, so below ~20 s slow successes start converting into timeouts. Above that, far below 300.

**The bound is enforced in `attempt()` by racing a timer, not delegated to the fetch.** A real fetch honours `signal` and tears the socket down, which is why it is still passed — but a bound that only holds when the callee cooperates is not a bound. The test's hung fetch is exactly a callee that does not, and that is what made this measurable.

## Relationship to #10

No retry is added here. A bounded attempt is what makes #10's backoff schedule mean anything — without it the schedule is bounded below by 300 s per attempt, not 1 s — and a `VenueSilent` is precisely the "did it land?" case #10's reconciliation exists for. When #10 lands, its `req()` can treat `VenueSilent` as the reconcile-then-retry path; until then, the run stops in 25 s with the right sentence instead of 5 minutes with the wrong one. I said on #10 I would file this separately so as not to race it on the same function; this is that.

## Tests

The script self-executes under top-level `await`, so the bound is a pure function in `examples/attempt.mjs` with the fetch passed in. `tests/attempt.test.ts` hangs a fake:

- the two hang cases reject **in under 2 s** as `VenueSilent`, naming the operation and the "may still have been committed" fact
- an answered attempt passes through untouched
- a refused connection and a caller's own `AbortError` are rethrown, not misclassified as silence
- the bound sits above the slowest measured success and below the default

With the race removed and a 1.5 s test timeout: **2 failed — `Test timed out in 1500ms`**. With it: **5 passed**.

## CI, run locally in the documented order

```
pnpm install --frozen-lockfile
pnpm -r --include-workspace-root build     clean
pnpm -r --include-workspace-root test      83 + 34 + 31 passed
scripts/no-agent-trailers.sh               pass
```

`SPEC.md` unchanged — example transport, not protocol. `CHANGELOG.md` has an `[Unreleased] / Fixed` entry. No version bump, no unrelated refactor.

Reporter: `did:key:z6MkmDkcrgAGa2DZ9qxfmMjNpwaKBXkDt3owfUPKyUxRQAtx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
