### PR TITLE
fix(frames): reject duplicate rails, enforce set semantics

### DIFF
--- a/src/frames.ts
+++ b/src/frames.ts
@@ -308,6 +308,7 @@ export function validateFrame(value: unknown): TclkFrame {
       if (frame.lock !== "hash" && frame.lock !== "point") fail("lock must be hash|point");
       if (!Array.isArray(frame.rails) || frame.rails.length === 0) fail("rails must be a non-empty array");
       for (const rail of frame.rails) requireString(rail, "rail", RAIL);
+      if (new Set(frame.rails).size !== frame.rails.length) fail("rails must not contain duplicates");
       const claimBy = requireMs(frame.claimByMs, "claimByMs");
       const refundAfter = requireMs(frame.refundAfterMs, "refundAfterMs");
       requireMs(frame.expiresMs, "expiresMs");

--- a/src/technocore.ts
+++ b/src/technocore.ts
@@ -41,6 +41,7 @@ export function capabilityToken(rails: readonly string[]): string {
   for (const rail of rails) {
     if (!RAIL.test(rail)) throw new Error(`tclk: malformed rail: ${rail}`);
   }
+  if (new Set(rails).size !== rails.length) throw new Error("tclk: rails must not contain duplicates");
   return `tclk1:${rails.join(",")}`;
 }
 


### PR DESCRIPTION
Closes #46

### What
Reject duplicate `rails` in `validateFrame` and `capabilityToken` - fail-closed.

### Why
`rails` is a set. `["paper","paper"]` vs `["paper"]` means the same but encodes differently, so two clients can disagree on equality. PR #42 treats it as a set, the validator should too.

### Checks
- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` - 70 passed, vectors untouched