### PR TITLE
fix: reject contradictory receipt rail/ref and zero adaptor witness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `applyFrame` now rejects `receipt` frames whose `rail` or `ref` contradicts the contract's
+  locked settlement terms, or that assert a settlement rail on a `cancelled` contract where
+  no lock was ever established.
+- `extractWitness` in the Schnorr adaptor module now returns `null` if the scalar difference
+  is zero, matching scalar range validation and preventing emission of an invalid zero witness.
 - `applyFrame` now rejects `lock` frames when the refund window is already open
   (`nowMs >= refundAfterMs`), matching the settlement rail's refusing-to-lock invariant
   and preventing a phantom `locked` state from which the payee can no longer claim (#43).

--- a/src/adaptor.ts
+++ b/src/adaptor.ts
@@ -128,7 +128,9 @@ export function adapt(pre: PreSignature, witness: string): Signature | null {
  */
 export function extractWitness(pre: PreSignature, sig: Signature): string | null {
   try {
-    return scalarHex(toScalar(sig.s) - toScalar(pre.s));
+    const diff = mod(toScalar(sig.s) - toScalar(pre.s));
+    if (diff === 0n) return null;
+    return scalarHex(diff);
   } catch {
     return null;
   }

--- a/src/machine.ts
+++ b/src/machine.ts
@@ -213,6 +213,15 @@ export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number
       if (frame.outcome !== state.status) {
         return reject(state, `receipt outcome ${frame.outcome} does not match ${state.status}`);
       }
+      if (frame.rail !== undefined && state.rail !== undefined && frame.rail !== state.rail) {
+        return reject(state, `receipt rail ${frame.rail} does not match contract rail ${state.rail}`);
+      }
+      if (frame.ref !== undefined && state.railRef !== undefined && frame.ref !== state.railRef) {
+        return reject(state, "receipt ref does not match contract railRef");
+      }
+      if (state.status === "cancelled" && (frame.rail !== undefined || frame.ref !== undefined)) {
+        return reject(state, "receipt on cancelled contract cannot name a settlement rail");
+      }
       return { ok: true, state };
     }
 

--- a/tests/adaptor.test.ts
+++ b/tests/adaptor.test.ts
@@ -93,8 +93,9 @@ describe("Schnorr adaptor signature", () => {
     const pre = preSign(SK, MSG, T)!;
     expect(adapt(pre, "0x" + "00".repeat(32))).toBeNull(); // zero witness
     expect(adapt({ nonce: "0xbad", s: pre.s }, t)).toBeNull();
-    // extractWitness: malformed scalars.
+    // extractWitness: malformed scalars and zero witness.
     expect(extractWitness({ nonce: pre.nonce, s: "0xzz" }, { nonce: pre.nonce, s: pre.s })).toBeNull();
+    expect(extractWitness(pre, { nonce: pre.nonce, s: pre.s })).toBeNull();
   });
 });
 

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -252,6 +252,26 @@ describe("tclk state machine", () => {
     expect(receipt.ok).toBe(true);
     expect(receipt.state.status).toBe("claimed");
 
+    const validReceiptWithRail = applyFrame(claimed.state, {
+      type: "receipt", from: PAYER_DID, contract: state.contract!, outcome: "claimed",
+      rail: "flop-htlc", ref: "escrow-42",
+    }, T0 + 3);
+    expect(validReceiptWithRail.ok).toBe(true);
+
+    const wrongRail = applyFrame(claimed.state, {
+      type: "receipt", from: PAYER_DID, contract: state.contract!, outcome: "claimed",
+      rail: "x402",
+    }, T0 + 3);
+    expect(wrongRail.ok).toBe(false);
+    expect(wrongRail.reason).toMatch(/receipt rail x402 does not match contract rail flop-htlc/);
+
+    const wrongRef = applyFrame(claimed.state, {
+      type: "receipt", from: PAYER_DID, contract: state.contract!, outcome: "claimed",
+      ref: "different-ref",
+    }, T0 + 3);
+    expect(wrongRef.ok).toBe(false);
+    expect(wrongRef.reason).toMatch(/receipt ref does not match contract railRef/);
+
     const contradictoryReceipt = applyFrame(claimed.state, {
       type: "receipt", from: PAYER_DID, contract: state.contract!, outcome: "refunded",
     }, T0 + 3);


### PR DESCRIPTION
### Summary

This PR addresses two fail-closed invariant gaps across the state machine and adaptor cryptography modules:

1. **Receipt rail/ref consistency (`src/machine.ts`):**
   - In PR #7, validation was added ensuring `frame.outcome === state.status`. However, `ReceiptFrame` also includes optional `rail` and `ref` fields.
   - Previously, a receipt naming a completely different `rail` or `ref` than what was locked and recorded in `state.rail` and `state.railRef` was accepted without objection. Similarly, a receipt on a `cancelled` contract (where no lock ever existed) was permitted to assert a settlement rail.
   - `applyFrame` now rejects receipts whose `rail` or `ref` contradicts the contract's locked state, as well as receipts naming a rail on a `cancelled` deal.

2. **Zero witness rejection in Schnorr adaptor (`src/adaptor.ts`):**
   - PR #27 enforced that scalars cannot be zero (`v === 0n || v >= N`).
   - In `extractWitness(pre, sig)`, if an identical pre-signature was passed as the signature (`sig.s === pre.s`), `toScalar(sig.s) - toScalar(pre.s)` evaluated to `0n`, which `scalarHex` formatted as a 32-byte zero hex string rather than failing closed.
   - `extractWitness` now checks `diff === 0n` and returns `null`, preventing the emission of an invalid zero witness.

### Verification

- Unit tests added to `tests/tclk.test.ts` covering matching receipts, mismatched rails, and mismatched refs.
- Unit test added to `tests/adaptor.test.ts` verifying that identical pre-signature / signature pairs return `null`.
- All 78 root tests, 34 MCP tests, and 31 worker tests pass cleanly.
