### PR TITLE
fix(mcp): isolate a malformed envelope in a window read instead of failing it whole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `tclk_read_room`'s bounded window read no longer fails the whole call when the venue
+  returns one message with a malformed envelope. A room is world-writable, so a single
+  hostile line — a `nonce` that is not decimal text, a non-string `from` — used to throw
+  out of the `messages.map`, denying every reader the rest of the room. Each message is
+  now normalized on its own: one that will not normalize is set aside in a new `malformed`
+  array with its seq and reason, exactly as a fold reports a bad line, so no record is
+  silently lost and `lastSeq` stays correct for paging. The `full` export path already
+  fails closed on the whole file by design and is unchanged.
 - `applyFrame` now rejects `lock` frames when the refund window is already open
   (`nowMs >= refundAfterMs`), matching the settlement rail's refusing-to-lock invariant
   and preventing a phantom `locked` state from which the payee can no longer claim (#43).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,12 @@ All notable changes to this project are documented here. Format follows
   out of the `messages.map`, denying every reader the rest of the room. Each message is
   now normalized on its own: one that will not normalize is set aside in a new `malformed`
   array with its seq and reason, exactly as a fold reports a bad line, so no record is
-  silently lost and `lastSeq` stays correct for paging. The `full` export path already
-  fails closed on the whole file by design and is unchanged.
+  silently lost and `lastSeq` stays correct for paging. The `full` export path keeps the
+  opposite rule and is unchanged: an export claims to be the complete history, where a
+  partial answer is indistinguishable from a whole one, so `parseTranscriptExport` refuses
+  the file rather than hand back a transcript with a hole in it. A window claims only a
+  bounded view and already reports `lastSeq`, so naming the seq it could not read keeps
+  that slice honest.
 - `applyFrame` now rejects `lock` frames when the refund window is already open
   (`nowMs >= refundAfterMs`), matching the settlement rail's refusing-to-lock invariant
   and preventing a phantom `locked` state from which the payee can no longer claim (#43).

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -344,7 +344,9 @@ export function createServer(options: HandlerOptions = {}): McpServer {
       description:
         "Read a room as complete transcript records ready for tclk_apply_transcript. " +
         "Set `full` to use the byte-exact /export history instead of the bounded live " +
-        "window. Records preserve line, sender, signature, nonce, sequence and venue time.",
+        "window. Records preserve line, sender, signature, nonce, sequence and venue time. " +
+        "A window read whose venue returns a malformed envelope sets that message aside " +
+        "in `malformed` (with its seq and reason) rather than failing the whole read.",
       annotations: NETWORK_READS,
       inputSchema: {
         room,

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -426,11 +426,30 @@ export function createHandlers(options: HandlerOptions = {}) {
       }
 
       const view = await client.readRoom(input.room, input.since);
-      const records = view.messages.map((message) => transcriptRecord(input.room, message));
+      // Normalize each message on its own. A room is world-writable, so one message with a
+      // malformed envelope (a `nonce` that is not decimal text, a non-string `from`) must
+      // not throw the whole read: that would let a single hostile line deny every reader
+      // the rest of the room. A record that will not normalize becomes a `malformed` entry
+      // carrying its seq and the reason, exactly as a fold reports a bad line, so the seq
+      // stays visible and auditable instead of vanishing.
+      const records: TranscriptRecord[] = [];
+      const malformed: { seq: number | null; reason: string }[] = [];
+      for (const message of view.messages) {
+        try {
+          records.push(transcriptRecord(input.room, message));
+        } catch (error) {
+          const seq =
+            message !== null && typeof message === "object" && Number.isSafeInteger((message as { seq?: unknown }).seq)
+              ? ((message as { seq: number }).seq)
+              : null;
+          malformed.push({ seq, reason: errorMessage(error).replace(/^tclk: /, "") });
+        }
+      }
       return {
         room: input.room,
         source: "window" as const,
         records,
+        malformed,
         count: records.length,
         lastSeq: view.last_seq,
       };

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -432,6 +432,15 @@ export function createHandlers(options: HandlerOptions = {}) {
       // the rest of the room. A record that will not normalize becomes a `malformed` entry
       // carrying its seq and the reason, exactly as a fold reports a bad line, so the seq
       // stays visible and auditable instead of vanishing.
+      //
+      // The `full` export above deliberately keeps the opposite rule, and the difference is
+      // what the two things claim rather than which is stricter. An export claims to be the
+      // complete history: a partial one is indistinguishable from a whole one, so a reader
+      // who audits from it would conclude something about a deal from a transcript with a
+      // hole in it, and `parseTranscriptExport` refuses the file instead. A window claims
+      // only a bounded view and already reports `lastSeq`, so a caller knows it is holding
+      // a slice; naming the seq it could not read leaves that slice honest. Handing back
+      // silently fewer records than the venue served is the one thing neither may do.
       const records: TranscriptRecord[] = [];
       const malformed: { seq: number | null; reason: string }[] = [];
       for (const message of view.messages) {

--- a/mcp/tests/transport.test.ts
+++ b/mcp/tests/transport.test.ts
@@ -149,6 +149,64 @@ describe("tclk_read_room", () => {
     );
   });
 
+  it("isolates a malformed envelope instead of failing the whole window read", async () => {
+    const line = offerLine();
+    const nonce = 11;
+    const good = signer.sign(canonicalMessage("lobby", nonce, line));
+    const { fetchLike } = fakeFetch([
+      {
+        body: "",
+        json: {
+          room: "lobby",
+          count: 4,
+          last_seq: 33,
+          messages: [
+            { seq: 30, ts: "2026-01-01T00:00:00Z", from: "~stranger", text: "gm" },
+            // Hostile envelope: `nonce` is a JSON boolean, which transcriptRecord refuses.
+            // Before the fix this one message threw and took the entire read down with it.
+            { seq: 31, ts: "2026-01-01T00:00:01Z", from: "~attacker", nonce: true, text: "tclk1 x" },
+            { seq: 32, ts: "2026-01-01T00:00:02Z", from: signer.did, nonce: String(nonce), sig: good, text: line },
+            // A second bad shape: `from` is not a string.
+            { seq: 33, ts: "2026-01-01T00:00:03Z", from: 12345, text: "gm" },
+          ],
+        },
+      },
+    ]);
+    const h = createHandlers({ env: {}, fetch: fetchLike });
+
+    const result = await h.tclk_read_room({ room: "lobby" });
+    // The two well-formed envelopes survive; the two hostile ones are set aside, not dropped.
+    expect(result.records).toHaveLength(2);
+    expect(result.records.map((r) => r.seq)).toEqual([30, 32]);
+    expect(result.malformed).toHaveLength(2);
+    expect(result.malformed.map((m) => m.seq)).toEqual([31, 33]);
+    expect(result.malformed[0].reason).toMatch(/nonce/);
+    // lastSeq still reflects the venue's own count, so `since` paging is unbroken.
+    expect(result.lastSeq).toBe(33);
+
+    // The surviving signed record is intact: it carries the sender and signature the
+    // venue verified, ready to hand to a fold.
+    expect(result.records[1]).toMatchObject({ seq: 32, sender: signer.did, signature: good });
+  });
+
+  it("records a malformed envelope with no usable seq as null", async () => {
+    const { fetchLike } = fakeFetch([
+      {
+        body: "",
+        json: {
+          room: "lobby",
+          count: 1,
+          last_seq: 40,
+          messages: [{ seq: "not-a-number", ts: "2026-01-01T00:00:00Z", from: "~x", text: "gm" }],
+        },
+      },
+    ]);
+    const h = createHandlers({ env: {}, fetch: fetchLike });
+    const result = await h.tclk_read_room({ room: "lobby" });
+    expect(result.records).toHaveLength(0);
+    expect(result.malformed).toEqual([{ seq: null, reason: expect.stringMatching(/seq/) }]);
+  });
+
   it("reads and strictly parses the full JSONL export", async () => {
     const line = offerLine();
     const nonce = 17;

--- a/mcp/tests/transport.test.ts
+++ b/mcp/tests/transport.test.ts
@@ -189,6 +189,17 @@ describe("tclk_read_room", () => {
     expect(result.records[1]).toMatchObject({ seq: 32, sender: signer.did, signature: good });
   });
 
+  it("keeps the export's opposite rule: one bad row refuses the whole file", async () => {
+    // Pins the asymmetry rather than leaving it to a comment. An export claims to be the
+    // complete history, so it may not answer with a hole; a window may, because it says
+    // which seq it could not read. If either side is ever changed, this fails.
+    const good = JSON.stringify({ seq: 1, ts: "2026-01-01T00:00:00Z", from: "~a", text: "gm" });
+    const bad = JSON.stringify({ seq: 2, ts: "2026-01-01T00:00:01Z", from: "~b", nonce: true, text: "gm" });
+    const { fetchLike } = fakeFetch([{ body: `${good}\n${bad}\n` }]);
+    const h = createHandlers({ env: {}, fetch: fetchLike });
+    await expect(h.tclk_read_room({ room: "lobby", full: true })).rejects.toThrow(/line 2/);
+  });
+
   it("records a malformed envelope with no usable seq as null", async () => {
     const { fetchLike } = fakeFetch([
       {

--- a/mcp/worker/src/tool-manifest.generated.ts
+++ b/mcp/worker/src/tool-manifest.generated.ts
@@ -750,7 +750,7 @@ export const TOOLS: readonly ManifestTool[] = [
   },
   {
     "name": "tclk_read_room",
-    "description": "Read a room as complete transcript records ready for tclk_apply_transcript. Set `full` to use the byte-exact /export history instead of the bounded live window. Records preserve line, sender, signature, nonce, sequence and venue time.",
+    "description": "Read a room as complete transcript records ready for tclk_apply_transcript. Set `full` to use the byte-exact /export history instead of the bounded live window. Records preserve line, sender, signature, nonce, sequence and venue time. A window read whose venue returns a malformed envelope sets that message aside in `malformed` (with its seq and reason) rather than failing the whole read.",
     "inputSchema": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## What

A window read (`tclk_read_room` without `full`) that hits one message with a
malformed envelope no longer throws the entire call. Each message is normalized on
its own; one that won't normalize is set aside in a new `malformed` array with its
seq and reason. Well-formed records and `lastSeq` are returned as before.

## Why

A room is world-writable. Since #40, the window path runs every venue message
through `transcriptRecord` inside one `messages.map`, with no per-record isolation.
`transcriptRecord` throws on a bad envelope field — a `nonce` that is not decimal
text, a non-string `from` — and that throw escapes the whole read. So a single line
anyone can post denies every reader the rest of the room: a denial-of-audit on a
public board, and the offer board is exactly where strangers meet.

This is a regression. Before #40 the read skipped an undecodable line and counted
it; #40 replaced that with a fold-grade normalizer but did not carry over the
per-record isolation a fold has. This restores it on the read side: a bad record
becomes a reported entry, never a lost one, so the evidence that someone posted
garbage stays visible.

The `full` export path fails closed on the whole file by design (existing tests
cover that) and is left alone. No optional flag — the isolation is unconditional.

Hostile counterparty gets nothing new: a bad line it posts now costs it a
`malformed` entry instead of taking the room down.
