### PR TITLE
fix(commitments): accept uppercase hex, as the rest of the library does

### DIFF
--- a/src/commitments.ts
+++ b/src/commitments.ts
@@ -17,11 +17,21 @@ import { TCLK_DOMAIN } from "./frames.js";
 import { hexToU8a, randomU8a, stringToU8a, u8aToHex } from "./hex.js";
 import { SECP256K1_N } from "./points.js";
 
-const HEX32 = /^0x[0-9a-f]{64}$/;
+const HEX32 = /^0x[0-9a-fA-F]{64}$/;
+
+/** Validate 32 bytes of 0x-hex and return it lowercased.
+ *
+ * `isHex` accepts either case and `verifyPointWitness` compares case-insensitively, so a
+ * peer's uppercase hex is the same value, not a malformed one. Normalising here keeps the
+ * digest stable whichever case arrives.
+ */
+function requireHex32(value: string, name: string): string {
+  if (!HEX32.test(value)) throw new Error(`tclk: ${name} must be 32 bytes of 0x-hex`);
+  return value.toLowerCase();
+}
 
 function requireSecret(value: string, name: string): Uint8Array {
-  if (!HEX32.test(value)) throw new Error(`tclk: ${name} must be 32 bytes of 0x-hex`);
-  return hexToU8a(value);
+  return hexToU8a(requireHex32(value, name));
 }
 
 /** A fresh 32-byte salt. A commitment without one is a dictionary lookup, not a secret. */
@@ -44,9 +54,10 @@ export function voteCommitment(contract: string, verdict: string, salt: string):
   if (!HEX32.test(contract)) throw new Error("tclk: contract must be a 0x-hex contract id");
   if (verdict.length === 0) throw new Error("tclk: verdict must not be empty");
   if (verdict.includes("|")) throw new Error("tclk: verdict must not contain '|'");
-  requireSecret(salt, "salt");
+  const contractId = contract.toLowerCase();
+  const saltHex = requireHex32(salt, "salt");
   return u8aToHex(
-    sha256(stringToU8a(`${TCLK_DOMAIN}|commit|${contract}|${verdict}|${salt}`)),
+    sha256(stringToU8a(`${TCLK_DOMAIN}|commit|${contractId}|${verdict}|${saltHex}`)),
   );
 }
 
@@ -109,8 +120,7 @@ export function combineSecret(shares: readonly string[]): string {
 }
 
 function scalar(value: string, name: string): bigint {
-  requireSecret(value, name);
-  const v = BigInt(value);
+  const v = BigInt(requireHex32(value, name));
   if (v <= 0n || v >= SECP256K1_N) throw new Error(`tclk: ${name} is not a scalar in [1, n)`);
   return v;
 }

--- a/tests/commitments.test.ts
+++ b/tests/commitments.test.ts
@@ -125,3 +125,33 @@ describe("unanimous panels — splitting the secret", () => {
     }
   });
 });
+
+describe("hex case", () => {
+  const upper = (hex: string) => "0x" + hex.slice(2).toUpperCase();
+
+  it("a reveal whose salt arrives uppercase still verifies", () => {
+    // `isHex` accepts either case and `verifyPointWitness` compares case-insensitively, so
+    // a peer emitting uppercase hex has sent the same salt, not a malformed one. Treating
+    // it as a mismatch discards a juror's vote.
+    const salt = generateSalt();
+    const commitment = voteCommitment(CONTRACT, "yes", salt);
+    expect(verifyVoteCommitment(commitment, CONTRACT, "yes", upper(salt))).toBe(true);
+  });
+
+  it("an uppercase contract id commits to the same value", () => {
+    const salt = generateSalt();
+    expect(voteCommitment(upper(CONTRACT), "yes", salt)).toBe(
+      voteCommitment(CONTRACT, "yes", salt),
+    );
+  });
+
+  it("an uppercase preimage splits and recombines", () => {
+    const { preimage } = generateHashLock();
+    expect(combineSecret(splitSecret(upper(preimage), 3))).toBe(preimage);
+  });
+
+  it("an uppercase witness splits and recombines", () => {
+    const { witness } = generatePointLock();
+    expect(combineWitness(splitWitness(upper(witness), 3))).toBe(witness);
+  });
+});


### PR DESCRIPTION
## What

`commitments.ts` gates every 32-byte value on a lowercase-only regex:

```ts
const HEX32 = /^0x[0-9a-f]{64}$/;
```

Nothing else in the library is case-sensitive:

| | case |
|---|---|
| `hex.ts` `isHex` | `[\da-fA-F]` — either |
| `hex.ts` `hexToU8a` | decodes either |
| `points.ts` `verifyPointWitness` | `toLowerCase()` on both sides |
| `commitments.ts` `verifyVoteCommitment` | lowercases the **commitment** only |
| `commitments.ts` `HEX32` | lowercase only |

`verifyVoteCommitment` already normalises the commitment it is handed. It does not normalise the salt or the contract id, and those go into the digest as raw strings.

## What it costs

A peer whose implementation emits uppercase hex is not malformed, it has sent the same value. Today:

```
lowercase salt: true
uppercase salt: false        ← same salt
```

and

```
splitSecret(uppercase preimage)
  → "tclk: preimage must be 32 bytes of 0x-hex"
```

which is exactly what it is.

The doc on `verifyVoteCommitment` promises the opposite:

> Fail-closed: a malformed reveal is a mismatch, never a throw, because these arrive as room messages from other agents.

In a commit–reveal vote that is a juror's verdict discarded, and per `SPEC.md` §8.2 a discarded verdict is not a neutral outcome — the panel is unanimous-or-refund.

## Change

Accept either case and normalise to lowercase before hashing, so the digest is stable whichever arrives. `requireHex32` does the validate-and-lowercase, `requireSecret` builds on it, and `voteCommitment` lowercases the contract id and salt before they reach the hash input.

Nothing existing changes: values this library produces come out of `u8aToHex`, which already emits lowercase, so every commitment computed today is byte-identical after this.

## Tests

Four cases added to `tests/commitments.test.ts`. All four fail against `main`:

```
× a reveal whose salt arrives uppercase still verifies
× an uppercase contract id commits to the same value
× an uppercase preimage splits and recombines
× an uppercase witness splits and recombines
```

With the change `vitest run` is 96/97 and `tsc -p tsconfig.json --noEmit` is clean.

The one remaining failure is `tests/schema-conformance.test.ts` — "generated protocol fields are stale; run pnpm generate:protocol". It fails the same way on an untouched `main` here, so it is not from this change, but it may be worth a look on your side.