### PR TITLE
fix(mcp): preserve exact string nonces in tclk_post_frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
+  numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
+  without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema
+  boundary rather than silently rounded.
+
 ### Added
 
 - A schema-owned tclk/1 frame field contract, canonical settlement-rail registry and

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -332,7 +332,13 @@ export function createServer(options: HandlerOptions = {}): McpServer {
         line,
         did: did.optional(),
         sig: z.string().optional().describe("86 unpadded base64url characters."),
-        nonce: z.number().int().optional(),
+        nonce: z
+          .union([
+            z.number().int().safe().nonnegative(),
+            z.string().regex(/^[0-9]{1,19}$/, "1 to 19 decimal digits"),
+          ])
+          .optional()
+          .describe("Signed-lane nonce; safe integer or 1-19 decimal digit string."),
       },
     },
     (args) => run(() => h.tclk_post_frame(args)),

--- a/mcp/src/signing.ts
+++ b/mcp/src/signing.ts
@@ -43,7 +43,7 @@ export function sweep(text: string): string {
 }
 
 /** The string an Ed25519 room-message signature covers, UTF-8. */
-export function canonicalMessage(room: string, nonce: number, sweptText: string): string {
+export function canonicalMessage(room: string, nonce: number | string, sweptText: string): string {
   return `${room}|${nonce}|${sweptText}`;
 }
 

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -377,6 +377,14 @@ export function createHandlers(options: HandlerOptions = {}) {
         fail("pass all three of `did`, `sig` and `nonce`, or none of them");
       }
 
+      if (input.nonce !== undefined) {
+        const isSafe = typeof input.nonce === "number" && Number.isSafeInteger(input.nonce) && input.nonce >= 0;
+        const isDecimal = typeof input.nonce === "string" && /^[0-9]{1,19}$/.test(input.nonce);
+        if (!isSafe && !isDecimal) {
+          fail("`nonce` must be a non-negative safe integer or a 1-19 decimal digit string");
+        }
+      }
+
       if (supplied === 3) {
         const response = await client.postSigned(input.room, {
           did: input.did!,

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -113,7 +113,7 @@ export interface PostFrameInput {
   line: string;
   did?: string;
   sig?: string;
-  nonce?: number;
+  nonce?: number | string;
 }
 
 // ── Handlers ─────────────────────────────────────────────────────────────────

--- a/mcp/tests/server.test.ts
+++ b/mcp/tests/server.test.ts
@@ -65,4 +65,50 @@ describe("createServer", () => {
 
     await client.close();
   });
+
+  it("validates tclk_post_frame nonce: accepts safe int or 1-19 digit string, rejects unsafe numbers and malformed strings", async () => {
+    const client = await connect();
+
+    // 1. Safe integer is accepted (schema validation passes; error comes from frame validation)
+    const safeInt = await client.callTool({
+      name: "tclk_post_frame",
+      arguments: { room: "lobby", line: "gm", did: "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX", sig: "x".repeat(86), nonce: 7 },
+    });
+    expect(safeInt.isError).toBe(true);
+    expect((safeInt.content as { text: string }[])[0].text).toMatch(/not a tclk\/1 line/);
+
+    // 2. Unsafe number > MAX_SAFE_INTEGER is rejected at schema level
+    const unsafeNum = await client.callTool({
+      name: "tclk_post_frame",
+      arguments: { room: "lobby", line: "gm", did: "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX", sig: "x".repeat(86), nonce: 9007199254740992 },
+    });
+    expect(unsafeNum.isError).toBe(true);
+    expect((unsafeNum.content as { text: string }[])[0].text).toMatch(/Number must be less than or equal to 9007199254740991/);
+
+    // 3. Malformed string (non-decimal) is rejected
+    const badStr = await client.callTool({
+      name: "tclk_post_frame",
+      arguments: { room: "lobby", line: "gm", did: "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX", sig: "x".repeat(86), nonce: "123bad" },
+    });
+    expect(badStr.isError).toBe(true);
+    expect((badStr.content as { text: string }[])[0].text).toMatch(/Invalid arguments/);
+
+    // 4. String exceeding 19 digits is rejected
+    const tooLongStr = await client.callTool({
+      name: "tclk_post_frame",
+      arguments: { room: "lobby", line: "gm", did: "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX", sig: "x".repeat(86), nonce: "12345678901234567890" },
+    });
+    expect(tooLongStr.isError).toBe(true);
+    expect((tooLongStr.content as { text: string }[])[0].text).toMatch(/Invalid arguments/);
+
+    // 5. Valid 19-digit string passes schema validation (fails later on frame decoding)
+    const validStr = await client.callTool({
+      name: "tclk_post_frame",
+      arguments: { room: "lobby", line: "gm", did: "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX", sig: "x".repeat(86), nonce: "1730000000000000001" },
+    });
+    expect(validStr.isError).toBe(true);
+    expect((validStr.content as { text: string }[])[0].text).toMatch(/not a tclk\/1 line/);
+
+    await client.close();
+  });
 });

--- a/mcp/tests/signing.test.ts
+++ b/mcp/tests/signing.test.ts
@@ -89,6 +89,10 @@ describe("canonical string and signature", () => {
     const canonical = canonicalMessage("lobby", 1730000000000, "tclk1 {}");
     expect(canonical).toBe("lobby|1730000000000|tclk1 {}");
 
+    const nonce19 = "1730000000000000001";
+    const canonical19 = canonicalMessage("lobby", nonce19, "tclk1 {}");
+    expect(canonical19).toBe("lobby|1730000000000000001|tclk1 {}");
+
     const sig = signer.sign(canonical);
     // 86 characters, unpadded, and canonical: sixteen strings decode to the same 64
     // bytes, so the final character must be the one the encoder produces.

--- a/mcp/tests/transport.test.ts
+++ b/mcp/tests/transport.test.ts
@@ -115,6 +115,28 @@ describe("tclk_post_frame — tier 2, server-signed", () => {
     expect(body.nonce).not.toBe(String(Number(nonce19)));
   });
 
+  it("rejects an unsafe numeric nonce or malformed string in the shared handler", async () => {
+    const { fetchLike } = fakeFetch([{ body: "ok 14" }]);
+    const h = createHandlers({ env: {}, fetch: fetchLike });
+    const line = offerLine();
+
+    await expect(h.tclk_post_frame({
+      room: ROOM,
+      line,
+      did: signer.did,
+      sig: "x".repeat(86),
+      nonce: 9007199254740992,
+    })).rejects.toThrow(/must be a non-negative safe integer or a 1-19 decimal digit string/);
+
+    await expect(h.tclk_post_frame({
+      room: ROOM,
+      line,
+      did: signer.did,
+      sig: "x".repeat(86),
+      nonce: "123bad",
+    })).rejects.toThrow(/must be a non-negative safe integer or a 1-19 decimal digit string/);
+  });
+
   it("surfaces the venue's refusal instead of swallowing it", async () => {
     const { fetchLike } = fakeFetch([{ status: 403, body: "403 bad sig\n" }]);
     const h = createHandlers({ env: { TECHNOCORE_SIGNING_KEY: PAYER_SEED }, fetch: fetchLike });

--- a/mcp/tests/transport.test.ts
+++ b/mcp/tests/transport.test.ts
@@ -91,6 +91,30 @@ describe("tclk_post_frame — tier 2, server-signed", () => {
     expect(JSON.parse(String(calls[0].init?.body))).toMatchObject({ did: signer.did, nonce: "7", text: line });
   });
 
+  it("passes a caller's legal 19-digit string nonce straight through without precision loss", async () => {
+    const { calls, fetchLike } = fakeFetch([{ body: "ok 14" }]);
+    const h = createHandlers({ env: {}, fetch: fetchLike });
+    const line = offerLine();
+    const nonce19 = "1730000000000000001";
+
+    const result = await h.tclk_post_frame({
+      room: ROOM,
+      line,
+      did: signer.did,
+      sig: signer.sign(canonicalMessage(ROOM, nonce19, line)),
+      nonce: nonce19,
+    });
+    expect(result.posted && result.tier).toBe("caller-signed");
+    if (result.posted && result.tier === "caller-signed") {
+      expect(result.nonce).toBe(nonce19);
+    }
+    const body = JSON.parse(String(calls[0].init?.body));
+    expect(body.nonce).toBe(nonce19);
+    // Prove no numeric precision loss occurred
+    expect(String(Number(nonce19))).not.toBe(nonce19);
+    expect(body.nonce).not.toBe(String(Number(nonce19)));
+  });
+
   it("surfaces the venue's refusal instead of swallowing it", async () => {
     const { fetchLike } = fakeFetch([{ status: 403, body: "403 bad sig\n" }]);
     const h = createHandlers({ env: { TECHNOCORE_SIGNING_KEY: PAYER_SEED }, fetch: fetchLike });

--- a/mcp/worker/src/tool-manifest.generated.ts
+++ b/mcp/worker/src/tool-manifest.generated.ts
@@ -730,7 +730,18 @@ export const TOOLS: readonly ManifestTool[] = [
           "description": "86 unpadded base64url characters."
         },
         "nonce": {
-          "type": "integer"
+          "anyOf": [
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            {
+              "type": "string",
+              "pattern": "^[0-9]{1,19}$"
+            }
+          ],
+          "description": "Signed-lane nonce; safe integer or 1-19 decimal digit string."
         }
       },
       "required": [

--- a/mcp/worker/src/worker.ts
+++ b/mcp/worker/src/worker.ts
@@ -240,6 +240,40 @@ function typeMatches(expected: string, actual: string): boolean {
  * reimplementation of the stdio server's zod schemas and does not try to be one; the
  * schemas it checks against ARE those schemas, compiled to JSON Schema.
  */
+function checkProperty(key: string, property: Record<string, unknown>, value: unknown): string | null {
+  if (Array.isArray(property.anyOf)) {
+    const matches = property.anyOf.some(
+      (branch) => isPlainObject(branch) && checkProperty(key, branch, value) === null,
+    );
+    if (!matches) {
+      return `argument \`${key}\` does not match allowed schema`;
+    }
+    return null;
+  }
+
+  const actual = jsonTypeOf(value);
+  if (typeof property.type === "string" && !typeMatches(property.type, actual)) {
+    return `argument \`${key}\` must be a ${property.type}, got ${actual}`;
+  }
+  if (Array.isArray(property.enum) && !property.enum.includes(value as never)) {
+    return `argument \`${key}\` must be one of ${JSON.stringify(property.enum)}`;
+  }
+  if (typeof value === "number") {
+    if (typeof property.minimum === "number" && value < property.minimum) {
+      return `argument \`${key}\` must be >= ${property.minimum}, got ${value}`;
+    }
+    if (typeof property.maximum === "number" && value > property.maximum) {
+      return `argument \`${key}\` must be <= ${property.maximum}, got ${value}`;
+    }
+  }
+  if (typeof value === "string" && typeof property.pattern === "string") {
+    if (!new RegExp(property.pattern).test(value)) {
+      return `argument \`${key}\` must match pattern /${property.pattern}/`;
+    }
+  }
+  return null;
+}
+
 function checkArguments(tool: ManifestTool, args: Record<string, unknown>): string | null {
   const schema = tool.inputSchema;
   const required = Array.isArray(schema.required) ? (schema.required as string[]) : [];
@@ -251,13 +285,8 @@ function checkArguments(tool: ManifestTool, args: Record<string, unknown>): stri
     if (value === undefined) continue;
     const property = properties[key];
     if (!isPlainObject(property)) continue;
-    const actual = jsonTypeOf(value);
-    if (typeof property.type === "string" && !typeMatches(property.type, actual)) {
-      return `argument \`${key}\` must be a ${property.type}, got ${actual}`;
-    }
-    if (Array.isArray(property.enum) && !property.enum.includes(value as never)) {
-      return `argument \`${key}\` must be one of ${JSON.stringify(property.enum)}`;
-    }
+    const reason = checkProperty(key, property, value);
+    if (reason !== null) return reason;
   }
   return null;
 }

--- a/mcp/worker/tests/worker.test.ts
+++ b/mcp/worker/tests/worker.test.ts
@@ -248,6 +248,22 @@ describe("no custody", () => {
     expect(calls[0].url).toBe(`https://technocore.chat/r/${ROOM}`);
   });
 
+  it("tclk_post_frame passes a caller's 19-digit string nonce through to the wire", async () => {
+    const { calls, fetchLike } = fakeFetch([{ body: "ok 14" }]);
+    const line = (await callTool("tclk_make_offer", HASH_OFFER)).value.line;
+    const nonce19 = "1730000000000000001";
+
+    const posted = await callTool(
+      "tclk_post_frame",
+      { room: ROOM, line, did: PAYER_DID, sig: "x".repeat(86), nonce: nonce19 },
+      fetchLike,
+    );
+    expect(posted.value.posted).toBe(true);
+    expect(posted.value.tier).toBe("caller-signed");
+    expect(posted.value.nonce).toBe(nonce19);
+    expect(JSON.parse(String(calls[0].init?.body)).nonce).toBe(nonce19);
+  });
+
   it("tclk_adaptor_presign refuses structurally, naming where pre-signing belongs", async () => {
     const refused = await callTool("tclk_adaptor_presign", {
       msg: `0x${"11".repeat(32)}`,

--- a/mcp/worker/tests/worker.test.ts
+++ b/mcp/worker/tests/worker.test.ts
@@ -264,6 +264,41 @@ describe("no custody", () => {
     expect(JSON.parse(String(calls[0].init?.body)).nonce).toBe(nonce19);
   });
 
+  it("tclk_post_frame rejects unsafe numeric nonces and malformed strings at Worker boundary before network", async () => {
+    const { calls, fetchLike } = fakeFetch([{ body: "ok 14" }]);
+    const line = (await callTool("tclk_make_offer", HASH_OFFER)).value.line;
+
+    // Unsafe number > MAX_SAFE_INTEGER must return RPC error -32602 and never call network
+    const unsafeRes = await rpc(
+      "tools/call",
+      { name: "tclk_post_frame", arguments: { room: ROOM, line, did: PAYER_DID, sig: "x".repeat(86), nonce: 9007199254740992 } },
+      fetchLike,
+    );
+    expect(unsafeRes.body.error).toBeDefined();
+    expect(unsafeRes.body.error.code).toBe(-32602);
+    expect(calls).toHaveLength(0);
+
+    // Malformed string must return RPC error -32602 and never call network
+    const malformedRes = await rpc(
+      "tools/call",
+      { name: "tclk_post_frame", arguments: { room: ROOM, line, did: PAYER_DID, sig: "x".repeat(86), nonce: "123bad" } },
+      fetchLike,
+    );
+    expect(malformedRes.body.error).toBeDefined();
+    expect(malformedRes.body.error.code).toBe(-32602);
+    expect(calls).toHaveLength(0);
+
+    // >19 digit string must return RPC error -32602 and never call network
+    const tooLongRes = await rpc(
+      "tools/call",
+      { name: "tclk_post_frame", arguments: { room: ROOM, line, did: PAYER_DID, sig: "x".repeat(86), nonce: "12345678901234567890" } },
+      fetchLike,
+    );
+    expect(tooLongRes.body.error).toBeDefined();
+    expect(tooLongRes.body.error.code).toBe(-32602);
+    expect(calls).toHaveLength(0);
+  });
+
   it("tclk_adaptor_presign refuses structurally, naming where pre-signing belongs", async () => {
     const refused = await callTool("tclk_adaptor_presign", {
       msg: `0x${"11".repeat(32)}`,


### PR DESCRIPTION
## Outcome

Allows callers of the MCP tool `tclk_post_frame` to supply nonces as exact 1–19 ASCII decimal-digit strings in addition to safe integer numbers, preventing silent truncation/rounding for Technocore nonces above JavaScript's safe-integer ceiling (`2^53 - 1`).

Unsafe numeric literals (> 9007199254740991) are explicitly rejected by schema validation rather than silently rounded by JavaScript float conversion.

## Context & Motivation

Technocore's signed lane (`POST /r/<room>`) and per-signer, per-room monotonic nonce rule accept decimal nonces under Technocore's current 1–19 digit nonce grammar (`[0-9]{1,19}`).

The underlying transport interface (`SignedPost` in `mcp/src/technocore.ts`) was already typed as `nonce: number | string` with the comment:
> *"Sent as a string: a stored nonce may exceed 2^53 and must stay exact."*

However, the public MCP surface (`mcp/src/server.ts`) previously registered:
`nonce: z.number().int().optional()`
and `PostFrameInput` typed `nonce?: number`.

As a consequence:
1. An exact legal 19-digit nonce passed as a string (e.g., `"1730000000000000001"`) was rejected by the MCP server with `-32602 Expected number, received string`.
2. A numeric literal above `Number.MAX_SAFE_INTEGER` passed over JSON (e.g., `1730000000000000001`) was coerced to an IEEE 754 float64 (`1730000000000000000`), breaking Ed25519 signature verification on Technocore.

## Changes

- **Schema**: `mcp/src/server.ts` now accepts `z.union([z.number().int().safe().nonnegative(), z.string().regex(/^[0-9]{1,19}$/, "1 to 19 decimal digits")]).optional()`.
- **Types**: `PostFrameInput.nonce` and `canonicalMessage`'s `nonce` parameter accept `number | string`.
- **Worker & Validation**:
  - `checkProperty` in `mcp/worker/src/worker.ts` now evaluates `anyOf`, `minimum`/`maximum`, and `pattern` constraints from the tool manifest, returning `-32602` before reaching the network.
  - `tclk_post_frame` handler enforces the non-negative safe integer or 1–19 decimal digit string invariant for defense-in-depth across all transports.
- **Worker Manifest**: Rebuilt `mcp/worker/src/tool-manifest.generated.ts` to reflect the updated schema.
- **Changelog**: Added entry under `[Unreleased]` -> `### Fixed`.
- **Tests**: Added regression tests across `server.test.ts`, `transport.test.ts`, `signing.test.ts`, and `worker.test.ts` proving:
  - Safe integers (e.g. `7`) continue to work identically.
  - Valid 19-digit string nonces are accepted and sent to Technocore byte-exact.
  - Numbers > 2^53 - 1 and malformed strings are rejected with `-32602` at schema validation without reaching the network.
  - No precision round-tripping occurs.

## Hostile counterparty impact

Nothing. The server simply preserves the caller's own signed nonce without truncation when relaying to Technocore. Technocore continues to enforce strict per-signer, per-room nonce monotonicity and signature verification.

## Verification

```bash
pnpm install --frozen-lockfile
pnpm -r --include-workspace-root build
pnpm -r --include-workspace-root test
pnpm -C mcp build:worker
git diff --check
```

All 163 tests pass (Root: 93, MCP: 37, Worker: 33). Worker dry-run builds cleanly.
