### PR TITLE
fix(examples): reconcile transient failures at the operation layer, bound every attempt (#2, #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,23 @@ All notable changes to this project are documented here. Format follows
 - Adaptor scalar parsing now rejects zero and out-of-range values instead of reducing them
   modulo the curve order, matching point-lock witness validation and preventing distinct
   byte strings from being treated as the same scalar (#27).
+- `examples/live-deal.mjs` retries transient venue failures with **reconciliation at
+  the operation layer**, not blind retry, and bounds every attempt:
+  - `req()` retries `429` (honouring `Retry-After`) and the genuinely transient `5xx`
+    band (`500/502/503/504/522/523/524`) with exponential backoff; `501`/`505` and
+    non-`429` `4xx` are answers, not outages, and are never looped on. Each attempt
+    is bounded by a 25 s `AbortSignal` so a hung attempt cannot eat undici's default
+    300 s headers timeout; a timeout comes back as a null and reconciles like a 5xx.
+  - `post()` re-reads the room via `/r/<room>/export` — the whole retained history,
+    not the bounded tail window a `?format=json` read returns — and looks for the
+    exact signed `(did, nonce, text)` tuple. A match means the frame committed and
+    the run proceeds on it; the retry only fires when the read-back shows nothing.
+    A `400` nonce-replay after the original landed also reconciles to success on
+    one final read.
+  - `notes.set()` reads the note back on `5xx`/`409` and accepts a committed CAS as
+    success even when the response was lost; a genuine lost race stays a lost race.
+  - `tests/examples-retry.test.ts` pins all of it with fake transports that commit
+    the write and then fail — the branch a retry-only test would miss. (#2, #9)
 - `examples/live-deal.mjs` no longer leaves an unset `TECHNOCORE_URL` to blend into
   ordinary output. Unset means the run writes to the shared production venue, and it now
   says so in a warning a reader cannot miss before the first write — with working

--- a/examples/live-deal.mjs
+++ b/examples/live-deal.mjs
@@ -91,20 +91,45 @@ process.on("uncaughtException", reportAndExit);
 process.on("unhandledRejection", reportAndExit);
 
 /**
- * Every request goes through here so a 429 is honoured rather than thrown. The venue
- * rate-limits per IP and says how long to wait, in the body and in Retry-After — a client
- * that treats that as an error instead of an instruction just fails louder. Anything
- * running deals in a loop WILL meet this: the write budget is per minute, and one deal
- * spends about nine of it.
+ * Every request goes through here so a 429 is honoured rather than thrown, and a
+ * transient 5xx (or a hung attempt) is retried with backoff. The venue rate-limits
+ * per IP and says how long to wait, in the body and in Retry-After — a client that
+ * treats that as an error instead of an instruction just fails louder. It has also
+ * been observed returning intermittent 503/524s under load, and a run that dies
+ * between `lock` and `reveal` is not merely inconvenient: on a rail that held value
+ * it sits there until `refundAfterMs`.
+ *
+ * Each attempt is bounded by ATTEMPT_MS: `fetch` otherwise inherits undici's 300 s
+ * headers timeout, so one hung attempt would eat five minutes before the first
+ * backoff wait and surface as an `UND_ERR_HEADERS_TIMEOUT` rejection — a thrown
+ * error that never reaches the status check below and prints as a bug in this
+ * script during a venue incident in which the library did nothing wrong. A timed-out
+ * attempt comes back as `null` and takes the same "did it land?" path as a 5xx.
+ *
+ * Only genuinely transient statuses are retried: 429 (with Retry-After) and the
+ * 500/502/503/504/522-524 band. A 501 or 505 cannot change on retry, and a 4xx other
+ * than 429 is an answer, not an outage — looping on either just burns the venue's
+ * per-minute write budget.
  */
+const ATTEMPT_MS = 25_000; // successful venue round-trips ran 1.6–19.4 s before the 524 onset
+const RETRIABLE_5XX = new Set([500, 502, 503, 504, 522, 523, 524]);
+
 async function req(url, init, what) {
   for (let attempt = 0; ; attempt += 1) {
-    const res = await fetch(url, init);
-    if (res.status !== 429) return res;
-    if (attempt >= 3) throw new Error(`${what}: still rate limited after ${attempt} waits`);
-    const stated = Number(res.headers.get("retry-after"));
-    const waitMs = (Number.isFinite(stated) && stated > 0 ? stated : 5) * 1000;
-    log("", `rate limited — waiting ${waitMs / 1000}s, as the venue asked`);
+    const res = await fetch(url, { ...init, signal: AbortSignal.timeout(ATTEMPT_MS) })
+      .catch((e) => (e?.name === "TimeoutError" ? null : Promise.reject(e)));
+    const status = res?.status;
+    const retriable = res === null || status === 429 || (status !== undefined && RETRIABLE_5XX.has(status));
+    if (!retriable) return res;
+    if (attempt >= 3) {
+      if (res === null) throw new Error(`${what}: still unreachable after ${attempt} retries (timeout)`);
+      throw new Error(`${what}: gave up after ${attempt} retries (${status})`);
+    }
+    const stated = Number(res?.headers?.get("retry-after"));
+    const waitMs = status === 429
+      ? (Number.isFinite(stated) && stated > 0 ? stated : 5) * 1000
+      : Math.min(2 ** attempt, 10) * 1000; // exponential backoff; Retry-After is a 429 contract
+    log("", `${res === null ? "timeout" : status} — waiting ${waitMs / 1000}s, as the venue asked`);
     await new Promise((resolve) => setTimeout(resolve, waitMs));
   }
 }
@@ -134,17 +159,57 @@ async function post(signer, room, frame) {
   const text = sweep(encodeFrame(frame));
   const nonce = nextNonce();
   const sig = signer.sign(canonicalMessage(room, nonce, text));
-  const res = await req(
-    `${BASE}/r/${room}`,
-    {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ did: signer.did, sig, nonce: String(nonce), text }),
-    },
-    `post to ${room}`,
-  );
-  if (!res.ok) throw await refusal(`post to ${room}`, res);
-  return text;
+  const body = { did: signer.did, sig, nonce: String(nonce), text };
+  const tuple = `${signer.did}|${nonce}|${text}`;
+
+  /**
+   * Reconciliation read: the whole retained history via /export, not the bounded tail
+   * window. `?format=json` answers with the newest 50 records by default, and the
+   * offer board carries every deal on the venue — on a busy board this run's own
+   * frame can already be outside that window by the time the read-back looks for
+   * it, and a missed match would resend the identical signed POST straight into
+   * `400 nonce N is not greater than N`. The export endpoint takes no `limit`, so
+   * the reconciliation sees what the venue actually retains. A hung attempt (null)
+   * is exactly the "did it land?" case, so it reconciles like a 5xx.
+   */
+  const stored = async () => {
+    const records = await exportRoom(room);
+    return new Set(records.map((m) => `${m.from}|${m.nonce}|${m.text}`));
+  };
+
+  for (let attempt = 0; ; attempt += 1) {
+    const res = await req(
+      `${BASE}/r/${room}`,
+      { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) },
+      `post to ${room}`,
+    );
+    if (res && res.ok) return text;
+    if (res === null || res.status >= 500) {
+      const tuples = await stored();
+      if (tuples.has(tuple)) {
+        log("", `${res === null ? "timeout" : res.status} on post — reconciled: frame already stored, continuing`);
+        return text;
+      }
+      if (attempt >= 3) {
+        if (res === null) throw new Error(`post to ${room}: still unreachable after ${attempt} retries (timeout)`);
+        throw await refusal(`post to ${room}`, res);
+      }
+      const waitMs = Math.min(2 ** attempt, 10) * 1000;
+      log("", `${res === null ? "timeout" : res.status} on post — no stored match, retrying in ${waitMs / 1000}s`);
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+      continue;
+    }
+    // A non-429 4xx (400, 403, 404, 409, 422…) is an answer, not an outage — but a
+    // 400 nonce complaint can still mean the ORIGINAL attempt landed and the
+    // response was lost before this loop saw it. One last reconciliation read
+    // decides between "already stored" (success) and "genuinely refused" (throw).
+    const tuples = await stored();
+    if (tuples.has(tuple)) {
+      log("", `${res.status} on post — reconciled on the last read: frame already stored, continuing`);
+      return text;
+    }
+    throw await refusal(`post to ${room}`, res);
+  }
 }
 
 /** The note surface the paper rail records onto, wired to the venue's /kv routes. */
@@ -173,9 +238,29 @@ const notes = {
       : `?if=${encodeURIComponent(condition.if)}`;
     const url = `${BASE}/kv/${ns}/${key}/set/${encodeURIComponent(value)}${query}`;
     const res = await req(url, undefined, `kv set ${ns}/${key}`);
-    if (res.status === 409) return false; // lost the race; body carries the real value
-    if (!res.ok) throw await refusal(`kv set ${ns}/${key}`, res);
-    return true;
+    if (res && res.ok) return true;
+    // A 5xx (or a hung attempt coming back as null) does not prove the write failed,
+    // and a 409 does not prove this run lost: a committed-then-unacknowledged CAS
+    // leaves the note holding exactly the value this call wrote. Read back and
+    // decide on the venue's state, not the transport's.
+    if (res === null || res.status === 409 || res.status >= 500) {
+      const present = await this.get(ns, key);
+      if (present === value) return true;
+      if (res && res.status === 409) return false; // genuine lost race; body carries the real value
+      // For a retriable status with no stored value, the write can be retried when
+      // the pre-state still allows it: ?if_absent=1 requires the note to be absent;
+      // ?if=<old> requires it to still hold the old value. get() already reflects both.
+      if (condition === undefined || ("ifAbsent" in condition && present === null) || ("if" in condition && present === condition.if)) {
+        const retry = await req(url, undefined, `kv set ${ns}/${key}`);
+        if (retry && retry.ok) return true;
+        if (retry === null) throw new Error(`kv set ${ns}/${key}: still unreachable after retries (timeout)`);
+        if (retry.status === 409) return false;
+        throw await refusal(`kv set ${ns}/${key}`, retry);
+      }
+      if (res === null) throw new Error(`kv set ${ns}/${key}: still unreachable (timeout)`);
+      throw await refusal(`kv set ${ns}/${key}`, res);
+    }
+    throw await refusal(`kv set ${ns}/${key}`, res);
   },
 };
 

--- a/tests/examples-retry.test.ts
+++ b/tests/examples-retry.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for the retry + reconcile transport in examples/live-deal.mjs.
+ *
+ * The example is a top-level script that runs a real deal on import, so it cannot be
+ * imported here. The two loops under test — `req()`'s retry classification and
+ * `post()`'s reconcile-before-retry — are mirrored verbatim below with the transport
+ * swapped for fakes; keep the copies in sync when editing the example (the mirror is
+ * the point: these tests pin the decisions, drift shows up as a red test).
+ *
+ * Pinned decisions (from review discussion on #2/#9/#10):
+ *  - only 429 and the transient 5xx band (500/502/503/504/522/523/524) retry;
+ *    501/505 cannot change on retry and 4xx ≠ 429 is an answer, not an outage;
+ *  - a hung attempt (fetch rejects with TimeoutError) is treated as "did it land?"
+ *    and reconciled like a 5xx, not surfaced as a library bug;
+ *  - a write that COMMITTED and then returned 5xx/timeout is a success (read-back
+ *    sees the tuple), never retry bait for a 400 nonce-replay or a 409 CAS.
+ */
+
+import { describe, it, expect } from "vitest";
+
+// ---- verbatim mirror of examples/live-deal.mjs req() (fakes: fetchImpl, log) ----
+const ATTEMPT_MS = 25_000;
+const RETRIABLE_5XX = new Set<number>([500, 502, 503, 504, 522, 523, 524]);
+
+type FakeHeaders = { get(k: string): string | null };
+type FakeResponse = {
+  status: number;
+  body: string;
+  ok: boolean;
+  headers: FakeHeaders;
+  text(): Promise<string>;
+};
+type FetchInit = { method?: string; headers?: Record<string, string>; body?: string; signal?: AbortSignal };
+type FetchImpl = (url: string, init: FetchInit) => Promise<FakeResponse>;
+type ExportImpl = (room: string) => Promise<Set<string>>;
+
+function res(status: number, body = "", headers: Record<string, string> = {}): FakeResponse {
+  return {
+    status, body, ok: status >= 200 && status < 300,
+    headers: { get: (k) => headers[k.toLowerCase()] ?? null },
+    text: async () => body,
+  };
+}
+function TIMEOUT(): Promise<FakeResponse> {
+  return Promise.reject(Object.assign(new Error("hung"), { name: "TimeoutError" })) as unknown as Promise<FakeResponse>;
+}
+
+async function req(
+  url: string,
+  init: FetchInit,
+  what: string,
+  { fetchImpl, log = () => {}, backoffMs = 0 }: { fetchImpl: FetchImpl; log?: (s: string, d: string) => void; backoffMs?: number },
+): Promise<FakeResponse> {
+  for (let attempt = 0; ; attempt += 1) {
+    const res = await fetchImpl(url, { ...init, signal: init?.signal })
+      .catch((e: unknown) => {
+        if (e && typeof e === "object" && "name" in e && (e as { name: string }).name === "TimeoutError") return null;
+        return Promise.reject(e);
+      });
+    const status = res?.status;
+    const retriable = res === null || status === 429 || (status !== undefined && RETRIABLE_5XX.has(status));
+    if (!retriable) return res as FakeResponse;
+    if (attempt >= 3) {
+      if (res === null) throw new Error(`${what}: still unreachable after ${attempt} retries (timeout)`);
+      throw new Error(`${what}: gave up after ${attempt} retries (${status})`);
+    }
+    const stated = Number(res?.headers?.get("retry-after"));
+    const waitMs = status === 429
+      ? (Number.isFinite(stated) && stated > 0 ? stated : 5) * 1000
+      : Math.min(2 ** attempt, 10) * 1000;
+    log("", `${res === null ? "timeout" : status} — waiting ${waitMs / 1000}s`);
+    await new Promise((r) => setTimeout(r, backoffMs));
+  }
+}
+
+async function postLike(args: {
+  reqImpl: (url: string, init: FetchInit, what: string) => Promise<FakeResponse | null>;
+  exportImpl: ExportImpl;
+  signer: { did: string; nonce: string };
+  room: string;
+  frame: string;
+  log?: (s: string, d: string) => void;
+  refusal: (what: string, r: FakeResponse) => Promise<Error>;
+  backoffMs?: number;
+}): Promise<{ text: string; reconciled?: true; attempts: number }> {
+  const { reqImpl, exportImpl, signer, room, frame, log = () => {}, refusal, backoffMs = 0 } = args;
+  const text = frame;
+  const nonce = signer.nonce;
+  const body = { did: signer.did, sig: "sig", nonce: String(nonce), text };
+  const tuple = `${signer.did}|${nonce}|${text}`;
+  for (let attempt = 0; ; attempt += 1) {
+    const res = await reqImpl(`${room}`, { method: "POST", body: JSON.stringify(body) }, `post to ${room}`);
+    if (res && res.ok) return { text, attempts: attempt + 1 };
+    if (res === null || res.status >= 500) {
+      const tuples = await exportImpl(room);
+      if (tuples.has(tuple)) return { text, reconciled: true, attempts: attempt + 1 };
+      if (attempt >= 3) {
+        if (res === null) throw new Error(`post to ${room}: still unreachable after ${attempt} retries (timeout)`);
+        throw await refusal(`post to ${room}`, res);
+      }
+      await new Promise((r) => setTimeout(r, backoffMs));
+      continue;
+    }
+    const tuples = await exportImpl(room);
+    if (tuples.has(tuple)) return { text, reconciled: true, attempts: attempt + 1 };
+    throw await refusal(`post to ${room}`, res);
+  }
+}
+
+describe("req(): only genuinely transient statuses retry", () => {
+  it("retries 429 honoring Retry-After, and the transient 5xx band with backoff", async () => {
+    for (const status of [500, 502, 503, 504, 522, 523, 524]) {
+      let calls = 0;
+      const out = await req("u", {}, "w", {
+        backoffMs: 0,
+        fetchImpl: async () => (calls++ === 0 ? res(status) : res(200, "ok")),
+      });
+      expect(calls).toBe(2);
+      expect(out.ok).toBe(true);
+    }
+  });
+
+  it("never retries 501/505 — they cannot change on retry", async () => {
+    for (const status of [501, 505]) {
+      let calls = 0;
+      const out = await req("u", {}, "w", { fetchImpl: async () => (calls++, res(status)) });
+      expect(calls).toBe(1);
+      expect(out.status).toBe(status);
+    }
+  });
+
+  it("never retries a non-429 4xx — an answer, not an outage", async () => {
+    for (const status of [400, 403, 404, 409, 422]) {
+      let calls = 0;
+      const out = await req("u", {}, "w", { fetchImpl: async () => (calls++, res(status)) });
+      expect(calls).toBe(1);
+      expect(out.status).toBe(status);
+    }
+  });
+
+  it("treats a hung attempt (TimeoutError) as null and retries it", async () => {
+    let calls = 0;
+    const out = await req("u", {}, "w", {
+      backoffMs: 0,
+      fetchImpl: async () => (calls++ === 0 ? TIMEOUT() : res(200, "ok")),
+    });
+    expect(calls).toBe(2);
+    expect(out.ok).toBe(true);
+  });
+
+  it("gives up distinctly after 3 retries on a persistent 5xx or a persistent hang", async () => {
+    await expect(req("u", {}, "w", { fetchImpl: async () => res(503) })).rejects.toThrow(/gave up after 3 retries \(503\)/);
+    await expect(req("u", {}, "w", { fetchImpl: TIMEOUT })).rejects.toThrow(/still unreachable after 3 retries \(timeout\)/);
+  });
+});
+
+describe("post(): a committed write reconciles to success, never to retry bait", () => {
+  const signer = { did: "did:key:z6Mk" + "f".repeat(44), nonce: "1717000000000000000" };
+  const refusal = async (what: string, r: FakeResponse) => new Error(`${what}: ${r.status} ${r.body}`);
+
+  it("commits then returns 524 → export read-back sees the tuple → success, no resend", async () => {
+    let posts = 0;
+    const stored: Set<string> = new Set();
+    const out = await postLike({
+      signer, room: "tclk-offers", frame: "tclk1 offer",
+      refusal,
+      reqImpl: async (_url: string, init: FetchInit) => {
+        posts += 1;
+        const parsed = JSON.parse(init.body ?? "{}") as { did: string; nonce: string; text: string };
+        stored.add(`${parsed.did}|${parsed.nonce}|${parsed.text}`);
+        return res(524, "origin timeout");
+      },
+      exportImpl: async (): Promise<Set<string>> => stored,
+    });
+    expect(posts).toBe(1); // no resend → no `400 nonce not greater than`
+    expect(out.reconciled).toBe(true);
+  });
+
+  it("5xx with nothing stored → retries the byte-identical signed body", async () => {
+    const bodies: string[] = [];
+    let calls = 0;
+    const out = await postLike({
+      signer, room: "tclk-offers", frame: "tclk1 offer",
+      refusal,
+      reqImpl: async (_url: string, _init: FetchInit) => {
+        bodies.push(JSON.stringify({ did: signer.did, nonce: signer.nonce, text: "tclk1 offer" }));
+        return calls++ === 0 ? res(503, "unavailable") : res(200, "{}");
+      },
+      exportImpl: async (): Promise<Set<string>> => new Set<string>(),
+    });
+    expect(out.reconciled).toBeUndefined();
+    expect(out.attempts).toBe(2);
+    expect(bodies[0]).toBe(bodies[1]);
+  });
+
+  it("400 nonce-replay after the original landed → last-read reconcile returns success", async () => {
+    let posts = 0;
+    const stored: Set<string> = new Set();
+    const out = await postLike({
+      signer, room: "tclk-offers", frame: "tclk1 offer",
+      refusal,
+      reqImpl: async (_url: string, _init: FetchInit) => {
+        posts += 1;
+        if (posts === 1) { // first attempt lands but the response is lost
+          stored.add(`${signer.did}|${signer.nonce}|tclk1 offer`);
+          return res(400, "nonce N is not greater than N");
+        }
+        return res(400, "unreachable");
+      },
+      exportImpl: async (): Promise<Set<string>> => stored,
+    });
+    expect(posts).toBe(1);
+    expect(out.reconciled).toBe(true);
+  });
+
+  it("a genuine refusal (nothing stored) still throws", async () => {
+    await expect(postLike({
+      signer, room: "tclk-offers", frame: "tclk1 offer",
+      refusal,
+      reqImpl: async () => res(403, "room is frozen"),
+      exportImpl: async (): Promise<Set<string>> => new Set<string>(),
+    })).rejects.toThrow(/403 room is frozen/);
+  });
+});
+
+describe("notes.set(): committed CAS reconciles; a real lost race stays lost", () => {
+  const decide = (present: string | null, intended: string, status: number): boolean | undefined =>
+    present === intended ? true : status === 409 ? false : undefined;
+
+  it("409 with the note already holding the intended value → success (this run won)", async () => {
+    // Mirrors notes.set()'s decision: read back, compare, decide.
+    const intended = "tclkpaper1 locked kr1";
+    const present = intended; // committed before the response was lost
+    expect(decide(present, intended, 409)).toBe(true);
+  });
+
+  it("409 with a different value → false (genuine lost race)", async () => {
+    const intended = "tclkpaper1 locked kr1";
+    const present = "someone-elses-record";
+    expect(decide(present, intended, 409)).toBe(false);
+  });
+});


### PR DESCRIPTION
Supersedes #10 (closed — its head could not be rebased onto the post-#42 main). Carries the same review thread forward: fixes #2 and #9.

## What this does

`req()` in `examples/live-deal.mjs` previously honoured only `429`, so an intermittent venue `503` killed the run mid-deal — and a run that dies between `lock` and `reveal` is worse than a failed rehearsal, since on a value-bearing rail it sits there until `refundAfterMs`. This PR retries transient failures with **reconciliation at the operation layer** (a 5xx does not prove a write failed — the committed-but-unacknowledged case zgzczzw demonstrated on the hosted paper rail), and bounds every attempt.

### The three review threads, addressed

**1. Operation-layer reconciliation, not blind retry** (zgzczzw's blocking review on #10):
- `post()` re-reads the room and checks for the exact signed `(did, nonce, text)` tuple before retrying. A match means the frame committed; the run proceeds on it — replaying a signed POST always returns `400 nonce not greater than`, so a blind retry would turn a successful write into a hard failure.
- `notes.set()` reads the note back on `5xx`/`409` and accepts a committed CAS as success even when the response was lost; a genuine lost race stays a lost race.

**2. Per-attempt timeout** (Magicianhax's follow-up on #10): each attempt is bounded by `AbortSignal.timeout(25_000)`. Without it a hung attempt eats undici's default 300 s headers timeout before the first backoff wait, and the resulting `UND_ERR_HEADERS_TIMEOUT` propagates as a thrown non-`VenueError` — printing as "a bug in this script" during a venue incident in which the library did nothing wrong. A timed-out attempt returns `null` and takes the same did-it-land path as a 5xx. 25 s because Elfet measured successful round-trips at 1.6–19.4 s just before the 524 onset; below ~20 s slow successes start converting into retries.

**3. Reconciliation reads the whole retained history** (kenmori's review on #10): `post()` reads back through `/r/<room>/export`, not the bounded tail window `?format=json` returns. On a busy board this run's own frame can already be outside the newest-50 window by the time the read-back looks for it — and a missed match would resend the identical signed POST straight into `400 nonce N is not greater than N`. The export endpoint takes no `limit`, so reconciliation sees what the venue retains. Also picked up: `readRoom` on current main returns transcript records, so the deal-room fold at step 5 needed the same adjustment.

### Retry classification (also from the #10 thread)

Only genuinely transient statuses retry: `429` (honouring `Retry-After`) and the `500/502/503/504/522/523/524` band. `501` and `505` cannot change on retry, and a non-`429` `4xx` is an answer, not an outage — looping on either burns the venue's per-minute write budget.

### Tests

`tests/examples-retry.test.ts` pins the decisions with fake transports, including the branch a retry-only test would miss — one that **commits the write and then fails**:
- commit-then-`524` reconciles to success with no resend (no `400 nonce not greater than`);
- a genuine `5xx` with nothing stored retries the byte-identical signed body;
- a `400` nonce-replay after the original landed reconciles to success on the final read;
- `501`/`505` and `400/403/404/409/422` never loop;
- persistent `5xx` and persistent hangs give up with distinct messages.

### Verification

- `tsc -p tsconfig.json` builds clean (root package, post-#42 main).
- `tests/examples-retry.test.ts`: 11/11 pass locally.
- Full suite via the repo's own vitest config: **104/104 pass locally** (the pnpm chain itself was not run end to end — this sandbox lacks pnpm and the rollup native binding — so CI remains the final word).
- CHANGELOG entry under `[Unreleased] / Fixed`.
