### PR TITLE
docs: propose tclk/2 settlement model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project are documented here. Format follows
 - A non-normative tclk/2 design proposal that separates commercial agreements, concrete transfer
   attempts, and verified rail observations; scopes the first profile to direct conditional
   payments for flop-core; and records the cross-project and formal-literature basis for the wire
-  break. tclk/1 remains normative and byte-for-byte replayable.
+  break. A companion decision note records the tclk/1 hardening boundary, merge order, property
+  rationale, and issue/PR disposition. tclk/1 remains normative and byte-for-byte replayable.
 - A schema-owned tclk/1 frame field contract, canonical settlement-rail registry and
   intersection-based, order-independent rail matching helpers. Generated decoder fields
   and the normative `SPEC.md` table are checked for drift in CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- A non-normative tclk/2 design proposal that separates commercial agreements, concrete transfer
+  attempts, and verified rail observations; scopes the first profile to direct conditional
+  payments for flop-core; and records the cross-project and formal-literature basis for the wire
+  break. tclk/1 remains normative and byte-for-byte replayable.
 - A schema-owned tclk/1 frame field contract, canonical settlement-rail registry and
   intersection-based, order-independent rail matching helpers. Generated decoder fields
   and the normative `SPEC.md` table are checked for drift in CI.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ nothing and holds no keys — it is a place both agents can reach, an append-ord
 transcript, and a compare-and-set primitive, nothing more.
 
 Full normative tclk/1 spec: [`SPEC.md`](SPEC.md). The non-normative, research-backed proposal for
-the intentionally breaking tclk/2 design is [`TCLK2-PROPOSAL.md`](TCLK2-PROPOSAL.md). Worked
-two-agent example:
+the intentionally breaking tclk/2 design is [`TCLK2-PROPOSAL.md`](TCLK2-PROPOSAL.md); its
+tclk/1 hardening and merge rationale is
+[`TCLK1-TO-TCLK2-DECISION.md`](TCLK1-TO-TCLK2-DECISION.md). Worked two-agent example:
 [`examples/htlc-walkthrough.md`](examples/htlc-walkthrough.md).
 
 ## Frame flow

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ anything else that can hold funds under a hash or point statement). Technocore i
 nothing and holds no keys — it is a place both agents can reach, an append-ordered signed
 transcript, and a compare-and-set primitive, nothing more.
 
-Full normative spec: [`SPEC.md`](SPEC.md). Worked two-agent example:
+Full normative tclk/1 spec: [`SPEC.md`](SPEC.md). The non-normative, research-backed proposal for
+the intentionally breaking tclk/2 design is [`TCLK2-PROPOSAL.md`](TCLK2-PROPOSAL.md). Worked
+two-agent example:
 [`examples/htlc-walkthrough.md`](examples/htlc-walkthrough.md).
 
 ## Frame flow

--- a/TCLK1-TO-TCLK2-DECISION.md
+++ b/TCLK1-TO-TCLK2-DECISION.md
@@ -1,0 +1,386 @@
+# tclk/1 hardening and tclk/2 convergence
+
+Status: **decision note for team review**  
+Date: 2026-09-04  
+Companion design: [`TCLK2-PROPOSAL.md`](TCLK2-PROPOSAL.md)  
+Normative protocol today: [`SPEC.md`](SPEC.md)
+
+## Decision requested
+
+Approve the following direction before merging implementation work:
+
+1. Merge the non-normative tclk/2 proposal in
+   [PR #58](https://github.com/flop-labs/tclk/pull/58) as the design direction, not as a change to
+   the current wire protocol.
+2. Keep every historical `tclk1 ` frame decodable and byte-exact. Never edit the golden vectors
+   to accommodate a new interpretation.
+3. Continue merging tclk/1 changes that fail closed, preserve bytes, bind evidence more exactly,
+   bound resources, or repair examples without changing protocol meaning.
+4. Make one coherent, documented restriction to **new tclk/1 construction**: support the direct,
+   payer-proposed, hash-lock path as the production-shaped path; leave legacy forms replayable.
+   This is a builder/API policy, not a new tclk/1 wire profile.
+5. Do not partially backport tclk/2's agreement, transfer-attempt, observation, native-expiry, or
+   profile-digest objects into tclk/1. Implement them together behind the `tclk2 ` prefix.
+6. Do not merge a value-bearing rail into tclk/1. The first flop-core HTLC integration should
+   implement the reviewed tclk/2 direct-payment profile.
+
+The practical result is a smaller state model now, less tclk/1 code to discard, and an explicit
+compatibility promise: old traffic remains auditable, while new traffic stops relying on the
+parts of tclk/1 whose security meaning is underspecified.
+
+## Why make this decision now
+
+tclk has launched, but it has not yet crossed the expensive compatibility boundary: the repository
+ships `PaperRail`, which rehearses a lifecycle but holds no value. This is the best point at which
+to remove claims the implementation cannot justify before flop-core treats them as a contract.
+
+There are two different meanings of "breaking change" here:
+
+- Reinterpreting an already-signed `tclk1 ` line is a dangerous wire break. It changes the bytes or
+  security meaning of durable public evidence. We should not do it.
+- Refusing to construct a new ambiguous or unsafe tclk/1 deal is a deliberate API restriction.
+  Existing lines still decode and replay. At alpha, this is the cheaper and safer kind of break.
+
+The recommendation uses the second kind where necessary and reserves the first kind for an honest
+`tclk2 ` prefix and signature domain.
+
+## Background: the four layers that must not be conflated
+
+The current discussions become much simpler if four artifacts are kept separate.
+
+### 1. Historical wire evidence
+
+A `tclk1 ` frame is canonical, signed coordination evidence. Its exact encoded bytes determine its
+identifier and signature. The decoder must preserve the historical grammar closely enough to audit
+already-posted lines, even when a new builder would refuse to emit the same shape.
+
+### 2. New construction policy
+
+Builders decide which new agreements this release is willing to create. They can be stricter than
+the historical decoder: canonical rail identifiers only, registered adapters only, payer-authored
+offers only, and no production claim for the unaudited point-lock path.
+
+### 3. Coordination state
+
+The room transcript proves that a named signer made a statement in a named room. It can derive
+states such as `accepted`, "funding announced", or `witness-known`. It does not prove that an
+escrow exists or that money moved.
+
+### 4. Authoritative settlement state
+
+Only a rail-specific verifier can establish funded, claimed, or refunded value. tclk/2 makes this
+boundary explicit with verified `RailObservation` objects. Treating a signed room frame as money
+state would preserve a simple enum at the cost of giving that enum a false meaning.
+
+This separation is the central reason not to grow the tclk/1 state machine further.
+
+## What is structurally wrong with tclk/1 as a value contract
+
+The problem is not one missing guard. tclk/1 combines concepts that real settlement systems keep
+separate:
+
+1. **Condition authority depends on author order.** The acceptor always supplies the statement,
+   while the specification describes the payee as the party that owns and reveals the secret. A
+   payee-authored offer therefore makes the payer construct a condition it cannot later reveal
+   ([issue #12](https://github.com/flop-labs/tclk/issues/12)).
+2. **Assertions stand in for rail evidence.** A payer-signed `lock` changes transcript state to
+   `locked`; a room `reveal` or `refund` changes it to a monetary-sounding terminal state. These
+   statements may coordinate a rail action, but they are not proof that the rail performed it.
+3. **One identifier does two jobs.** `contract` identifies both commercial terms and the concrete
+   lock. That leaves no clean identity for a retry, replacement, partial payment, or second rail.
+4. **Three clocks share one unit without sharing one authority.** `expiresMs` is coordination time,
+   `claimByMs` is an operational safety margin, and `refundAfterMs` is intended to describe rail
+   enforcement. Real rails may use height, consensus time, ledger-close time, or a bilateral clock.
+5. **`point` is not a cryptographic suite.** It does not pin the signing construction, message,
+   domain, nonce rules, or production-compatible signature format. The frame does not carry the
+   message required by the stated pre-signature verifier
+   ([issue #36](https://github.com/flop-labs/tclk/issues/36)), and the repository's adaptor code is
+   explicitly unaudited reference cryptography.
+6. **The room topology is treated as protocol truth.** A derived room is useful transport policy,
+   but admitting multiple room streams without one authenticated total order makes replay
+   ambiguous. Falling back while skipping strict audit is worse: the example can report success
+   after its own evidence verifier refused the transcript.
+
+Fixing these one at a time inside the old object would produce a protocol that still says `tclk1`
+but no longer means what existing implementations signed. The tclk/2 separation is smaller than
+that accumulation of exceptions.
+
+## Properties that drive the decision
+
+These are ordered deliberately: safety invariants first, reachable flows second, and temporal
+expectations last. A model that reaches a happy path does not establish the invariants, and a legal
+refund transition does not establish that a refund will eventually be included.
+
+### Safety invariants — high impact
+
+These directly govern whether the first value-bearing rail can lose, duplicate, or misattribute
+value:
+
+1. **Conservation:** one attempt cannot claim or refund more than it reserved.
+2. **Terminal exclusivity:** one attempt cannot become both finally claimed and finally refunded.
+3. **Exact binding:** the rail reference, amount, asset, condition, destinations, expiry, and
+   observation all bind to the same attempt.
+4. **Authoritative funding:** a participant's announcement cannot establish funded value without a
+   successful rail verifier.
+5. **Boundary safety:** claim and refund are accepted only in the intervals defined by the selected
+   rail profile, including the exact equality boundary.
+6. **Replay and reentrancy safety:** duplicate, reordered, or recursively delivered operations do
+   not repeat a monetary effect or replace a terminal outcome.
+7. **Deterministic audit:** the same authenticated evidence has one result. Caller-provided ordering
+   across incomparable room streams cannot choose between `cancelled` and `locked`.
+8. **No shared secret custody:** the MCP service never stores or later echoes a preimage or witness.
+9. **Immutable profile meaning:** a registry update cannot reinterpret a signed attempt; the signed
+   rail profile digest identifies the verifier contract used at construction.
+
+### Reachability witnesses — high or medium impact
+
+The executable tclk/2 model should demonstrate traces that reach each required shape:
+
+- a payer proposal that the payee completes with the condition, followed by verified funding and
+  verified claim;
+- a payee proposal that the payee already condition-authorizes, followed by the same settlement
+  path;
+- verified funding followed by expiry becoming open and a verified refund;
+- an agreed but never-funded agreement becoming observably non-actionable without inventing a
+  monetary terminal state;
+- an unknown or locally untrusted rail profile remaining decodable for audit while being unable to
+  construct an attempt or advance authoritative settlement;
+- duplicate observations leaving the same derived result.
+
+Reaching these states in simulation is evidence about sampled traces, not a proof that the safety
+invariants hold for all traces. The invariants need bounded exhaustive checking where feasible and
+implementation tests at the rail boundary.
+
+### Temporal and environment expectations — explicit assumptions
+
+The base protocol cannot promise these without assumptions supplied by a rail profile:
+
+- a valid submitted claim is eventually included and observed;
+- a valid refund is eventually included after expiry;
+- the rail clock progresses;
+- finality is eventually reached and does not later reverse;
+- an honest watcher sees the relevant condition or timeout in time;
+- message and observation delay stay within any deadline margin used by a routed profile.
+
+The first safety model can use a monotonic predicate such as `refundOpen`. Numeric clock progress,
+bounded inclusion, and eventual recovery belong in later liveness checks against the actual
+flop-core semantics. Encoding several integers in the base state would not make these assumptions
+true.
+
+## The tclk/1 simplification we can make now
+
+The goal is to narrow new behavior without changing historical bytes.
+
+### Preserve unchanged
+
+- Keep the `tclk1 ` prefix, decoder, canonical encoder, identifiers, signatures, state fold, and
+  golden vectors.
+- Keep both `claimByMs` and `refundAfterMs` on the tclk/1 wire.
+- Keep decoding legacy payee-authored offers, point locks, custom rail identifiers, and terminal
+  frames without `ref` when historical compatibility requires it.
+- Keep point/adaptor primitives and end-to-end reference tests, with the unaudited banner.
+
+### Restrict new construction
+
+1. **Payer-authored offers only for the supported tclk/1 payment flow.** The payee accepts and
+   supplies the hash condition, matching who later reveals the secret. Payee-authored historical
+   offers still replay.
+2. **Hash locks only for production-shaped new deals.** Point locks remain explicit reference or
+   legacy functionality until a profile pins an audited suite and its signed message. Do not imply
+   that the current `point` spelling is Bitcoin PTLC compatible.
+3. **Require `expiresMs < claimByMs < refundAfterMs` on new emissions.** This closes the ordering
+   ambiguity in [issue #26](https://github.com/flop-labs/tclk/issues/26) without changing a
+   historical decoder.
+4. **Treat `claimByMs` as advisory policy.** It is the latest safe local initiation target, not a
+   second rail transition. tclk/1 already permits a reveal until `refundAfterMs`; preserve that
+   behavior. `refundAfterMs` remains the only tclk/1 rail boundary.
+5. **Require `ref` from new reveal/refund builders.** Historical absence remains decodable; a
+   supplied mismatch fails closed. The main branch already implements this direction.
+6. **Use a caller-owned custom rail registry.** A new custom rail must be explicitly configured,
+   owner-namespaced, versioned, and map `refundAfterMs` to its native expiry. Unknown identifiers
+   are decode-only. Avoid process-global mutation and never load adapter code from a room.
+7. **Do not add `abandoned` or `expired` wire states.** Expose derived predicates such as
+   `canLock`, `fundingDeadlinePassed`, and `refundOpen`. Expiry enables an action; it is not proof
+   that the action happened.
+
+`direct-conditional-payment@1` should remain the name of the actual tclk/2 profile. Giving the
+restricted tclk/1 builder the same on-wire profile name would falsely imply that old frames bind all
+of its semantics.
+
+## What must wait for tclk/2
+
+The following pieces are valuable only when introduced as one coherent signed model:
+
+- separate `agreementId` and `attemptId` values;
+- a rail-native opaque expiry with profile-defined clock and equality semantics;
+- signed rail `id`, immutable semantic `profile`, and canonical `profileHash`;
+- verified pending/final observations with idempotency keys;
+- replacement or multipart attempts;
+- point/adaptor suites that pin all cryptographic details;
+- routed-payment deadline staggering and private backward fulfillment;
+- normalized cross-rail reconciliation fields;
+- reversible or chargeback-capable settlement profiles.
+
+For the initial direct profile, `final` should mean **economically irreversible within the selected
+profile's stated trust and finality model**. ACH returns, card chargebacks, administrative rollback,
+or probabilistic finality that can still be displaced cannot be mapped to that state. A future
+reversible-rail profile may need provisional settlement and reversal observations; adding a generic
+`reversed` value now would claim common semantics that have not been specified.
+
+Likewise, settled amount, fee, net amount, and value date should remain in the rail-specific
+evidence schema for now. Applications may derive a local normalized reconciliation view, but that
+view is not authoritative protocol state until units, sign conventions, fee ownership, and value
+date semantics are defined across at least two real rails.
+
+## Current pull-request disposition
+
+This table reflects the live repository on 2026-09-04. `BLOCKED` or `DIRTY` on GitHub means the
+branch must be rebased and re-run through the required CI before merge; it is not itself a design
+rejection.
+
+| PR | Disposition | Reason |
+| --- | --- | --- |
+| [#58](https://github.com/flop-labs/tclk/pull/58) tclk/2 proposal | **Merge after team review** | Establishes the target boundary without changing tclk/1. This note resolves the migration decision and clarifies irreversible finality and reconciliation scope. |
+| [#63](https://github.com/flop-labs/tclk/pull/63) strict hex | **Rebase, then merge** | Fail-closed canonical validation; reduces ambiguity without widening accepted bytes. |
+| [#60](https://github.com/flop-labs/tclk/pull/60) decode size cap | **Rebase, then merge** | Applies the encoder's resource bound to untrusted input. |
+| [#59](https://github.com/flop-labs/tclk/pull/59) schema/decoder agreement | **Rebase, then merge** | The published schema must not authorize frames the money-path decoder rejects. |
+| [#51](https://github.com/flop-labs/tclk/pull/51) receipt binding / zero witness | **Rebase, then merge** | Exact rail/reference binding and fail-closed scalar validation are direct safety fixes. |
+| [#16](https://github.com/flop-labs/tclk/pull/16) nested unknown keys | **Repair/rebase, then merge** | Closed schemas must be recursive; a nested `type` must not bypass unknown-key rejection. |
+| [#52](https://github.com/flop-labs/tclk/pull/52) malformed window record isolation | **Rebase, then merge** | One hostile record should not erase other independently authenticated records. Preserve an explicit rejected-record audit result. |
+| [#55](https://github.com/flop-labs/tclk/pull/55) exact string nonce | **Rebase, then merge** | Prevents numeric coercion from changing signature-covered evidence. |
+| [#56](https://github.com/flop-labs/tclk/pull/56) bounded operation retries | **Rebase, then merge** | Centralizes transient retry and timeout policy. It supersedes #45 and closes issue #2. |
+| [#50](https://github.com/flop-labs/tclk/pull/50) walkthrough frames | **Resolve conflicts, then merge** | Documentation examples must pass the real decoder and match their stated commitment. |
+| [#32](https://github.com/flop-labs/tclk/pull/32) proposed cancel binding | **Repair conflicts, then merge** | Fixes the tclk/1 ambiguity in issue #5 without creating a new lifecycle state. |
+| [#62](https://github.com/flop-labs/tclk/pull/62) dual-room fallback | **Do not merge as written** | It unions two streams with no authenticated total order; tied timestamps can yield different terminal states from the same evidence. Select exactly one post-accept source. |
+| [#65](https://github.com/flop-labs/tclk/pull/65) example-only fallback | **Do not merge as written** | It retries into the offer room and then accepts an audit result after strict transcript verification refused those records. An example must not label unauditable completion as success. |
+| [#54](https://github.com/flop-labs/tclk/pull/54) response cap | **Revise** | A blanket cap also truncates `/export`, the full-history audit path. Stream or paginate exports; cap only bounded endpoints. |
+| [#53](https://github.com/flop-labs/tclk/pull/53) uppercase commitments | **Close** | Accepting uppercase expands canonical tclk/1 input and collapses byte-distinct spellings. Canonical commitments remain lowercase. |
+| [#45](https://github.com/flop-labs/tclk/pull/45) per-attempt timeout | **Close as superseded by #56** | Retry, timeout, and reconciliation should live in one operation-layer abstraction. |
+| [#21](https://github.com/flop-labs/tclk/pull/21) EVM rail | **Postpone and retarget to tclk/2** | A value-bearing rail would fossilize tclk/1's fused contract/attempt identity and wall-clock assumptions. |
+| [#28](https://github.com/flop-labs/tclk/pull/28) autonomous Python client | **Postpone or close** | It duplicates a lifecycle that is about to be narrowed and would become a second implementation to migrate. |
+| [#13](https://github.com/flop-labs/tclk/pull/13) Python walkthrough | **Reduce scope** | Keep an independent golden-vector checker in CI; drop the duplicate lifecycle state machine. |
+
+## Current issue disposition
+
+| Issue | Disposition | Reason |
+| --- | --- | --- |
+| [#64](https://github.com/flop-labs/tclk/issues/64) work quantity as settlement | **Close or transfer** | The named `analyzeDeal`, `DealIntent`, and `toTclkOffer` surfaces are not in this repository. The semantic boundary belongs in the job-to-payment adapter that owns them. |
+| [#61](https://github.com/flop-labs/tclk/issues/61) room binding | **Keep until one-source policy lands** | The useful problem is transport fallback under a per-client room quota; the solution must not union unordered streams or bypass audit. |
+| [#57](https://github.com/flop-labs/tclk/issues/57) tclk/2 design | **Close with #58** | The proposal records the design boundary and remaining flop-core-specific decisions. |
+| [#49](https://github.com/flop-labs/tclk/issues/49) broken walkthrough | **Close with #50** | The repaired example should be decoder-tested. |
+| [#48](https://github.com/flop-labs/tclk/issues/48) canonical JSON escapes | **Fix now** | Identifier and future profile-hash bytes require exact lowercase escapes, surrogate behavior, short escapes, slash behavior, and DEL policy. Add independent vectors. |
+| [#41](https://github.com/flop-labs/tclk/issues/41) abandonment | **Resolve with derived actionability** | Do not add a signed terminal state for the absence of funding. Expose whether funding is still actionable; model explicit abandonment in tclk/2 agreement state. |
+| [#36](https://github.com/flop-labs/tclk/issues/36) missing presig message | **Restrict new point emission; defer suite to tclk/2** | The missing signed-message contract cannot be repaired by another optional tclk/1 field without changing the suite's meaning. |
+| [#26](https://github.com/flop-labs/tclk/issues/26) independent interop gaps | **Split and close through focused fixes** | Require new-emission deadline ordering, reject duplicate JSON keys, pin canonical escapes/provenance, and retain the independent vectors. |
+| [#12](https://github.com/flop-labs/tclk/issues/12) payee-authored secret custody | **Restrict new tclk/1 emission; solve generally in tclk/2** | Payer-proposed tclk/1 restores the documented direct-payment role. tclk/2 makes condition authority independent of author order. |
+| [#5](https://github.com/flop-labs/tclk/issues/5) proposed cancel identity | **Close with repaired #32** | Bind proposed cancellation to the offer identity and keep receipt handling explicit. |
+| [#4](https://github.com/flop-labs/tclk/issues/4) private reporting | **Enable administratively** | This is repository security configuration, independent of the protocol queue. |
+| [#3](https://github.com/flop-labs/tclk/issues/3) room quota bootstrap | **Update and close with room-source policy** | The observed refusal is a per-client room-creation quota, not proof of a globally full venue. |
+| [#2](https://github.com/flop-labs/tclk/issues/2) transient 5xx | **Close with #56** | One bounded operation layer should own retry and reconciliation. |
+
+## Structural improvements that close several items at once
+
+### A. One schema-owned validation pipeline
+
+Generate or derive recursive allowed-key sets, canonical scalar/hex validators, size limits, and
+JSON-schema constraints from one contract. This consolidates #16, #59, #60, #63, and part of #48
+and #26. Keep independent golden vectors outside that generator so the implementation cannot
+approve its own encoding drift.
+
+### B. One transcript-source policy
+
+Represent transcript input as an explicit source choice:
+
+```text
+offer and accept: offer room
+post-accept:       derived room OR offer room, fixed for the fold
+```
+
+The chosen source is policy/configuration, not inferred by unioning whatever records the caller
+provides. The audit output should name the source, rejected records, and whether every applied
+record passed signature, sender, room, and sequence checks. This replaces both #62 and #65 and can
+close #61 and #3.
+
+### C. One operation-layer venue client
+
+Centralize bounded request size, streaming export, per-operation timeout, retry classification,
+idempotency, reconciliation after uncertain responses, and exact nonce handling. This consolidates
+#2, #45, #54, #55, #56, and earlier example-specific retry patches. Examples should call this
+layer rather than implement their own failure semantics.
+
+### D. Versioned construction surfaces
+
+Expose the supported tclk/1 builder policy separately from the historical decoder, and make the
+tclk/2 profile registry caller-owned and digest-bound. This gives #12, #36, #41, and the future
+flop-core rail one deliberate migration point rather than separate compatibility exceptions.
+
+## Recommended merge order by return on effort
+
+1. **Merge #58 after review.** It prevents new work from targeting the wrong abstraction and costs
+   no runtime compatibility.
+2. **Land the byte-preserving fail-closed batch:** #63, #60, #59, #51, #16, then #48's canonical
+   escape rules. These protect every consumer of hostile wire input.
+3. **Land evidence and operation integrity:** #52, #55, and #56; close #45 and #2.
+4. **Repair user-facing correctness:** #50 and #32; close #49 and #5.
+5. **Make the coherent tclk/1 new-construction restriction** described above; resolve #12, #36,
+   #41, and the remaining focused parts of #26 in that decision or linked PRs.
+6. **Replace #62 and #65 with one deterministic transcript-source policy.** Do not trade audit
+   determinism for liveness under a room quota.
+7. **Write the normative tclk/2 spec and executable safety model**, then bind the first flop-core
+   HTLC rail. Retarget #21 or use it only as rail-adapter research after that contract is fixed.
+
+This order favors changes that prevent ambiguous or hostile input from entering any model, then
+repairs operational evidence, and only then changes supported construction policy.
+
+## Merge gates
+
+Every implementation PR should satisfy all applicable gates:
+
+- rebased on current `main`, with conflicts resolved semantically rather than mechanically;
+- `pnpm install --frozen-lockfile`;
+- `pnpm -r --include-workspace-root build`;
+- `pnpm -r --include-workspace-root test`;
+- no edits to golden vectors unless the PR deliberately introduces `tclk2 `;
+- an `[Unreleased]` changelog entry for user-visible behavior;
+- malformed, duplicate, boundary, replay, and reordering tests for the touched money path;
+- exact preservation of state on rejection;
+- no room assertion promoted to authoritative rail state;
+- no secret persisted, logged, or echoed by shared infrastructure.
+
+For the tclk/2 model, report safety checks, reachability traces, and temporal assumptions
+separately. Random simulation should be reported as the number of sampled runs, step bound, and
+observed counterexamples; it must not be described as proof.
+
+## Consequences and trade-offs
+
+The direction deliberately gives up some apparent breadth:
+
+- tclk/1 stops presenting payee-authored direct deals and point locks as equally supported new
+  value flows;
+- EVM and other value-bearing rail integrations wait for a profile that can state their real
+  clocks, evidence, and finality;
+- applications with custom rails must provide explicit local configuration;
+- a room-quota fallback takes more design work than reading both rooms.
+
+In exchange, the codebase has one honest compatibility rule, one smaller supported tclk/1 path,
+and one clean place to add real settlement semantics. This is lower total work than completing
+multiple clients and rails against tclk/1 and immediately migrating all of them.
+
+## Review questions for the team
+
+1. Do we agree that historical decode/replay and new construction may have different acceptance
+   policies?
+2. Do we agree that no value-bearing rail should merge until the tclk/2 direct profile and
+   flop-core clock/finality evidence are normative?
+3. Do we agree that `claimByMs` remains advisory in tclk/1 and that tclk/2 carries one
+   authoritative rail-native expiry?
+4. Do we agree that the supported new tclk/1 path is payer-proposed and hash-locked, while legacy
+   point/payee-proposed traffic remains auditable?
+5. Do we agree that `final` is reserved for economically irreversible observations within a
+   profile, and that reconciliation normalization remains a local projection for now?
+6. Do we agree to replace the dual-room and audit-bypass fallbacks with one explicit post-accept
+   transcript source?
+
+If these answers are yes, the merge queue above can proceed without waiting for every tclk/2 wire
+field to be designed. The remaining open design questions are then confined to the flop-core rail
+profile rather than leaking back into tclk/1.

--- a/TCLK2-PROPOSAL.md
+++ b/TCLK2-PROPOSAL.md
@@ -23,6 +23,10 @@ for the initial flop-core HTLC. Routed payments, general atomic swaps, redundant
 payments, and point/adaptor locks should be separate later profiles. In particular, tclk/2 must
 not claim that publishing one witness in a room is a generic routed-payment protocol.
 
+The first implementation needs at most one transfer attempt per agreement. The separate attempt
+identity prevents the agreement and the rail reservation from becoming the same object, but
+replacement and multipart attempt collections remain deferred until a profile needs them.
+
 This is intentionally a wire break. tclk/1 remains decodable and replayable; new tclk/2
 messages use a new prefix and domain. The tclk/1 golden vectors must not be edited.
 
@@ -71,6 +75,8 @@ and the safety properties consumers may rely on.
 - The rail profile states who may submit claim and refund operations. Submission authority is
   not inferred from the payout address.
 - Settlement is terminal only after a trusted rail observation.
+- The profile fixes the expiry clock and boundary semantics. The agreement carries one
+  rail-native expiry; an earlier safe claim deadline is local policy, not protocol state.
 
 This profile is the intended contract between tclk/2 and the first flop-core HTLC.
 
@@ -110,21 +116,21 @@ binds at least:
 interface TransferAttempt {
   attemptId: string;
   agreementId: string;
-  rail: { id: string; profile: string };
+  rail: { id: string; profile: string; profileHash: string };
   amount: string;
   asset: string;
   condition: Condition;
   claimTo: string;
   refundTo: string;
-  expiry: RailTime;
+  expiry: string; // canonical rail-native value; its profile defines the clock and comparison
   nonce: string;
 }
 ```
 
-The same agreement may create a replacement attempt after an earlier attempt fails, or several
-parts under an aggregate-payment profile. A condition is never an identifier: multiple attempts
-may intentionally share a witness, and unrelated attempts must not collide merely because they
-carry the same commitment.
+The initial direct-payment profile permits zero or one attempt. A later profile may permit a
+replacement after an earlier attempt fails, or several parts under aggregate-payment semantics.
+A condition is never an identifier: future attempts may intentionally share a witness, and
+unrelated attempts must not collide merely because they carry the same commitment.
 
 `railRef` is the rail's native identifier and is bound to exactly one `attemptId` after the rail
 accepts the reservation. Neither value substitutes for the other.
@@ -164,11 +170,6 @@ type Condition = {
   suite: "preimage-sha256@1";
   commitment: string; // canonical lowercase 0x + 32 bytes
 };
-
-type RailTime = {
-  clock: string; // for example "flop-core:block-height@1"
-  value: string; // canonical unsigned integer
-};
 ```
 
 A versioned rail profile should publish at least:
@@ -187,6 +188,47 @@ supports PREIMAGE-SHA-256, while FRAME's generic atomic-swap pallet uses Blake2 
 proof-size compatibility requirement. A registry update must not reinterpret an agreement that
 was signed against an older rail profile.
 
+### Built-in and custom rail registration
+
+tclk must ship useful built-in profiles without making that list a closed protocol namespace.
+An application may supply a caller-owned registry and register custom rail adapters before it
+creates or verifies an agreement. Registration is local configuration, not executable code
+downloaded from a room and not mutable global process state.
+
+Each entry binds:
+
+```ts
+interface RailProfileDescriptor {
+  id: string;            // namespaced stable identifier
+  profile: string;       // immutable semantic profile such as "direct-htlc@1"
+  conditionSuites: string[];
+  expiryClock: string;
+  expiryEncoding: string;
+  timeoutSemantics: "exclusive" | "refund-race" | "automatic-refund";
+  claimAuth: string;
+  refundAuth: string;
+  finalityRule: string;
+  verifier: string;      // stable local verifier interface/version identifier
+}
+```
+
+Registration computes `profileHash` from the canonical descriptor. The signed attempt binds
+`id`, `profile`, and that digest. The expiry is an opaque canonical string to the tclk core; only
+the registered adapter interprets and compares it. This permits block heights, consensus
+timestamps, ledger-close times, and custom monotonic counters without a generic clock union in
+protocol state.
+
+The registry must reject malformed identifiers, duplicate `(id, profile)` entries, attempts to
+rebind an existing entry to a different digest, and aliases in signed bytes. An unknown profile
+may be preserved while decoding or auditing, but it is unsupported for construction and cannot
+advance authoritative settlement state. Two valid registries lacking a common profile report
+"no match"; malformed or digest-conflicting entries fail closed.
+
+Custom identifiers should be owner-namespaced and versioned. For tclk/1's existing identifier
+grammar that means spellings such as `example.flop-htlc-v1`; tclk/2 may define a less ambiguous
+structured identifier. Registration establishes local trust in the adapter and verifier—it does
+not make the custom rail safe merely because it has a name.
+
 ## Time model
 
 tclk/2 separates three kinds of time:
@@ -194,8 +236,9 @@ tclk/2 separates three kinds of time:
 1. **Offer expiry** is a coordination deadline and may use qualified Unix time.
 2. **Delivery or work due time** is an optional commercial term. Passing it does not itself move
    money.
-3. **Attempt expiry** is a rail-native value boundary. Before it, the condition path may be
-   valid; at or after it, the refund path may be valid according to the selected rail profile.
+3. **Attempt expiry** is the one rail-native value boundary. Whether it disables the condition
+   path or merely enables a competing refund path is fixed by the selected rail profile. An
+   operational "claim by" margin is derived locally and does not create another protocol state.
 
 Expiry is not a settlement event. An expired escrow may still hold value until somebody submits
 a refund. The derived state is therefore `funded + expired`, not `refunded`.
@@ -203,6 +246,11 @@ a refund. The derived state is therefore `funded + expired`, not `refunded`.
 A future cross-rail profile must state and model the bounds it assumes for clock growth,
 transaction inclusion, finality, observation, and propagation. Deadline staggering is a policy
 over attempts in that profile, not a pair of universal wall-clock fields copied onto every rail.
+
+For the initial executable safety model, time can be a monotonic environment predicate such as
+`refundOpen`, rather than integer arithmetic. Numeric clock progress, inclusion bounds, and
+eventual refund are liveness assumptions supplied by the rail profile, not base-protocol safety
+facts.
 
 ## State derivation
 
@@ -270,6 +318,11 @@ that an honest party can get that action included in time.
   builders remain explicitly versioned.
 - Continue merging tclk/1 fixes that preserve existing bytes, reject malformed input, bound
   resources, or improve auditability.
+- Permit custom tclk/1 rail emission only through an explicit caller-owned registry. Because the
+  tclk/1 wire binds Unix milliseconds rather than a native expiry, such an adapter must define and
+  verify its versioned mapping from `refundAfterMs` to the rail lock. Unknown ids remain
+  decode-only. A process-global `registerRail()` would introduce cross-tenant ambiguity and is not
+  acceptable.
 - Do not add a new value-bearing rail or a large new tclk/1 client before the tclk/2 contract is
   settled. Those implementations would either encode the assumptions above or need an immediate
   rewrite.

--- a/TCLK2-PROPOSAL.md
+++ b/TCLK2-PROPOSAL.md
@@ -161,6 +161,18 @@ API response or bilateral receipt. A consumer must never silently promote `pendi
 observations that claim incompatible terminal outcomes for one attempt are a verification or
 rail failure, not a last-write-wins update.
 
+For the initial direct-payment profile, `final` means economically irreversible within that
+profile's stated trust and finality model. A rail with returns, chargebacks, administrative
+rollback, or a still-live reorganization risk cannot map an observation to `final`. Reversible
+rails remain deferred and may require a separate profile with provisional-settlement and reversal
+semantics; the base observation contract does not predeclare a generic `reversed` state whose
+meaning would differ across rails.
+
+Reconciliation facts such as settled amount, fee, net amount, and value date remain in the closed
+rail-specific `evidence` schema in the initial profile. Applications may derive normalized local
+views, but those views are not authoritative protocol fields until their units, sign conventions,
+fee ownership, and value-date meaning are specified across real rails.
+
 ## Conditions and rail capabilities
 
 Conditions are typed suites, not informal shapes:
@@ -310,6 +322,9 @@ relayer assumptions. A state machine that merely contains a legal recovery actio
 that an honest party can get that action included in time.
 
 ## Wire and migration
+
+The detailed tclk/1 merge and migration rationale is recorded in
+[`TCLK1-TO-TCLK2-DECISION.md`](TCLK1-TO-TCLK2-DECISION.md).
 
 - Reserve `tclk2 ` for the new frame encoding and `FLOP::tclk::v2` for identifiers/signatures.
 - Keep the tclk/1 decoder, state fold, schema, and golden vectors for historical replay.

--- a/TCLK2-PROPOSAL.md
+++ b/TCLK2-PROPOSAL.md
@@ -1,0 +1,347 @@
+# tclk/2 design proposal
+
+Status: **discussion draft; non-normative**. `SPEC.md` remains the normative tclk/1
+specification. Nothing in this document changes the meaning of an existing `tclk1 ` line.
+
+## Decision summary
+
+tclk/2 should begin as a deliberately narrow **direct conditional-payment** protocol. Its
+stable abstraction is:
+
+```text
+Agreement
+  └─ TransferAttempt / part [0..n]
+       └─ verified RailObservation [0..n]
+```
+
+An agreement records commercial intent. A transfer attempt records one concrete reservation
+of value on one rail. An observation records what that rail verifiably did. These are different
+objects with different identifiers and lifetimes.
+
+The first tclk/2 profile should support direct, two-party, preimage-SHA-256 payments suitable
+for the initial flop-core HTLC. Routed payments, general atomic swaps, redundant multipart
+payments, and point/adaptor locks should be separate later profiles. In particular, tclk/2 must
+not claim that publishing one witness in a room is a generic routed-payment protocol.
+
+This is intentionally a wire break. tclk/1 remains decodable and replayable; new tclk/2
+messages use a new prefix and domain. The tclk/1 golden vectors must not be edited.
+
+## Why tclk/1 is not the contract to give flop-core
+
+tclk/1 is useful coordination machinery, but it fuses concepts that real settlement systems
+keep separate:
+
+1. The counterparty always supplies `accept.statement`, while the specification says the payee
+   owns the secret. A payee-opened offer therefore assigns condition creation to the payer
+   ([#12](https://github.com/flop-labs/tclk/issues/12)).
+2. A payer-authored `lock` frame advances the transcript machine to `locked`, and a room
+   `reveal` or `refund` advances it to a monetary terminal state. A signed assertion is not
+   evidence that the rail funded, claimed, or refunded anything.
+3. `contract` is both the commercial agreement identifier and, in the reference rail, the
+   unique lock key. That excludes retries, replacements, partial payments, and multiple rails.
+4. `claimByMs`, `refundAfterMs`, and `expiresMs` mix commercial timing, coordination timing,
+   and rail enforcement in one wall-clock domain. Real rails use block height, ledger close
+   time, consensus time, or a bilateral clock with an explicit trust assumption.
+5. `lock: "hash" | "point"` does not identify the hash algorithm, curve, encoding, signature
+   construction, witness limit, or message/domain an adaptor signature commits to
+   ([#36](https://github.com/flop-labs/tclk/issues/36)).
+6. The state machine has no explicit, observable way to abandon an accepted but unfunded
+   agreement ([#41](https://github.com/flop-labs/tclk/issues/41)).
+7. The protocol describes one public witness as the propagation mechanism for routed
+   payments. That is at best one direct-HTLC construction, not a safe universal routing rule.
+
+Patching these independently would preserve the `tclk1 ` spelling while changing its security
+model. A versioned replacement is clearer and safer.
+
+## Scope and profiles
+
+Every agreement names a profile. A profile fixes roles, condition authority, required phases,
+and the safety properties consumers may rely on.
+
+### Initial profile: `direct-conditional-payment@1`
+
+- Exactly one payer and one payee are named explicitly in the completed terms.
+- The payee is the condition authority: it supplies or signs off on the public commitment,
+  regardless of which party proposed the agreement.
+- The only condition suite is `preimage-sha256@1`, with a 32-byte commitment and 32-byte
+  witness.
+- A successful attempt transfers its amount only to `claimTo`; an expired attempt returns its
+  amount only to `refundTo`.
+- `claimTo` is the payee and `refundTo` is the payer in this profile.
+- The rail profile states who may submit claim and refund operations. Submission authority is
+  not inferred from the payout address.
+- Settlement is terminal only after a trusted rail observation.
+
+This profile is the intended contract between tclk/2 and the first flop-core HTLC.
+
+### Deferred profiles
+
+- **Routed payment.** Needs per-hop or per-packet attempts, amounts, expiries, private backward
+  fulfillment, and possibly path-specific release keys.
+- **Atomic swap.** Needs a swap graph and explicit secret-generating leaders; a payee is not a
+  universal condition owner.
+- **Multipart/redundant payment.** Needs aggregate amount and threshold semantics so successful
+  parts cannot overpay and stragglers cannot block forever.
+- **Point/adaptor payment.** Needs an audited cryptographic suite that pins the group, point and
+  scalar encodings, signature algorithm, nonce construction, signed message, and domain.
+
+Deferring these is a scope boundary, not a claim that one direct-payment witness can safely be
+reused for them.
+
+## Objects and identifiers
+
+### Proposal and agreement
+
+A proposal may be authored by either party. It names proposed roles and terms but is not itself
+a reservation of money. The second party signs a completed, normalized agreement. If the payee
+authored the proposal, the condition may be present there; if the payer authored it, the payee
+adds the condition when agreeing.
+
+`agreementId` commits to the completed terms, both party identifiers, the proposal identifier,
+and negotiation nonces. It must not depend on putting the condition in an acceptor-specific
+field. Equivalent completed terms have one canonical representation before hashing.
+
+### Transfer attempt
+
+One agreement may have zero or more transfer attempts. Each attempt has a fresh `attemptId` and
+binds at least:
+
+```ts
+interface TransferAttempt {
+  attemptId: string;
+  agreementId: string;
+  rail: { id: string; profile: string };
+  amount: string;
+  asset: string;
+  condition: Condition;
+  claimTo: string;
+  refundTo: string;
+  expiry: RailTime;
+  nonce: string;
+}
+```
+
+The same agreement may create a replacement attempt after an earlier attempt fails, or several
+parts under an aggregate-payment profile. A condition is never an identifier: multiple attempts
+may intentionally share a witness, and unrelated attempts must not collide merely because they
+carry the same commitment.
+
+`railRef` is the rail's native identifier and is bound to exactly one `attemptId` after the rail
+accepts the reservation. Neither value substitutes for the other.
+
+### Rail observation
+
+A room participant may announce that it submitted an operation. That announcement is useful for
+coordination but does not change authoritative money state. A state-advancing observation must be
+verified according to the selected rail profile:
+
+```ts
+interface RailObservation {
+  observationId: string;
+  attemptId: string;
+  railRef: string;
+  status: "funded" | "claimed" | "refunded" | "rejected";
+  finality: "pending" | "final";
+  evidence: unknown; // closed, rail-specific schema
+}
+```
+
+The registry defines how `evidence` is authenticated and checked. For flop-core this may be a
+locally verified finalized transaction/event reference; another rail may use an authenticated
+API response or bilateral receipt. A consumer must never silently promote `pending` evidence to
+`final`.
+
+`observationId` is an idempotency key. Replaying the same observation is a no-op. Two final
+observations that claim incompatible terminal outcomes for one attempt are a verification or
+rail failure, not a last-write-wins update.
+
+## Conditions and rail capabilities
+
+Conditions are typed suites, not informal shapes:
+
+```ts
+type Condition = {
+  suite: "preimage-sha256@1";
+  commitment: string; // canonical lowercase 0x + 32 bytes
+};
+
+type RailTime = {
+  clock: string; // for example "flop-core:block-height@1"
+  value: string; // canonical unsigned integer
+};
+```
+
+A versioned rail profile should publish at least:
+
+- supported assets and amount bounds;
+- supported condition suites and maximum witness/evidence sizes;
+- supported expiry clocks, boundary semantics, and minimum safety margins;
+- claim and refund submission authorization;
+- finality rule and observation verifier;
+- whether expiry automatically transfers value or merely enables a refund operation;
+- callback/reentrancy behavior; and
+- a stable profile version or digest that signed agreements bind.
+
+Matching only the canonical rail id is insufficient. XRP Ledger conditional escrow, for example,
+supports PREIMAGE-SHA-256, while FRAME's generic atomic-swap pallet uses Blake2 and exposes a
+proof-size compatibility requirement. A registry update must not reinterpret an agreement that
+was signed against an older rail profile.
+
+## Time model
+
+tclk/2 separates three kinds of time:
+
+1. **Offer expiry** is a coordination deadline and may use qualified Unix time.
+2. **Delivery or work due time** is an optional commercial term. Passing it does not itself move
+   money.
+3. **Attempt expiry** is a rail-native value boundary. Before it, the condition path may be
+   valid; at or after it, the refund path may be valid according to the selected rail profile.
+
+Expiry is not a settlement event. An expired escrow may still hold value until somebody submits
+a refund. The derived state is therefore `funded + expired`, not `refunded`.
+
+A future cross-rail profile must state and model the bounds it assumes for clock growth,
+transaction inclusion, finality, observation, and propagation. Deadline staggering is a policy
+over attempts in that profile, not a pair of universal wall-clock fields copied onto every rail.
+
+## State derivation
+
+The coordination state and money state remain separate:
+
+```text
+proposal ──agreement──▶ agreed ──funding announcement──▶ agreed/funding
+     │                    │
+     └────withdrawn───────┴────abandoned (only before verified funding)
+
+attempt: unknown ──verified funded──▶ funded ──verified claimed──▶ claimed
+                                          └──verified refunded─▶ refunded
+```
+
+`funded`, `claimed`, and `refunded` require verified rail observations. A witness appearing in a
+room may be recorded as `witness-known`; it is not proof that a rail accepted a claim. Likewise,
+a refund request is not proof that the funds returned.
+
+Agreement-level status is derived from its attempts and profile. It is not a single mutable enum
+that lets one signed message erase contradictory rail state.
+
+## Execution and callback rules
+
+Beneficiary and executor are separate concepts:
+
+- `claimTo` and `refundTo` are immutable payout destinations.
+- `claimAuth` and `refundAuth` come from the rail profile and may be permissionless,
+  beneficiary-only, owner-only, witness-plus-signature, or another closed policy.
+- A coordination frame's `from` identifies its signer; it does not prove who submitted the rail
+  transaction.
+
+Where a rail invokes external code or middleware, terminalization consumes the live lock before
+any callback. Claim, refund, acknowledgement, and timeout handling must be idempotent under
+duplicate delivery and safe under reentrant invocation. At-least-once observation delivery must
+not create more than one monetary effect.
+
+## Required properties and adversary model
+
+The executable model and implementation tests should cover at least:
+
+1. **Conservation:** an attempt never pays or refunds more than was reserved.
+2. **Terminal exclusivity:** a funded attempt cannot become both claimed and refunded.
+3. **Exact binding:** observation, rail reference, amount, asset, destinations, condition, and
+   expiry all bind to the same attempt.
+4. **Authoritative funding:** a party announcement alone never establishes that funds exist.
+5. **Deadline safety:** claim cannot win outside its rail-valid interval and refund cannot win
+   before its rail-valid interval; the exact boundary is specified.
+6. **Replay and reentrancy safety:** duplicate, reordered, and recursive operations do not repeat
+   an effect or change a terminal result.
+7. **No secret custody:** shared MCP infrastructure neither stores nor later echoes a witness.
+8. **Recovery visibility:** accepted but unfunded agreements can become observably abandoned;
+   expired but unrefunded attempts remain distinguishable from refunds.
+
+The environment must include independent rail clocks, bounded or unbounded message delay,
+transaction inclusion/finality, duplicate observations, unavailable parties, and any watcher or
+relayer assumptions. A state machine that merely contains a legal recovery action has not proved
+that an honest party can get that action included in time.
+
+## Wire and migration
+
+- Reserve `tclk2 ` for the new frame encoding and `FLOP::tclk::v2` for identifiers/signatures.
+- Keep the tclk/1 decoder, state fold, schema, and golden vectors for historical replay.
+- Do not implicitly reinterpret a `tclk1 ` transcript as a tclk/2 agreement.
+- New construction APIs should emit only tclk/2 once the normative spec is complete; legacy
+  builders remain explicitly versioned.
+- Continue merging tclk/1 fixes that preserve existing bytes, reject malformed input, bound
+  resources, or improve auditability.
+- Do not add a new value-bearing rail or a large new tclk/1 client before the tclk/2 contract is
+  settled. Those implementations would either encode the assumptions above or need an immediate
+  rewrite.
+
+## Research basis
+
+The proposal takes structure and failure modes from multiple ecosystems rather than treating one
+Bitcoin construction as universal:
+
+- [Interledger Protocol v4](https://interledger.org/developers/rfcs/interledger-protocol/) uses
+  individually expiring Prepare/Fulfill/Reject packets, local per-hop amounts, and progressively
+  earlier expiries. A logical payment may contain many packets.
+- [STREAM](https://interledger.org/developers/rfcs/stream-protocol/) derives fulfillments and
+  conditions per encrypted packet, while
+  [ILP over HTTP](https://interledger.org/developers/rfcs/ilp-over-http/) specifies request
+  correlation, retries, and first-reply idempotence.
+- [Interledger HTLAs](https://interledger.org/developers/rfcs/hashed-timelock-agreements/)
+  distinguish ledger-enforced escrow, payment-channel agreements, trustlines, and notarized
+  timekeeping instead of pretending their trust assumptions are identical.
+- [XRP Ledger escrow](https://xrpl.org/docs/concepts/payment-types/escrow) separates immutable
+  payout destinations from transaction submitters, uses ledger close time, and leaves an expired
+  escrow present until a later cancellation returns the funds.
+- [Polkadot SDK FRAME atomic swap](https://paritytech.github.io/polkadot-sdk/master/pallet_atomic_swap/pallet/struct.Pallet.html)
+  uses native block durations and recommends a shorter duration for the secret revealer. Its
+  [configuration contract](https://docs.rs/pallet-atomic-swap/latest/pallet_atomic_swap/pallet/trait.Config.html)
+  makes cross-chain proof-size compatibility an explicit atomicity assumption.
+- [Cashu NUT-14](https://github.com/cashubtc/nuts/blob/main/14.md) represents receiver and refund
+  authorization separately from the preimage, while
+  [NUT-18](https://github.com/cashubtc/nuts/blob/main/18.md) lets a payee request a locking
+  condition and requires the payee to validate the received lock itself.
+- [Cosmos IBC application semantics](https://github.com/cosmos/ibc-go/blob/main/docs/docs/01-ibc/03-apps/01-apps.md)
+  distinguish success/error acknowledgements and timeouts. The
+  [IBC timeout-callback advisory](https://github.com/cosmos/ibc-go/security/advisories/GHSA-j496-crgh-34mx)
+  is a concrete example of repeated settlement effects caused by reentrancy before consuming the
+  packet commitment.
+- [Try-Confirm/Cancel](https://docs.oracle.com/en/database/oracle/transaction-manager-for-microservices/26.1/tmmdv/tcc-transaction-model.html)
+  independently uses a reservation identifier returned by the resource manager, followed by
+  confirm or cancel. tclk/2 borrows the separation of agreement and reservation, not TCC's trust
+  in a transaction coordinator.
+- Herlihy's [Atomic Cross-Chain Swaps](https://arxiv.org/abs/1801.09515) models swaps as directed
+  graphs and assigns secret generation to a feedback vertex set of leaders, showing why
+  payee-owned conditions are a payment-profile rule rather than a universal swap rule.
+- [Anonymous Multi-Hop Locks](https://www.ndss-symposium.org/wp-content/uploads/2019/02/ndss2019_09-4_Malavolta_paper.pdf)
+  identifies the wormhole attack against conventional two-round payment-channel routing and uses
+  an additional path-setup round with path-specific secret information.
+- [Boomerang](https://arxiv.org/abs/1910.01834) shows that redundant multipart routing needs
+  aggregate/threshold machinery to avoid counterparty risk and straggler stalls.
+- Boyd, Gjøsteen, and Wu's
+  [Tamarin analysis of HTLCs](https://fmbc.gitlab.io/2020/files/FMBC2020.pdf) finds a hidden
+  relative blockchain-growth assumption. Van der Meyden's
+  [atomic-swap model checking](https://arxiv.org/abs/1811.06099) shows why recovery strategies and
+  liveness matter beyond reachable contract states.
+- [ERC-2266](https://eips.ethereum.org/EIPS/eip-2266) and Interledger's free-option discussion
+  show that atomic safety does not remove economic optionality or liquidity griefing. Premiums,
+  bonds, fees, and maximum lock horizons belong in profile policy rather than the base state
+  machine.
+- [Cross-chain Deals and Adversarial Commerce](https://www.vldb.org/pvldb/vol13/p100-herlihy.pdf)
+  explains why adversarial commercial exchange needs explicit safety, liveness, and synchrony
+  assumptions rather than importing classical transaction atomicity unchanged.
+
+## Open decisions before a normative tclk/2 spec
+
+1. The exact flop-core clock and finality identifier, proof format, and boundary behavior.
+2. Whether flop-core claim and refund submission are permissionless with fixed destinations or
+   restricted to a party.
+3. The evidence representation and verifier API for finalized flop-core observations.
+4. Whether the initial release supports multiple sequential attempts or only reserves the model
+   for them while enforcing one active attempt.
+5. Whether agreement cancellation requires one signature, both signatures, or merely becomes a
+   derived abandonment after its funding deadline.
+6. Maximum lock horizon and whether job/payment profiles require a bond or cancellation fee to
+   bound optionality and liquidity griefing.
+
+Those decisions should be made against the flop-core HTLC specification. They do not require the
+base tclk/2 wire to take on routed-payment or general atomic-swap semantics.


### PR DESCRIPTION
Closes #57.

## What this proposes

- keep tclk/1 normative, decodable, and byte-for-byte replayable;
- make tclk/2 a deliberate wire/domain break;
- separate commercial agreements, concrete transfer attempts, and verified rail observations;
- start with one narrow `direct-conditional-payment@1` profile for flop-core's HTLC;
- use one rail-native expiry per attempt; an earlier safe claim deadline is local policy rather
  than protocol state;
- ship built-in profiles while allowing caller-owned custom rail registries; signed attempts bind
  the immutable profile name and canonical descriptor digest;
- keep expiry interpretation, evidence, finality, destinations, and submission authority explicit
  in the selected profile;
- defer routed, general atomic-swap, multipart, and point/adaptor profiles until their additional
  assumptions are modeled and specified.

The proposal links each structural choice to primary specifications, implementations, security
advisories, or formal literature across Interledger, XRPL, Polkadot, Cashu, Cosmos IBC, TCC,
atomic swaps, routed payments, and cross-chain commerce.

## Compatibility and security

This is documentation only. It does not change the tclk/1 parser, wire bytes, state machine, rail
behavior, vectors, or MCP behavior. A hostile counterparty gains no new input or transition
surface from this PR.

The document also records the near-term merge boundary: continue tclk/1 compatibility,
validation, resource-bound, and auditability fixes; postpone new value-bearing rails and large
tclk/1 clients until the tclk/2 contract is settled.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -r --include-workspace-root build`
- `pnpm -r --include-workspace-root test` (158 tests passed: 93 library, 34 MCP, 31 worker)
