### PR TITLE
fix(schema): the published schema admits frames the decoder rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@ All notable changes to this project are documented here. Format follows
   append order.
 - Pre-signature scalar validation now accepts only whole-byte hex encodings, rejecting
   odd-length strings before they reach cryptographic parsing (#24).
+- The published `schema/tclk1-frames.schema.json` no longer admits frames the decoder
+  rejects. `presig.s` was still the pre-byte-pair `^0x[0-9a-f]{1,64}$`, so the schema kept
+  accepting exactly the odd-length scalars the decoder stopped taking in #24. `job.proto`,
+  `job.id` and `job.context` carried no constraint at all, where the decoder requires a
+  lowercase protocol id plus non-empty strings. SPEC §3 calls this file the artifact the
+  decoder uses and the package ships it, so an independent implementation validating
+  against the schema was being told to emit frames the reference refuses. Only the schema
+  moved. No decoder behaviour, wire byte or golden vector changed.
 - Adaptor scalar parsing now rejects zero and out-of-range values instead of reducing them
   modulo the curve order, matching point-lock witness validation and preventing distinct
   byte strings from being treated as the same scalar (#27).

--- a/schema/tclk1-frames.schema.json
+++ b/schema/tclk1-frames.schema.json
@@ -46,9 +46,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "proto": { "type": "string" },
-        "id": { "type": "string" },
-        "context": { "type": "string" }
+        "proto": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,31}$" },
+        "id": { "type": "string", "minLength": 1 },
+        "context": { "type": "string", "minLength": 1 }
       },
       "required": ["proto", "id"]
     },
@@ -57,7 +57,7 @@
       "additionalProperties": false,
       "properties": {
         "nonce": { "$ref": "#/$defs/hex33" },
-        "s": { "type": "string", "pattern": "^0x[0-9a-f]{1,64}$" }
+        "s": { "type": "string", "pattern": "^0x(?:[0-9a-f]{2}){1,32}$" }
       },
       "required": ["nonce", "s"]
     },

--- a/tests/schema-conformance.test.ts
+++ b/tests/schema-conformance.test.ts
@@ -7,7 +7,51 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
+import { makeOffer, validateFrame, type JobRef } from "../src/index.js";
+
 const root = fileURLToPath(new URL("..", import.meta.url));
+
+const schema = JSON.parse(readFileSync(
+  new URL("../schema/tclk1-frames.schema.json", import.meta.url),
+  "utf8",
+));
+
+const PAYER_DID = "did:key:z6Mk" + "f".repeat(44);
+const CONTRACT = "0x" + "11".repeat(32);
+const PRESIG_NONCE = "0x02" + "11".repeat(32);
+
+/**
+ * Evaluate one schema string leaf against a value, following at most one `$ref`. Every
+ * constraint checked below is a string leaf, so `minLength` and `pattern` are the whole
+ * surface this needs; it is deliberately not a general JSON Schema validator.
+ */
+function schemaAdmits(definition: string, field: string, value: string): boolean {
+  const property = schema.$defs[definition].properties[field];
+  const leaf = property.$ref ? schema.$defs[property.$ref.split("/").at(-1)] : property;
+  if (leaf.type !== "string") throw new Error(`${definition}.${field} is not a string leaf`);
+  if (leaf.minLength !== undefined && value.length < leaf.minLength) return false;
+  return leaf.pattern === undefined || new RegExp(leaf.pattern).test(value);
+}
+
+function offerWithJob(job: JobRef) {
+  return () => makeOffer({
+    from: PAYER_DID,
+    role: "payer",
+    amount: "1000000",
+    asset: "FLOP",
+    lock: "hash",
+    rails: ["paper"],
+    claimByMs: 1_756_800_000_000,
+    refundAfterMs: 1_756_886_400_000,
+    expiresMs: 1_756_713_600_000,
+    nonce: "9f2c81d04c9e1f7a",
+    job,
+  });
+}
+
+function lockWithPresigScalar(s: string) {
+  return { type: "lock", from: PAYER_DID, contract: CONTRACT, rail: "paper", ref: "escrow-1", presig: { nonce: PRESIG_NONCE, s } };
+}
 
 describe("protocol schema", () => {
   it("has current generated decoder fields and SPEC documentation", () => {
@@ -19,10 +63,37 @@ describe("protocol schema", () => {
   });
 
   it("keeps historical duplicate rail arrays decodable under tclk1", () => {
-    const schema = JSON.parse(readFileSync(
-      new URL("../schema/tclk1-frames.schema.json", import.meta.url),
-      "utf8",
-    ));
     expect(schema.$defs.offer.properties.rails.uniqueItems).toBeUndefined();
+  });
+
+  // SPEC §3 calls this schema "the same artifact the decoder uses" and the package ships
+  // it, so an independent implementation validates against the schema rather than against
+  // `src/`. A constraint the decoder enforces but the schema omits leaves that
+  // implementation emitting frames the reference rejects, which is why both halves are
+  // asserted on the same values here.
+
+  it("admits no pre-signature scalar the decoder rejects", () => {
+    for (const s of ["0x1", "0x111", `0x${"a".repeat(63)}`]) {
+      expect(schemaAdmits("presig", "s", s), `schema admits presig.s ${s}`).toBe(false);
+      expect(() => validateFrame(lockWithPresigScalar(s))).toThrow(/presig\.s is malformed/);
+    }
+    for (const s of ["0x11", `0x${"a".repeat(64)}`]) {
+      expect(schemaAdmits("presig", "s", s), `schema rejects presig.s ${s}`).toBe(true);
+      expect(() => validateFrame(lockWithPresigScalar(s))).not.toThrow();
+    }
+  });
+
+  it("admits no job reference the decoder rejects", () => {
+    const rejected: ReadonlyArray<[keyof JobRef, string, JobRef]> = [
+      ["proto", "A2A", { proto: "A2A", id: "task-3f" }],
+      ["proto", "", { proto: "", id: "task-3f" }],
+      ["id", "", { proto: "a2a", id: "" }],
+      ["context", "", { proto: "a2a", id: "task-3f", context: "" }],
+    ];
+    for (const [field, value, job] of rejected) {
+      expect(schemaAdmits("job", field, value), `schema admits job.${field} ${JSON.stringify(value)}`).toBe(false);
+      expect(offerWithJob(job)).toThrow(new RegExp(`job\\.${field}`));
+    }
+    expect(offerWithJob({ proto: "a2a", id: "task-3f", context: "ctx-1" })).not.toThrow();
   });
 });


### PR DESCRIPTION
## What

`schema/tclk1-frames.schema.json` no longer admits frames `validateFrame` rejects. `presig.s`
was the pre-byte-pair `^0x[0-9a-f]{1,64}$`; `job.proto`, `job.id` and `job.context` carried no
constraint at all. Nothing in `src/` changes.

## Why

SPEC §3 calls this file "the same artifact the decoder uses" and `files[]` ships it, so an
independent implementation validates against the schema rather than against `src/` (#26 is
one). Every row below is schema-valid today and fails to decode:

| value | decoder |
|---|---|
| `presig.s = "0x1"` | `tclk: presig.s is malformed: 0x1` |
| `job.proto = "A2A"` | `tclk: job.proto is malformed: A2A` |
| `job.id = ""` | `tclk: job.id must be a non-empty string` |

`presig.s` is the sharp one: #24 took odd-length scalars out of the decoder and the
`[Unreleased]` entry says so, while the schema kept admitting exactly those. `job.id` and
`job.context` are also the only free-form strings in the file without `minLength: 1`.

I treated the code as correct, being what #42 landed and what the vectors pin.

`--check` passes on the old schema too, so the existing gate could not catch this: it reads
field sets and the rail registry, never value constraints. The new cases assert the schema leaf
and `validateFrame` on the same values; reverting the schema hunk alone gives
`2 failed | 2 passed`.

One overlap worth naming: #16 fixes the mirror image, a nested `type` key that slips past the
decoder while the schema already forbids it. It moves `src/frames.ts`; this moves `schema/`.

This also sits inside the boundary #58 writes down, "Continue merging tclk/1 fixes that preserve
existing bytes, reject malformed input, bound resources, or improve auditability", next to the
line that keeps the tclk/1 schema for historical replay. Nothing here reinterprets a `tclk1 `
transcript.

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` (95 root, was 93; 34 mcp; 31 worker)
- [x] Golden vectors untouched — or, if the wire format moved deliberately, the version prefix
      moved with it and this PR says so in its title. No wire bytes move here;
      `tests/vectors.test.ts` is unmodified
- [x] `CHANGELOG.md` has an `[Unreleased]` entry for anything user-visible
- [x] Docs that would now be wrong are updated: `SPEC.md`, `README.md`, `mcp/README.md`,
      `mcp/worker/README.md`, `AGENTS.md`. None of them state a constraint this changes, and
      SPEC's generated field table is byte-identical (`--check` confirms it)
- [x] New surface on the money path: nothing new. No decoder answer differs before or after,
      so a hostile counterparty gets exactly what it got already

---

AI assistance (Claude, Anthropic) was used in developing this change. The design, review and
verification were done by the author. Verified locally before submitting: the three CI commands
above, `node scripts/generate-frame-fields.mjs --check` and a revert of the schema hunk alone
to confirm both new tests fail without it.

**Provenance.** `did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL`, fingerprint
`f15ddb2552fee06f`.

- Signed bytes: `sha256` over the lines `<sha256 of the file bytes at 70e0e86>  <path>` for
  `CHANGELOG.md`, `schema/tclk1-frames.schema.json`, `tests/schema-conformance.test.ts` in that
  order gives `3e5f2749b4857f7c20a00fed8648319adc08f9a3002b5fe239d7661ef4857175`. Signature over
  `tclk-pr|flop-labs/tclk|70e0e865595928cbbe6201d003d04b9ce1ec488c|<that digest>`:
  `P1K_KJH1m8DsMKpzA03NDOKNnLqcx8BM7hY89f0MRP212q_Aqst-Fu9ZQF16TcxhdkP5OV3nmtS6Uxye0J_IAw`.
  Checks with the raw Ed25519 key decoded out of the DID, no private key in the loop.
- Signed post naming this change: `/r/technocore` seq `3670779`, re-verifiable from
  `https://technocore.chat/r/technocore/export`.
- DID note: `https://technocore.chat/kv/agent/f15ddb2552fee06f`. The documented
  `/kv/did/<fingerprint>` path refused the write with `400 note limit reached (131072 is the
  cap, and this would be a new one)`, so the note went to the `agent` namespace instead.
