### PR TITLE
fix(frames): decode enforces the room-message cap the encoder already does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ All notable changes to this project are documented here. Format follows
   append order.
 - Pre-signature scalar validation now accepts only whole-byte hex encodings, rejecting
   odd-length strings before they reach cryptographic parsing (#24).
+- `decodeFrame` now enforces the same `MAX_FRAME_CHARS` room-message cap `encodeFrame` does.
+  SPEC §2 states the cap as a property of a frame, and technocore refuses a longer text, so a
+  longer line was never a stored room message. The check runs before `JSON.parse`, which bounds
+  what one row of an untrusted `/export` can cost a `foldTranscript` call. No wire bytes move
+  and no golden vector changes.
 - Adaptor scalar parsing now rejects zero and out-of-range values instead of reducing them
   modulo the curve order, matching point-lock witness validation and preventing distinct
   byte strings from being treated as the same scalar (#27).

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -476,6 +476,12 @@ export function encodeFrame(frame: TclkFrame): string {
 /** Decode a room-message line. Throws on a malformed tclk line or a non-tclk line. */
 export function decodeFrame(text: string): TclkFrame {
   if (!isTclkLine(text)) fail("not a tclk/1 line");
+  // The cap is a property of a frame, not just of our emitter: the venue refuses a longer
+  // text, so a longer line was never a stored room message. Checked before the parse, so a
+  // fold over an untrusted export bounds the work a single row can cost it.
+  if (text.length > MAX_FRAME_CHARS) {
+    fail(`frame exceeds the ${MAX_FRAME_CHARS}-char room-message cap (${text.length})`);
+  }
   let parsed: unknown;
   try {
     parsed = JSON.parse(text.slice(TCLK_PREFIX.length));

--- a/tests/live-wire-conformance.test.ts
+++ b/tests/live-wire-conformance.test.ts
@@ -15,11 +15,13 @@ import {
   makeAccept,
   makeOffer,
   matchingRails,
+  MAX_FRAME_CHARS,
   offerId,
   openContract,
   parseCapabilityToken,
   railSetsMatch,
   TCLK_PREFIX,
+  tryDecodeFrame,
 } from "../src/index.js";
 
 const PAYER = "did:key:z6Mk" + "f".repeat(44);
@@ -230,5 +232,32 @@ describe("live-wire conformance gaps", () => {
       note: "agentic-commerce heartbeat",
       status: "active",
     } as never)).toThrow(/unknown field on receipt/);
+  });
+
+  it("refuses a line the venue could never have stored, on decode as well as encode", () => {
+    const beat = (note: string) => ({
+      type: "heartbeat" as const,
+      from: PAYER,
+      contract: "0x" + "11".repeat(32),
+      nonce: "0123456789abcdef",
+      note,
+    });
+    // Grow the note until the line lands exactly on the cap: both halves must still take it.
+    const spare = MAX_FRAME_CHARS - encodeFrame(beat("x")).length;
+    const atCap = beat("x".repeat(1 + spare));
+    expect(encodeFrame(atCap).length).toBe(MAX_FRAME_CHARS);
+    expect(decodeFrame(encodeFrame(atCap))).toEqual(atCap);
+
+    // One character more, and neither half takes it.
+    const overCap = beat("x".repeat(2 + spare));
+    const line = `${TCLK_PREFIX}${canonicalJson(overCap)}`;
+    expect(line.length).toBe(MAX_FRAME_CHARS + 1);
+    expect(() => encodeFrame(overCap)).toThrow(/room-message cap/);
+    expect(() => decodeFrame(line)).toThrow(/room-message cap/);
+    expect(tryDecodeFrame(line)).toBeNull();
+
+    // The bound is what keeps one doctored export row from costing a fold a megabyte of parsing.
+    const megabyte = `${TCLK_PREFIX}${canonicalJson(beat("x".repeat(1_000_000)))}`;
+    expect(tryDecodeFrame(megabyte)).toBeNull();
   });
 });


### PR DESCRIPTION
## What

`decodeFrame` now enforces the `MAX_FRAME_CHARS` cap that `encodeFrame` already enforces. A
caller decoding a line longer than 4096 chars gets the same refusal an emitter gets.

## Why

SPEC §2 states the cap as a property of a frame, not of our emitter: "one frame per message,
single line, ≤ 4096 chars". technocore refuses a longer text (`MAX_TEXT_CHARS = 4096` in its
store), so a longer line was never a stored room message. The encoder refused to emit one; the
decoder took one of any length.

Measured on `main`:

| line | `encodeFrame` | `decodeFrame` |
|---|---|---|
| 219 chars | ok | ok |
| 200209 chars | `frame exceeds the 4096-char room-message cap` | returns a `heartbeat` |
| 5000209 chars | same refusal | returns a `heartbeat`, after parsing 5 MB |

The check sits before `JSON.parse`, so it also bounds what one row of an untrusted `/export`
can cost. `foldTranscript` calls `tryDecodeFrame` on whatever the export says. Nothing else
caps a line.

I treated SPEC §2 as correct and brought the decoder to it. No wire bytes move and no golden
vector changes: every frame the vectors pin is inside the cap. So is every frame a venue
could have stored, so tightening decode cannot break historical replay.

The regression lives in `tests/live-wire-conformance.test.ts` because that is where the wire
contract is pinned. It walks a heartbeat's `note` up to exactly 4096, asserts both halves still
take it, adds one character and asserts neither does. Reverting the `src/frames.ts` hunk alone
gives `1 failed | 13 passed` there.

Fits the boundary #58 writes down, "Continue merging tclk/1 fixes that preserve existing bytes,
reject malformed input, bound resources, or improve auditability". No overlap with any open PR:
nothing else touches `tests/live-wire-conformance.test.ts`. #16 is the only other PR in
`src/frames.ts` (its change is `validateFrame`'s nested-key check, a different function).

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` (94 root, was 93; 34 mcp; 31 worker)
- [x] Golden vectors untouched — or, if the wire format moved deliberately, the version prefix
      moved with it and this PR says so in its title. The vectors are unmodified and still pass;
      the accepted set only shrinks by lines the venue could not store
- [x] `CHANGELOG.md` has an `[Unreleased]` entry for anything user-visible
- [x] Docs that would now be wrong are updated: `SPEC.md`, `README.md`, `mcp/README.md`,
      `mcp/worker/README.md`, `AGENTS.md`. None needs a change; §2 already states the cap, and
      this makes the decoder agree with it
- [x] New surface on the money path: nothing new, plus one thing removed. A hostile counterparty
      can no longer hand a fold a line no venue could have carried, nor make it parse megabytes
      before the rejection

---

AI assistance (Claude, Anthropic) was used in developing this change. The design, review and
verification were done by the author. Verified locally before submitting: the three CI commands
above plus a revert of the `src/frames.ts` hunk alone to confirm the new regression fails
without it.

**Provenance.** `did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL`, fingerprint
`f15ddb2552fee06f`.

- Signed bytes: `sha256` over the lines `<sha256 of the file bytes at 468e865>  <path>` for
  `CHANGELOG.md`, `src/frames.ts`, `tests/live-wire-conformance.test.ts` in that order gives
  `a7b69d29b9e96bfcdf832e49cd582afbe0120db13d12f174914d7959744eb74a`. Signature over
  `tclk-pr|flop-labs/tclk|468e865b4febc560a250da3a01de25c0ce7d642a|<that digest>`:
  `a0Qo8H7EzJph935WpOAg5GyKGb7aoYeBAUGBhMDsqABgxpSSSWQn3RuM9INxow05zsBdrcn-9JDgV0giQZ0FAw`.
  Checks with the raw Ed25519 key decoded out of the DID, no private key in the loop.
- DID note: `https://technocore.chat/kv/agent/f15ddb2552fee06f`.
