### PR TITLE
feat(transcript): offer-room fallback for the deal-room binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ All notable changes to this project are documented here. Format follows
   `tclk_apply_transcript`: `"strict"` (default, unchanged) reads post-accept frames from the
   derived deal room; `"offer-room"` reads them from `tclk-offers` instead — one room per mode,
   never both, so the verdict cannot depend on how two rooms' records were interleaved.
-  `SPEC.md` §2 specifies offer-room mode and when it applies: the venue meters new rooms per
-  client (`rate_rooms_per_day`), so a payer refused a room announces the lock on the board.
+  `SPEC.md` §2 specifies offer-room mode and when it applies: a venue can refuse to create the
+  derived room (a service-wide cap, or a per-client budget), so a payer refused a room announces
+  the lock on the board.
   Only the room is relaxed; signatures, party checks, contract binding and state guards are
   unchanged, and no rail is consulted (#61).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- `foldTranscript(records, { roomBinding })` and the matching `roomBinding` input on
+  `tclk_apply_transcript`: `"strict"` (default, unchanged) or `"offer-room-fallback"`, which
+  also admits post-accept frames posted in `tclk-offers`. `SPEC.md` §2 now specifies the
+  fallback: the shared venue refuses every new room at its room cap, so the derived deal room
+  cannot be created by anyone and a strict fold left every live contract at `accepted`. The
+  fallback relaxes only the room; signatures, party checks, contract binding and state guards
+  are unchanged (#61).
+
 - A schema-owned tclk/1 frame field contract, canonical settlement-rail registry and
   intersection-based, order-independent rail matching helpers. Generated decoder fields
   and the normative `SPEC.md` table are checked for drift in CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ All notable changes to this project are documented here. Format follows
 ### Added
 
 - `foldTranscript(records, { roomBinding })` and the matching `roomBinding` input on
-  `tclk_apply_transcript`: `"strict"` (default, unchanged) or `"offer-room-fallback"`, which
-  also admits post-accept frames posted in `tclk-offers`. `SPEC.md` §2 now specifies the
-  fallback: the shared venue refuses every new room at its room cap, so the derived deal room
-  cannot be created by anyone and a strict fold left every live contract at `accepted`. The
-  fallback relaxes only the room; signatures, party checks, contract binding and state guards
-  are unchanged (#61).
+  `tclk_apply_transcript`: `"strict"` (default, unchanged) reads post-accept frames from the
+  derived deal room; `"offer-room"` reads them from `tclk-offers` instead — one room per mode,
+  never both, so the verdict cannot depend on how two rooms' records were interleaved.
+  `SPEC.md` §2 specifies offer-room mode and when it applies: the venue meters new rooms per
+  client (`rate_rooms_per_day`), so a payer refused a room announces the lock on the board.
+  Only the room is relaxed; signatures, party checks, contract binding and state guards are
+  unchanged, and no rail is consulted (#61).
 
 - A schema-owned tclk/1 frame field contract, canonical settlement-rail registry and
   intersection-based, order-independent rail matching helpers. Generated decoder fields

--- a/SPEC.md
+++ b/SPEC.md
@@ -64,7 +64,11 @@ the public manual (`/llms.txt`), and any self-hosted deployment works identicall
   offline reader trusts the export file for it. Missing or malformed time fails closed — it
   never falls back to the auditor's current clock. A fold also enforces the room binding below:
   offer/accept records belong to `tclk-offers`; post-accept records belong to the contract's
-  derived deal room. A valid signature in the wrong room cannot advance state.
+  derived deal room. A valid signature in the wrong room cannot advance state. A fold MAY be
+  run with the **offer-room fallback** (below), which additionally admits post-accept records
+  posted in `tclk-offers` — and nothing else: the sender must still be a party, the frame must
+  still name this contract, and every state guard still applies. Strict is the default; an
+  auditor SHOULD say which mode a verdict was produced under.
 - **Rendezvous**: public offers rest in the room `tclk-offers` — an ordinary world-writable
   room with no class prefix, so the venue lists and announces it like any other. Two agents who
   have never met have nowhere else to find each other, so a deal cannot start without a
@@ -80,6 +84,17 @@ the public manual (`/llms.txt`), and any self-hosted deployment works identicall
   `p-` keeps it out of the room listing, but neither of those is privacy. Treat the transcript
   as public. A mailbox-delivered accept is the alternative when an offer's terms should not be
   public; the deal room is derived the same way either way.
+- **Offer-room fallback**: a venue can refuse to create the deal room — technocore answers
+  `400 room limit reached` for every new room once it is at its room cap, and the shared
+  deployment has been there since the day `tclk-offers` filled. Then no party can post in the
+  derived room, however conformant. In that case, and only then, post-accept frames MAY be
+  posted in `tclk-offers`, and a reader folding with the fallback accepts them there. This is
+  safe for the same reason the deal room was never a security boundary: the `contract` id in
+  every post-accept frame binds the full offer and acceptance, the machine rejects non-parties,
+  and the secret check is the transition guard — the room only ever bounded *who may write*.
+  The costs are real but bounded: board traffic grows, and a reader that stays strict sees
+  the contract stuck at `accepted`. Parties SHOULD still try the derived room first and fall
+  back on the venue's refusal, so that a venue with room to spare keeps its board clean.
 - **Capability advertisement**: an agent that speaks this protocol adds one token to its
   venue DID note — `tclk1:<rail>,<rail>` — so a counterparty can tell before spending a message
   on it. Presence of the token means tclk/1; the value is the settlement rails the agent

--- a/SPEC.md
+++ b/SPEC.md
@@ -64,11 +64,14 @@ the public manual (`/llms.txt`), and any self-hosted deployment works identicall
   offline reader trusts the export file for it. Missing or malformed time fails closed — it
   never falls back to the auditor's current clock. A fold also enforces the room binding below:
   offer/accept records belong to `tclk-offers`; post-accept records belong to the contract's
-  derived deal room. A valid signature in the wrong room cannot advance state. A fold MAY be
-  run with the **offer-room fallback** (below), which additionally admits post-accept records
-  posted in `tclk-offers` — and nothing else: the sender must still be a party, the frame must
-  still name this contract, and every state guard still applies. Strict is the default; an
-  auditor SHOULD say which mode a verdict was produced under.
+  derived deal room. A valid signature in the wrong room cannot advance state. A fold MAY
+  instead be run in **offer-room mode** (below), which reads post-accept records from
+  `tclk-offers` *rather than* the derived room — one room or the other, never both, so the
+  verdict cannot depend on how two rooms' records were interleaved. Nothing else is relaxed:
+  the sender must still be a party, the frame must still name this contract, and every state
+  guard still applies. Strict is the default; an auditor SHOULD say which mode a verdict was
+  produced under. A fold in either mode establishes what was signed, not what was funded —
+  the rail is consulted separately.
 - **Rendezvous**: public offers rest in the room `tclk-offers` — an ordinary world-writable
   room with no class prefix, so the venue lists and announces it like any other. Two agents who
   have never met have nowhere else to find each other, so a deal cannot start without a
@@ -84,40 +87,20 @@ the public manual (`/llms.txt`), and any self-hosted deployment works identicall
   `p-` keeps it out of the room listing, but neither of those is privacy. Treat the transcript
   as public. A mailbox-delivered accept is the alternative when an offer's terms should not be
   public; the deal room is derived the same way either way.
-- **Offer-room fallback**: a venue can refuse to create the deal room — technocore answers
-  `400 room limit reached` for every new room once it is at its room cap, and the shared
-  deployment has been there since the day `tclk-offers` filled. Then no party can post in the
-  derived room, however conformant. In that case, and only then, post-accept frames MAY be
-  posted in `tclk-offers`, and a reader folding with the fallback accepts them there. This is
-  safe for the same reason the deal room was never a security boundary: the `contract` id in
-  every post-accept frame binds the full offer and acceptance, the machine rejects non-parties,
-  and the secret check is the transition guard — the room only ever bounded *who may write*.
-  The costs are real but bounded: board traffic grows, and a reader that stays strict sees
-  the contract stuck at `accepted`. Parties SHOULD still try the derived room first and fall
-  back on the venue's refusal, so that a venue with room to spare keeps its board clean.
-- **Capability advertisement**: an agent that speaks this protocol adds one token to its
-  venue DID note — `tclk1:<rail>,<rail>` — so a counterparty can tell before spending a message
-  on it. Presence of the token means tclk/1; the value is the settlement rails the agent
-  accepts. Like the rest of that note it proves nothing on its own — the note is world-writable
-  and forgeable, so treat it as a routing hint and let the first signed frame verifying against
-  the DID beside it be the proof. Getting it wrong costs a wasted message, never funds.
-- **State pointer**: a CAS-moved note `kv/tclk-<hh>/<14 hex>` (sharded off the contract id, like
-  the DID-note convention) holding the current status. It is a *coordination pointer*, not an
-  authority — the namespace is world-writable, so nothing may trust it; trust flows from signed
-  frames and the rail. Move it with `?if=` so two workers cannot both advance it.
-- **Known sharp edges, designed around**:
-  - *Duplicate filter* (422 on repeated ≥16-char texts): every offer/accept carries a random
-    `nonce`, so no two contracts serialize identically; within one contract each frame type
-    appears once per state transition.
-  - *Replay window* (a signed message URL becomes replayable once ~1 MiB of newer traffic buries
-    its nonce): the state machine is idempotent — a replayed frame is a no-op rejection, and
-    money never moves on a frame, only on the rail.
-  - *Retention* (rooms are a ring, reaped after 7 idle days; notes reaped too): the room is
-    coordination, not the record. Both parties persist frames they care about (`/export` gives
-    byte-exact re-verifiable JSONL) and the rail holds the money state. Deadlines longer than
-    the venue's retention are fine — they bind the rail, not the room.
-  - *Room epochs*: `seq` restarts if a room is reaped and recreated; contract ids are
-    self-contained hashes, never `room/seq` references, so nothing here dedupes on `seq`.
+- **Offer-room mode**: opening the derived room costs the payer one of its venue room
+  creations — technocore meters new rooms per client (`rate_rooms_per_day`, 20 on the shared
+  deployment) and refuses the twenty-first with `400 room limit reached (81920 is the cap, and
+  this would be a new one)`, a message that reads as if the venue were full when it is the
+  client's own budget. A payer refused this way MAY announce the lock in `tclk-offers` and
+  continue the deal there; a reader then folds the deal in offer-room mode. It is safe for the
+  same reason the deal room was never a security boundary: the `contract` id in every
+  post-accept frame binds the full offer and acceptance, the machine rejects non-parties, and
+  the secret check is the transition guard — the room only ever bounded *who may write*. The
+  costs are real: the board is a ~10 MiB ring, so a deal kept there is readable from the venue
+  for hours, not days, while a three-record derived room is not — offer-room mode restores
+  visibility, not durability. Parties SHOULD open the derived room whenever the venue lets them,
+  SHOULD NOT spend a room creation on a deal with no lock to announce, and SHOULD keep their
+  own copy of every record they care about at write time whichever room it went to.
 
 ## 3. Wire format
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -87,20 +87,45 @@ the public manual (`/llms.txt`), and any self-hosted deployment works identicall
   `p-` keeps it out of the room listing, but neither of those is privacy. Treat the transcript
   as public. A mailbox-delivered accept is the alternative when an offer's terms should not be
   public; the deal room is derived the same way either way.
-- **Offer-room mode**: opening the derived room costs the payer one of its venue room
-  creations — technocore meters new rooms per client (`rate_rooms_per_day`, 20 on the shared
-  deployment) and refuses the twenty-first with `400 room limit reached (81920 is the cap, and
-  this would be a new one)`, a message that reads as if the venue were full when it is the
-  client's own budget. A payer refused this way MAY announce the lock in `tclk-offers` and
-  continue the deal there; a reader then folds the deal in offer-room mode. It is safe for the
-  same reason the deal room was never a security boundary: the `contract` id in every
-  post-accept frame binds the full offer and acceptance, the machine rejects non-parties, and
-  the secret check is the transition guard — the room only ever bounded *who may write*. The
-  costs are real: the board is a ~10 MiB ring, so a deal kept there is readable from the venue
-  for hours, not days, while a three-record derived room is not — offer-room mode restores
-  visibility, not durability. Parties SHOULD open the derived room whenever the venue lets them,
-  SHOULD NOT spend a room creation on a deal with no lock to announce, and SHOULD keep their
-  own copy of every record they care about at write time whichever room it went to.
+- **Offer-room mode**: opening the derived room means creating a room, and a venue can refuse
+  that. technocore refuses for two reasons with two answers: a service-wide cap on rooms
+  (`400 <n> is the cap, and this would be a new one` — fail-closed at `max_rooms`, hit on the
+  shared deployment on 2026-09-03 until the operator raised the cap) and a per-client budget
+  (`429 room-creation budget spent` — `rate_rooms_per_day`, 20). Either way the payer has no
+  derived room to lock in, however conformant. A payer refused this way MAY announce the lock
+  in `tclk-offers` and continue the deal there; a reader then folds the deal in offer-room mode.
+  It is safe for the same reason the deal room was never a security boundary: the `contract`
+  id in every post-accept frame binds the full offer and acceptance, the machine rejects
+  non-parties, and the secret check is the transition guard — the room only ever bounded *who
+  may write*. The costs are real: the board is a ~10 MiB ring, so a deal kept there is readable
+  from the venue for hours, not days, while a three-record derived room is not — offer-room
+  mode restores visibility, not durability. Parties SHOULD open the derived room whenever the
+  venue lets them, SHOULD NOT spend a room creation on a deal with no lock to announce, and
+  SHOULD keep their own copy of every record they care about at write time whichever room it
+  went to.
+- **Capability advertisement**: an agent that speaks this protocol adds one token to its
+  venue DID note — `tclk1:<rail>,<rail>` — so a counterparty can tell before spending a message
+  on it. Presence of the token means tclk/1; the value is the settlement rails the agent
+  accepts. Like the rest of that note it proves nothing on its own — the note is world-writable
+  and forgeable, so treat it as a routing hint and let the first signed frame verifying against
+  the DID beside it be the proof. Getting it wrong costs a wasted message, never funds.
+- **State pointer**: a CAS-moved note `kv/tclk-<hh>/<14 hex>` (sharded off the contract id, like
+  the DID-note convention) holding the current status. It is a *coordination pointer*, not an
+  authority — the namespace is world-writable, so nothing may trust it; trust flows from signed
+  frames and the rail. Move it with `?if=` so two workers cannot both advance it.
+- **Known sharp edges, designed around**:
+  - *Duplicate filter* (422 on repeated ≥16-char texts): every offer/accept carries a random
+    `nonce`, so no two contracts serialize identically; within one contract each frame type
+    appears once per state transition.
+  - *Replay window* (a signed message URL becomes replayable once ~1 MiB of newer traffic buries
+    its nonce): the state machine is idempotent — a replayed frame is a no-op rejection, and
+    money never moves on a frame, only on the rail.
+  - *Retention* (rooms are a ring, reaped after 7 idle days; notes reaped too): the room is
+    coordination, not the record. Both parties persist frames they care about (`/export` gives
+    byte-exact re-verifiable JSONL) and the rail holds the money state. Deadlines longer than
+    the venue's retention are fine — they bind the rail, not the room.
+  - *Room epochs*: `seq` restarts if a room is reaped and recreated; contract ids are
+    self-contained hashes, never `room/seq` references, so nothing here dedupes on `seq`.
 
 ## 3. Wire format
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -250,7 +250,7 @@ export function createServer(options: HandlerOptions = {}): McpServer {
           .describe(
             "The one room post-accept frames are read from. `strict` (default): the derived " +
             "deal room. `offer-room`: `tclk-offers` instead, for a deal whose payer was refused " +
-            "a new room (per-client rate_rooms_per_day) and announced the lock on the board. " +
+            "a new room by the venue (cap or per-client budget) and announced the lock on the board. " +
             "Signatures, parties and state guards are unchanged; no rail is consulted.",
           ),
       },

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -244,6 +244,14 @@ export function createServer(options: HandlerOptions = {}): McpServer {
       annotations: READS,
       inputSchema: {
         records: z.array(transcriptRecord).describe("Complete room records, oldest first."),
+        roomBinding: z
+          .enum(["strict", "offer-room-fallback"])
+          .optional()
+          .describe(
+            "Where post-accept frames may live. `strict` (default): only the derived deal " +
+            "room. `offer-room-fallback`: also `tclk-offers`, for a venue that cannot create " +
+            "the deal room (room cap). Signatures, parties and state guards are unchanged.",
+          ),
       },
     },
     (args) => run(() => h.tclk_apply_transcript(args)),

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -245,12 +245,13 @@ export function createServer(options: HandlerOptions = {}): McpServer {
       inputSchema: {
         records: z.array(transcriptRecord).describe("Complete room records, oldest first."),
         roomBinding: z
-          .enum(["strict", "offer-room-fallback"])
+          .enum(["strict", "offer-room"])
           .optional()
           .describe(
-            "Where post-accept frames may live. `strict` (default): only the derived deal " +
-            "room. `offer-room-fallback`: also `tclk-offers`, for a venue that cannot create " +
-            "the deal room (room cap). Signatures, parties and state guards are unchanged.",
+            "The one room post-accept frames are read from. `strict` (default): the derived " +
+            "deal room. `offer-room`: `tclk-offers` instead, for a deal whose payer was refused " +
+            "a new room (per-client rate_rooms_per_day) and announced the lock on the board. " +
+            "Signatures, parties and state guards are unchanged; no rail is consulted.",
           ),
       },
     },

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -34,6 +34,7 @@ import {
   type OfferFrame,
   type PresigRef,
   type TclkFrame,
+  type RoomBinding,
   type TranscriptRecord,
 } from "@flop-labs/tclk";
 
@@ -256,8 +257,8 @@ export function createHandlers(options: HandlerOptions = {}) {
      * each record signature and sender binding, then applies its frame at that record's
      * venue timestamp. Every record gets a verdict and invalid input changes no state.
      */
-    tclk_apply_transcript(input: { records: TranscriptRecord[] }) {
-      const folded = foldTranscript(input.records);
+    tclk_apply_transcript(input: { records: TranscriptRecord[]; roomBinding?: RoomBinding }) {
+      const folded = foldTranscript(input.records, { roomBinding: input.roomBinding });
       if (folded.state === null) {
         const offerFailure = folded.steps.find((step) => step.type === "offer" && !step.ok);
         fail(

--- a/mcp/tests/transcript.test.ts
+++ b/mcp/tests/transcript.test.ts
@@ -150,7 +150,7 @@ describe("room binding", () => {
       ref: "escrow-45",
       secret: accept.secret,
     });
-    // Every record on the board, as on a venue that cannot create the deal room.
+    // Every record on the board, as when the payer was refused a new room.
     const board = records([offer.line, accept.line, lock.line, reveal.line], NOW).map(
       (rec, index) => {
         if (rec.room === "tclk-offers") return rec;
@@ -169,7 +169,7 @@ describe("room binding", () => {
     expect(strict.status).toBe("accepted");
     expect(strict.steps[2]).toMatchObject({ ok: false });
 
-    const relaxed = h.tclk_apply_transcript({ records: board, roomBinding: "offer-room-fallback" });
+    const relaxed = h.tclk_apply_transcript({ records: board, roomBinding: "offer-room" });
     expect(relaxed.steps.map((s) => s.ok)).toEqual([true, true, true, true]);
     expect(relaxed.status).toBe("claimed");
     expect(relaxed.secretRevealed).toBe(true);

--- a/mcp/tests/transcript.test.ts
+++ b/mcp/tests/transcript.test.ts
@@ -135,6 +135,48 @@ describe("refund path", () => {
   });
 });
 
+describe("room binding", () => {
+  it("passes roomBinding through so a board-only transcript can fold to claimed", () => {
+    const { offer, accept } = openDeal();
+    const lock = h.tclk_make_lock({
+      from: PAYER_DID,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-45",
+    });
+    const reveal = h.tclk_make_reveal({
+      from: PAYEE_DID,
+      contract: accept.contract,
+      ref: "escrow-45",
+      secret: accept.secret,
+    });
+    // Every record on the board, as on a venue that cannot create the deal room.
+    const board = records([offer.line, accept.line, lock.line, reveal.line], NOW).map(
+      (rec, index) => {
+        if (rec.room === "tclk-offers") return rec;
+        const signer = rec.sender === PAYEE_DID ? payee : payer;
+        const nonce = String(2000 + index);
+        return {
+          ...rec,
+          room: "tclk-offers",
+          nonce,
+          signature: signer.sign(canonicalMessage("tclk-offers", Number(nonce), rec.line)),
+        };
+      },
+    );
+
+    const strict = h.tclk_apply_transcript({ records: board });
+    expect(strict.status).toBe("accepted");
+    expect(strict.steps[2]).toMatchObject({ ok: false });
+
+    const relaxed = h.tclk_apply_transcript({ records: board, roomBinding: "offer-room-fallback" });
+    expect(relaxed.steps.map((s) => s.ok)).toEqual([true, true, true, true]);
+    expect(relaxed.status).toBe("claimed");
+    expect(relaxed.secretRevealed).toBe(true);
+    expect(JSON.stringify(relaxed)).not.toContain(accept.secret.slice(2));
+  });
+});
+
 describe("fail-closed folding", () => {
   it("gives garbage and out-of-turn frames a verdict, never a throw", () => {
     const { offer, accept } = openDeal();

--- a/mcp/worker/src/tool-manifest.generated.ts
+++ b/mcp/worker/src/tool-manifest.generated.ts
@@ -319,7 +319,7 @@ export const TOOLS: readonly ManifestTool[] = [
             "strict",
             "offer-room"
           ],
-          "description": "The one room post-accept frames are read from. `strict` (default): the derived deal room. `offer-room`: `tclk-offers` instead, for a deal whose payer was refused a new room (per-client rate_rooms_per_day) and announced the lock on the board. Signatures, parties and state guards are unchanged; no rail is consulted."
+          "description": "The one room post-accept frames are read from. `strict` (default): the derived deal room. `offer-room`: `tclk-offers` instead, for a deal whose payer was refused a new room by the venue (cap or per-client budget) and announced the lock on the board. Signatures, parties and state guards are unchanged; no rail is consulted."
         }
       },
       "required": [

--- a/mcp/worker/src/tool-manifest.generated.ts
+++ b/mcp/worker/src/tool-manifest.generated.ts
@@ -312,6 +312,14 @@ export const TOOLS: readonly ManifestTool[] = [
             "additionalProperties": false
           },
           "description": "Complete room records, oldest first."
+        },
+        "roomBinding": {
+          "type": "string",
+          "enum": [
+            "strict",
+            "offer-room-fallback"
+          ],
+          "description": "Where post-accept frames may live. `strict` (default): only the derived deal room. `offer-room-fallback`: also `tclk-offers`, for a venue that cannot create the deal room (room cap). Signatures, parties and state guards are unchanged."
         }
       },
       "required": [

--- a/mcp/worker/src/tool-manifest.generated.ts
+++ b/mcp/worker/src/tool-manifest.generated.ts
@@ -317,9 +317,9 @@ export const TOOLS: readonly ManifestTool[] = [
           "type": "string",
           "enum": [
             "strict",
-            "offer-room-fallback"
+            "offer-room"
           ],
-          "description": "Where post-accept frames may live. `strict` (default): only the derived deal room. `offer-room-fallback`: also `tclk-offers`, for a venue that cannot create the deal room (room cap). Signatures, parties and state guards are unchanged."
+          "description": "The one room post-accept frames are read from. `strict` (default): the derived deal room. `offer-room`: `tclk-offers` instead, for a deal whose payer was refused a new room (per-client rate_rooms_per_day) and announced the lock on the board. Signatures, parties and state guards are unchanged; no rail is consulted."
         }
       },
       "required": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export {
 } from "./transcript.js";
 export type {
   TranscriptRecord, TranscriptRecordVerification, TranscriptStep, TranscriptFoldResult,
-  ContractHandshake,
+  ContractHandshake, RoomBinding, FoldOptions,
 } from "./transcript.js";
 
 export { lockTerms, MemoryRail } from "./rail.js";

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -55,18 +55,25 @@ export interface TranscriptFoldResult {
 }
 
 /**
- * Where a fold lets post-accept frames live.
+ * Which single room a fold reads post-accept frames from. Exactly one, in either mode —
+ * admitting both rooms would leave the result depending on how the caller interleaved two
+ * independent streams (per-room `seq`, millisecond timestamps that can tie), so signed
+ * evidence would no longer determine one state.
  *
  * - `"strict"` — SPEC §2 as first written: post-accept frames only in the contract's derived
- *   deal room. The default, and what an auditor with their own venue should use.
- * - `"offer-room-fallback"` — additionally accepts post-accept frames posted in `tclk-offers`.
- *   The shared venue refuses every new room once it is at its room cap (`400 room limit
- *   reached`), so nobody there can create the derived deal room; the whole live board posts
- *   lock/reveal/refund/receipt on the offer room instead, and a strict fold sees every one of
- *   those contracts stuck at `accepted`. The fallback never relaxes anything else: the frame
- *   still has to be signed by a party, name this contract, and pass the state guards.
+ *   deal room. The default.
+ * - `"offer-room"` — post-accept frames only in `tclk-offers`; a frame in the derived room is
+ *   rejected like any other wrong-room frame. For deals whose payer could not open the derived
+ *   room — technocore refuses new rooms per client at `rate_rooms_per_day` (20) with a 400
+ *   that reads as if the venue were full — and so announced the lock on the board instead.
+ *
+ * Neither mode relaxes anything but the room: the frame still has to be signed by a party,
+ * name this contract, and pass the state guards. Neither consults a settlement rail — a fold
+ * says what the signed transcript establishes, not that anything was funded. And the board
+ * is a ~10 MiB ring: a deal kept there stops being verifiable from the venue within hours,
+ * so `"offer-room"` restores visibility, not durability.
  */
-export type RoomBinding = "strict" | "offer-room-fallback";
+export type RoomBinding = "strict" | "offer-room";
 
 export interface FoldOptions {
   roomBinding?: RoomBinding;
@@ -257,7 +264,7 @@ export function foldTranscript(
   options: FoldOptions = {},
 ): TranscriptFoldResult {
   const roomBinding: RoomBinding = options.roomBinding ?? "strict";
-  if (roomBinding !== "strict" && roomBinding !== "offer-room-fallback") {
+  if (roomBinding !== "strict" && roomBinding !== "offer-room") {
     throw new Error(`tclk: unknown roomBinding ${JSON.stringify(roomBinding)}`);
   }
   const steps: TranscriptStep[] = [];
@@ -314,21 +321,18 @@ export function foldTranscript(
       return;
     }
 
+    // Offer/accept always belong to the board; post-accept frames belong to exactly one
+    // room chosen by the mode. A frame anywhere else is rejected, in either mode.
     const expectedRoom =
       frame.type === "offer" || frame.type === "accept" || state.contract === undefined
         ? OFFER_ROOM
-        : dealRoom(state.contract);
-    // The fallback admits the offer room for post-accept frames; a frame in any other
-    // room is still rejected, and offer/accept never move off the board.
-    const roomOk =
-      record.room === expectedRoom ||
-      (roomBinding === "offer-room-fallback" && record.room === OFFER_ROOM);
-    if (!roomOk) {
+        : roomBinding === "offer-room"
+          ? OFFER_ROOM
+          : dealRoom(state.contract);
+    if (record.room !== expectedRoom) {
       const where = expectedRoom === OFFER_ROOM
         ? OFFER_ROOM
-        : roomBinding === "offer-room-fallback"
-          ? `the derived deal room ${expectedRoom} or ${OFFER_ROOM}`
-          : `the derived deal room ${expectedRoom}`;
+        : `the derived deal room ${expectedRoom}`;
       steps.push({
         ...base,
         type: frame.type,

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -54,6 +54,24 @@ export interface TranscriptFoldResult {
   steps: TranscriptStep[];
 }
 
+/**
+ * Where a fold lets post-accept frames live.
+ *
+ * - `"strict"` — SPEC §2 as first written: post-accept frames only in the contract's derived
+ *   deal room. The default, and what an auditor with their own venue should use.
+ * - `"offer-room-fallback"` — additionally accepts post-accept frames posted in `tclk-offers`.
+ *   The shared venue refuses every new room once it is at its room cap (`400 room limit
+ *   reached`), so nobody there can create the derived deal room; the whole live board posts
+ *   lock/reveal/refund/receipt on the offer room instead, and a strict fold sees every one of
+ *   those contracts stuck at `accepted`. The fallback never relaxes anything else: the frame
+ *   still has to be signed by a party, name this contract, and pass the state guards.
+ */
+export type RoomBinding = "strict" | "offer-room-fallback";
+
+export interface FoldOptions {
+  roomBinding?: RoomBinding;
+}
+
 export interface ContractHandshake {
   offer: TranscriptRecord;
   accept: TranscriptRecord;
@@ -231,9 +249,17 @@ export function findContractHandshake(
  * Authenticate and fold records in the supplied order. Every record gets a verdict;
  * invalid signatures, forged `from` fields, wrong rooms, malformed lines and bad
  * transitions are rejected without changing state. Deadline guards use that record's
- * venue timestamp.
+ * venue timestamp. `options.roomBinding` selects how the room binding is enforced
+ * (see RoomBinding); the default is strict.
  */
-export function foldTranscript(records: readonly TranscriptRecord[]): TranscriptFoldResult {
+export function foldTranscript(
+  records: readonly TranscriptRecord[],
+  options: FoldOptions = {},
+): TranscriptFoldResult {
+  const roomBinding: RoomBinding = options.roomBinding ?? "strict";
+  if (roomBinding !== "strict" && roomBinding !== "offer-room-fallback") {
+    throw new Error(`tclk: unknown roomBinding ${JSON.stringify(roomBinding)}`);
+  }
   const steps: TranscriptStep[] = [];
   let state: ContractState | null = null;
 
@@ -292,10 +318,17 @@ export function foldTranscript(records: readonly TranscriptRecord[]): Transcript
       frame.type === "offer" || frame.type === "accept" || state.contract === undefined
         ? OFFER_ROOM
         : dealRoom(state.contract);
-    if (record.room !== expectedRoom) {
+    // The fallback admits the offer room for post-accept frames; a frame in any other
+    // room is still rejected, and offer/accept never move off the board.
+    const roomOk =
+      record.room === expectedRoom ||
+      (roomBinding === "offer-room-fallback" && record.room === OFFER_ROOM);
+    if (!roomOk) {
       const where = expectedRoom === OFFER_ROOM
         ? OFFER_ROOM
-        : `the derived deal room ${expectedRoom}`;
+        : roomBinding === "offer-room-fallback"
+          ? `the derived deal room ${expectedRoom} or ${OFFER_ROOM}`
+          : `the derived deal room ${expectedRoom}`;
       steps.push({
         ...base,
         type: frame.type,

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -64,8 +64,8 @@ export interface TranscriptFoldResult {
  *   deal room. The default.
  * - `"offer-room"` — post-accept frames only in `tclk-offers`; a frame in the derived room is
  *   rejected like any other wrong-room frame. For deals whose payer could not open the derived
- *   room — technocore refuses new rooms per client at `rate_rooms_per_day` (20) with a 400
- *   that reads as if the venue were full — and so announced the lock on the board instead.
+ *   room — a venue can refuse a new room outright (service-wide cap, `400`) or per client
+ *   (`rate_rooms_per_day`, `429`) — and so announced the lock on the board instead.
  *
  * Neither mode relaxes anything but the room: the frame still has to be signed by a party,
  * name this contract, and pass the state guards. Neither consults a settlement rail — a fold

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -151,10 +151,10 @@ describe("trusted transcript records", () => {
     });
   });
 
-  it("admits post-accept frames on the offer room only under the offer-room fallback", () => {
-    // What the whole live board does: the venue is at its room cap, so the derived deal room
-    // cannot be created and lock/reveal land in tclk-offers. Strict stays strict; the
-    // fallback folds the same records to claimed.
+  it("reads post-accept frames from the board only in offer-room mode", () => {
+    // A payer refused a new room by the venue's per-client rate_rooms_per_day announces the
+    // lock on tclk-offers. Strict stays strict; offer-room mode folds the same records to
+    // claimed.
     const { lock, offer, accept } = deal();
     const lockFrame = {
       type: "lock" as const,
@@ -184,13 +184,48 @@ describe("trusted transcript records", () => {
       reason: expect.stringMatching(/derived deal room/),
     });
 
-    const relaxed = foldTranscript(records, { roomBinding: "offer-room-fallback" });
+    const relaxed = foldTranscript(records, { roomBinding: "offer-room" });
     expect(relaxed.steps.map((step) => step.ok)).toEqual([true, true, true, true]);
     expect(relaxed.state?.status).toBe("claimed");
     expect(relaxed.state?.secret).toBe(lock.preimage);
+
+    // One room per mode: in offer-room mode the derived room is the wrong room.
+    const mixed = foldTranscript(
+      [records[0], records[1], record(dealRoom(accept.contract), 1, NOW + 1, payer, encodeFrame(lockFrame))],
+      { roomBinding: "offer-room" },
+    );
+    expect(mixed.state?.status).toBe("accepted");
+    expect(mixed.steps[2]).toMatchObject({ ok: false, reason: "lock must be posted in tclk-offers" });
   });
 
-  it("keeps every other guard under the fallback", () => {
+  it("gives one answer regardless of how two rooms' records are interleaved", () => {
+    // Regression for the review on #62: a valid payer cancel on the board and a valid payer
+    // lock in the derived room, same millisecond. With both rooms admitted the verdict would
+    // depend on caller order; with one room per mode it does not.
+    const { offer, accept } = deal();
+    const lockFrame = {
+      type: "lock" as const,
+      from: payer.did,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-tie",
+    };
+    const cancel = { type: "cancel" as const, from: payer.did, contract: accept.contract };
+    const board = [
+      record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+      record(BOARD, 2, NOW, payee, encodeFrame(accept)),
+    ];
+    const cancelOnBoard = record(BOARD, 3, NOW + 1, payer, encodeFrame(cancel));
+    const lockInRoom = record(dealRoom(accept.contract), 1, NOW + 1, payer, encodeFrame(lockFrame));
+
+    for (const tail of [[cancelOnBoard, lockInRoom], [lockInRoom, cancelOnBoard]]) {
+      expect(foldTranscript([...board, ...tail]).state?.status).toBe("locked");
+      expect(foldTranscript([...board, ...tail], { roomBinding: "offer-room" }).state?.status)
+        .toBe("cancelled");
+    }
+  });
+
+  it("keeps every other guard in offer-room mode", () => {
     const { lock, offer, accept } = deal();
     const lockFrame = {
       type: "lock" as const,
@@ -222,12 +257,12 @@ describe("trusted transcript records", () => {
         record(BOARD, 5, NOW + 3, stranger, encodeFrame(strangerReveal)),
         record(BOARD, 6, NOW + 4, payee, encodeFrame(wrongSecret)),
       ],
-      { roomBinding: "offer-room-fallback" },
+      { roomBinding: "offer-room" },
     );
 
     expect(folded.steps[2]).toMatchObject({
       ok: false,
-      reason: expect.stringMatching(/derived deal room .* or tclk-offers/),
+      reason: "lock must be posted in tclk-offers",
     });
     expect(folded.steps[3]).toMatchObject({ ok: true, type: "lock" });
     expect(folded.steps[4]).toMatchObject({ ok: false, reason: "only the payee reveals" });
@@ -243,7 +278,7 @@ describe("trusted transcript records", () => {
         record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
         record(dealRoom(accept.contract), 1, NOW, payee, encodeFrame(accept)),
       ],
-      { roomBinding: "offer-room-fallback" },
+      { roomBinding: "offer-room" },
     );
     expect(offRoomAccept.state?.status).toBe("proposed");
     expect(offRoomAccept.steps[1]).toMatchObject({

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -151,6 +151,109 @@ describe("trusted transcript records", () => {
     });
   });
 
+  it("admits post-accept frames on the offer room only under the offer-room fallback", () => {
+    // What the whole live board does: the venue is at its room cap, so the derived deal room
+    // cannot be created and lock/reveal land in tclk-offers. Strict stays strict; the
+    // fallback folds the same records to claimed.
+    const { lock, offer, accept } = deal();
+    const lockFrame = {
+      type: "lock" as const,
+      from: payer.did,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-on-the-board",
+    };
+    const reveal = {
+      type: "reveal" as const,
+      from: payee.did,
+      contract: accept.contract,
+      ref: "escrow-on-the-board",
+      secret: lock.preimage,
+    };
+    const records = [
+      record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+      record(BOARD, 2, NOW, payee, encodeFrame(accept)),
+      record(BOARD, 3, NOW + 1, payer, encodeFrame(lockFrame)),
+      record(BOARD, 4, NOW + 2, payee, encodeFrame(reveal)),
+    ];
+
+    const strict = foldTranscript(records);
+    expect(strict.state?.status).toBe("accepted");
+    expect(strict.steps[2]).toMatchObject({
+      ok: false,
+      reason: expect.stringMatching(/derived deal room/),
+    });
+
+    const relaxed = foldTranscript(records, { roomBinding: "offer-room-fallback" });
+    expect(relaxed.steps.map((step) => step.ok)).toEqual([true, true, true, true]);
+    expect(relaxed.state?.status).toBe("claimed");
+    expect(relaxed.state?.secret).toBe(lock.preimage);
+  });
+
+  it("keeps every other guard under the fallback", () => {
+    const { lock, offer, accept } = deal();
+    const lockFrame = {
+      type: "lock" as const,
+      from: payer.did,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-44",
+    };
+    const strangerReveal = {
+      type: "reveal" as const,
+      from: stranger.did,
+      contract: accept.contract,
+      ref: "escrow-44",
+      secret: lock.preimage,
+    };
+    const wrongSecret = {
+      type: "reveal" as const,
+      from: payee.did,
+      contract: accept.contract,
+      ref: "escrow-44",
+      secret: `0x${"00".repeat(32)}`,
+    };
+    const folded = foldTranscript(
+      [
+        record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+        record(BOARD, 2, NOW, payee, encodeFrame(accept)),
+        record("lobby", 3, NOW + 1, payer, encodeFrame(lockFrame)),
+        record(BOARD, 4, NOW + 2, payer, encodeFrame(lockFrame)),
+        record(BOARD, 5, NOW + 3, stranger, encodeFrame(strangerReveal)),
+        record(BOARD, 6, NOW + 4, payee, encodeFrame(wrongSecret)),
+      ],
+      { roomBinding: "offer-room-fallback" },
+    );
+
+    expect(folded.steps[2]).toMatchObject({
+      ok: false,
+      reason: expect.stringMatching(/derived deal room .* or tclk-offers/),
+    });
+    expect(folded.steps[3]).toMatchObject({ ok: true, type: "lock" });
+    expect(folded.steps[4]).toMatchObject({ ok: false, reason: "only the payee reveals" });
+    expect(folded.steps[5]).toMatchObject({
+      ok: false,
+      reason: "secret does not open the statement",
+    });
+    expect(folded.state?.status).toBe("locked");
+
+    // An offer or accept never moves off the board, in either mode.
+    const offRoomAccept = foldTranscript(
+      [
+        record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+        record(dealRoom(accept.contract), 1, NOW, payee, encodeFrame(accept)),
+      ],
+      { roomBinding: "offer-room-fallback" },
+    );
+    expect(offRoomAccept.state?.status).toBe("proposed");
+    expect(offRoomAccept.steps[1]).toMatchObject({
+      ok: false,
+      reason: "accept must be posted in tclk-offers",
+    });
+
+    expect(() => foldTranscript([], { roomBinding: "lenient" as never })).toThrow(/roomBinding/);
+  });
+
   it("rejects unsigned records and malformed timestamps without a fallback clock", () => {
     const { offer } = deal();
     const unsigned = record(BOARD, 1, NOW, payer, encodeFrame(offer));


### PR DESCRIPTION
## What

`foldTranscript(records)` derives which single room post-accept frames are read from, from the records themselves: the contract's derived deal room binds whenever it holds a post-accept record that authenticates, is signed by a party of that contract and names it; `tclk-offers` binds only where the derived room holds none. `TranscriptFoldResult` and `tclk_apply_transcript` report the `roomBinding` a verdict was produced under, plus `equivocation` when parties signed post-accept records in both rooms. There is no caller option: `foldTranscript` takes records and nothing else, and `tclk_apply_transcript` takes `records` and nothing else.

Only the room moves. Signature, sender binding, party checks, contract id and every state guard still apply; offer/accept must still be on the board; no rail is consulted.

## Why

Follows #61. Opening the derived room means creating a room, and the venue can refuse that — service-wide cap (`400 … is the cap`, fail-closed; what technocore.chat returned on 2026-09-03 until the cap was raised) or per-client budget (`429 room-creation budget spent`, `rate_rooms_per_day: 20`). A payer refused either way announces the lock on the board, and a strict fold then reads that deal as `accepted` forever. The code implemented SPEC §2 faithfully; the **spec** had no rule for the refused payer, so SPEC §2 is amended and the code follows it — including that parties SHOULD open the derived room whenever they can (the board is a ring; the board restores visibility, not durability).

The binding is derived rather than selected because a mode is not evidence. As a caller option it was chosen after the records were known, so one authenticated record set had two mutually exclusive terminal states — `locked` under strict, `cancelled` under offer-room — and whoever ran the fold could present the favorable one. Deriving it from the records removes the choice: a stranger writing in either room is not evidence and moves nothing, and a party can no longer shop the mode.

Where both rooms hold party-signed post-accept records, the derived room wins and the fold reports `equivocation` rather than refusing a verdict. Refusing one would hand either party a veto over any deal going against them: post one contradicting frame in the other room and no fold could ever conclude. The wrong-room step says so in its reason, so the misbehaviour is visible in the steps as well as on the result.

History of this PR: v1 claimed the venue was permanently full and that no deal used a derived room (wrong), and admitted both rooms (non-deterministic, per review). v2 gave each mode exactly one room, which fixed caller order but left the mode a caller choice. v3 corrects the refusal wording to name both mechanisms. v4 removes the option and derives the binding.

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` — 108 root, 42 mcp, 33 worker
- [x] `pnpm check:protocol` clean; golden vectors untouched; wire format did not move
- [x] `CHANGELOG.md` has an `[Unreleased]` entry
- [x] Docs: `SPEC.md` §2 states the derivation, the precedence and its reason, and that one authenticated record set MUST fold to one state. `README.md`/`mcp/README.md`/`mcp/worker/README.md`/`AGENTS.md` state no room rule, so none is now wrong. Worker manifest regenerated with `gen:worker-manifest`
- [x] Regression per review: the tie case (payer `cancel` on the board, payer `lock` in the derived room, same millisecond) goes through both public entry points in both orders and requires one identical outcome — `locked`, `roomBinding: "strict"`, `equivocation: true`
- [x] New surface on the money path: nothing new — a hostile counterparty gets only a different single room to be read from, and cannot move the binding without being a party. The frame must still be signed by a party, name this contract and pass the guards (pinned by tests for a foreign room, a non-party reveal, a wrong secret, an off-board accept, a stranger writing in each room, and the cross-room tie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
