### PR TITLE
fix(hex): refuse every non-hex input, and stop echoing the rejected v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `hexToU8a` is fail-closed again for every input `isHex` rejects. It silently returned an
+  empty array for `""`, the one non-hex input it accepted, so a caller that length-checked
+  the result could not tell zero bytes from a malformed argument; `0x` remains the spelling
+  for zero bytes. Its refusal now reports the input's length instead of quoting it, matching
+  the no-echo rule `mcp/src/signing.ts` already states — `hashLockFromPreimage` and
+  `pointLockFromWitness` decode secret preimages and witnesses through this function, and the
+  old message put a rejected secret into whatever log caught the throw.
 - `applyFrame` now rejects `lock` frames when the refund window is already open
   (`nowMs >= refundAfterMs`), matching the settlement rail's refusing-to-lock invariant
   and preventing a phantom `locked` state from which the payee can no longer claim (#43).

--- a/src/hex.ts
+++ b/src/hex.ts
@@ -31,10 +31,22 @@ export function u8aToHex(value: Uint8Array): string {
   return out;
 }
 
-/** Decode `0x`-hex to bytes. Throws on non-hex or odd-length input (fail-closed). */
+/**
+ * Decode `0x`-hex to bytes. Throws on non-hex or odd-length input (fail-closed).
+ *
+ * `0x` is the spelling for zero bytes; `""` is not hex and is refused like any other
+ * malformed input. The refusal carries the input's length, never its value —
+ * `hashLockFromPreimage` and `pointLockFromWitness` decode secret preimages and
+ * witnesses through here, and an echoed secret lands in whatever log catches the throw.
+ */
 export function hexToU8a(value: string): Uint8Array {
-  if (!value) return new Uint8Array();
-  if (!isHex(value)) throw new Error(`Expected hex value to convert, found '${value}'`);
+  if (!isHex(value)) {
+    // `isHex` is a type guard, so it narrows `value` to `never` in this branch; widen it
+    // back, because untyped callers can still reach this line with a non-string.
+    const seen = value as unknown;
+    const shape = typeof seen === "string" ? `${seen.length} chars` : typeof seen;
+    throw new Error(`tclk: expected 0x-prefixed even-length hex, got ${shape}`);
+  }
   const body = value.slice(2);
   const out = new Uint8Array(body.length / 2);
   for (let i = 0; i < out.length; i++) {

--- a/tests/hex.test.ts
+++ b/tests/hex.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the `hexToU8a` fail-closed boundary.
+ *
+ * `hex.ts` documents `hexToU8a` as throwing on anything `isHex` rejects. Two properties
+ * hold that boundary up, and both are load-bearing for callers that decode secrets:
+ * every non-hex input is refused (no silent empty array), and the refusal describes the
+ * input's shape rather than quoting it.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { hexToU8a, isHex, u8aToHex } from "../src/hex.js";
+import { hashLockFromPreimage, pointLockFromWitness } from "../src/index.js";
+
+const ODD = "0x0a1";
+const SECRET_ODD = "0x" + "de".repeat(31) + "a";
+
+describe("hexToU8a", () => {
+  it("decodes `0x` to zero bytes", () => {
+    expect(hexToU8a("0x")).toEqual(new Uint8Array());
+    expect(u8aToHex(hexToU8a("0x"))).toBe("0x");
+  });
+
+  it("round-trips through u8aToHex", () => {
+    const hex = "0x" + "00ff7f80".repeat(4);
+    expect(u8aToHex(hexToU8a(hex))).toBe(hex);
+  });
+
+  it("throws on every input isHex rejects", () => {
+    for (const bad of ["", "0", "ff", "0X00", ODD, "0xzz", "0x 00", " 0x00"]) {
+      expect(isHex(bad)).toBe(false);
+      expect(() => hexToU8a(bad)).toThrow();
+    }
+  });
+
+  it("refuses the empty string rather than returning an empty array", () => {
+    // `0x` is the spelling for zero bytes. `""` is not hex, and decoding it to the same
+    // value would make the two indistinguishable to a caller that only checks length.
+    expect(() => hexToU8a("")).toThrow();
+  });
+
+  it("never echoes the input in the refusal", () => {
+    expect(() => hexToU8a(SECRET_ODD)).toThrow(/65 chars/);
+    try {
+      hexToU8a(SECRET_ODD);
+      expect.unreachable("expected a throw");
+    } catch (err) {
+      expect(String(err)).not.toContain("de");
+      expect(String(err)).not.toContain(SECRET_ODD);
+    }
+  });
+
+  it("survives a non-string from untyped callers", () => {
+    expect(() => hexToU8a(undefined as unknown as string)).toThrow(/undefined/);
+    expect(() => hexToU8a(null as unknown as string)).toThrow();
+  });
+});
+
+describe("secret-decoding callers stay fail-closed", () => {
+  it("refuses a malformed preimage without quoting it", () => {
+    expect(() => hashLockFromPreimage(SECRET_ODD)).toThrow();
+    expect(() => hashLockFromPreimage(SECRET_ODD)).not.toThrow(/de/);
+  });
+
+  it("refuses a malformed witness without quoting it", () => {
+    expect(() => pointLockFromWitness(SECRET_ODD)).toThrow();
+    expect(() => pointLockFromWitness(SECRET_ODD)).not.toThrow(/de/);
+  });
+});


### PR DESCRIPTION
## What

`hexToU8a` now throws on every input `isHex` rejects, and its refusal reports the input's
length instead of quoting it. `0x` is still the spelling for zero bytes and still decodes to an
empty array; `""` no longer does. `hex.ts` is internal — the barrel does not re-export it — so
the public API is unchanged.

## Why

Two holes in the fail-closed boundary `hex.ts` documents for itself.

`if (!value) return new Uint8Array()` accepted `""`, the one non-hex input that got a silent
empty array rather than a throw — indistinguishable from `0x` to a caller that length-checks
the result.

The refusal also embedded the value. `hashLockFromPreimage` and `pointLockFromWitness` decode
secret preimages and witnesses through this function, outside any catch, so a rejected secret
reached whatever log caught the throw. `mcp/src/signing.ts` states the opposite rule for the
same class of value — "the message never echoes the value" — and reports lengths only.
`hex.ts` was the one place that did not.

No caller depended on the old return; the surrounding length and `isHex`/`HEX32` guards already
rejected it. Eight tests cover the boundary, six fail on the old implementation.

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` — 101 / 34 / 31 pass
- [x] Golden vectors untouched
- [x] `CHANGELOG.md` has an `[Unreleased]` entry
- [x] No doc contradicts this — `hex.ts`'s own header already described this behaviour
- [x] New surface on the money path: nothing new. Strictly narrows what is accepted, and
      removes a secret from an error string.