### PR TITLE
fix(frames): decode enforces the single-line ASCII rule the encoder already does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,17 @@ All notable changes to this project are documented here. Format follows
   longer line was never a stored room message. The check runs before `JSON.parse`, which bounds
   what one row of an untrusted `/export` can cost a `foldTranscript` call. No wire bytes move
   and no golden vector changes.
+- `decodeFrame` now also enforces the other two clauses of that same SPEC §2 sentence, single
+  line and ASCII-only, which `encodeFrame` has always enforced and the decoder took on faith.
+  A line carrying a control or format character is not the line its sender signed — technocore
+  sweeps those to a space before storing — and a line carrying a raw non-ASCII character has an
+  `id` that commits to different bytes than the line itself, because §3 hashes the ASCII-escaped
+  form. Both used to decode, and re-encoding either produced a line that no longer matched the
+  signature a reader had just verified. Emission is unchanged, the guard is now one definition
+  used by both halves of the codec, and no frame the reference has ever emitted is affected:
+  none of the 10,063 `tclk1 ` lines stored in the live `/r/tclk-offers` room carries a byte
+  outside printable ASCII. Decode still deliberately accepts non-canonical key order, which
+  real stored frames do carry.
 - Adaptor scalar parsing now rejects zero and out-of-range values instead of reducing them
   modulo the curve order, matching point-lock witness validation and preventing distinct
   byte strings from being treated as the same scalar (#27).

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -25,6 +25,12 @@ export const TCLK_PREFIX = "tclk1 " as const;
 export const TCLK_DOMAIN = "FLOP::tclk::v1" as const;
 /** Technocore's message cap: a frame must fit one single-line room message. */
 export const MAX_FRAME_CHARS = 4096;
+/**
+ * The other half of SPEC §2's frame sentence: single line, ASCII-only. One definition, used
+ * by both halves of the codec — the encoder must not emit a line the venue would sweep, and
+ * the decoder must not accept one, because such a line was never the line a sender signed.
+ */
+const PRINTABLE_ASCII = /^[\x20-\x7e]*$/;
 
 export type LockKind = "hash" | "point";
 
@@ -469,7 +475,7 @@ export function encodeFrame(frame: TclkFrame): string {
   }
   // Sweep guard: technocore replaces controls/format chars with spaces before storing,
   // which would silently change the bytes a reader re-verifies. Refuse to emit them.
-  if (!/^[\x20-\x7e]*$/.test(line)) fail("frame line contains non-printable-ASCII characters");
+  if (!PRINTABLE_ASCII.test(line)) fail("frame line contains non-printable-ASCII characters");
   return line;
 }
 
@@ -482,6 +488,12 @@ export function decodeFrame(text: string): TclkFrame {
   if (text.length > MAX_FRAME_CHARS) {
     fail(`frame exceeds the ${MAX_FRAME_CHARS}-char room-message cap (${text.length})`);
   }
+  // Single-line and ASCII-only are properties of a frame too, from the same §2 sentence as
+  // the cap. A line carrying a control or format char is not the line its sender signed —
+  // the venue swept it to a space before storing — and a raw non-ASCII char makes the id
+  // commit to bytes the line does not carry, since the id hashes the escaped form (§3).
+  // Before the parse, for the same reason the cap is.
+  if (!PRINTABLE_ASCII.test(text)) fail("frame line contains non-printable-ASCII characters");
   let parsed: unknown;
   try {
     parsed = JSON.parse(text.slice(TCLK_PREFIX.length));

--- a/tests/live-wire-conformance.test.ts
+++ b/tests/live-wire-conformance.test.ts
@@ -260,4 +260,41 @@ describe("live-wire conformance gaps", () => {
     const megabyte = `${TCLK_PREFIX}${canonicalJson(beat("x".repeat(1_000_000)))}`;
     expect(tryDecodeFrame(megabyte)).toBeNull();
   });
+
+  it("refuses a line that is not single-line ASCII, on decode as well as encode", () => {
+    const beat = (note: string) => ({
+      type: "heartbeat" as const,
+      from: PAYER,
+      contract: "0x" + "11".repeat(32),
+      nonce: "0123456789abcdef",
+      note,
+    });
+
+    // Escaping is what makes a non-ASCII note emittable: the wire line stays printable ASCII
+    // and round-trips, which is the case the guard must not touch.
+    const accented = beat("café");
+    const escaped = encodeFrame(accented);
+    expect(escaped).toContain("\\u00e9");
+    expect(/^[\x20-\x7e]*$/.test(escaped)).toBe(true);
+    expect(decodeFrame(escaped)).toEqual(accented);
+
+    // The same frame with the character raw instead of escaped is a different line. The
+    // encoder refuses to emit it; decode must refuse it too, because the id hashes the
+    // escaped form (§3), so this line's own bytes are not the bytes its id commits to.
+    const raw = `${TCLK_PREFIX}${canonicalJson(accented)}`;
+    expect(raw).not.toBe(escaped);
+    expect(() => decodeFrame(raw)).toThrow(/non-printable-ASCII/);
+    expect(tryDecodeFrame(raw)).toBeNull();
+
+    // DEL is ASCII, so escaping leaves it alone: both halves have to catch it by the guard.
+    const del = beat("a\x7fb");
+    expect(() => encodeFrame(del)).toThrow(/non-printable-ASCII/);
+    expect(() => decodeFrame(`${TCLK_PREFIX}${canonicalJson(del)}`)).toThrow(/non-printable-ASCII/);
+
+    // "Single line" is the third clause of the same §2 sentence, and JSON.parse would other-
+    // wise take a newline as insignificant whitespace between tokens.
+    const multiline = `${TCLK_PREFIX}${canonicalJson(beat("ok")).replace(/,/, ",\n")}`;
+    expect(() => decodeFrame(multiline)).toThrow(/non-printable-ASCII/);
+    expect(tryDecodeFrame(multiline)).toBeNull();
+  });
 });


### PR DESCRIPTION
## What

`decodeFrame` now enforces the single-line and ASCII-only clauses of SPEC §2's frame sentence.
`encodeFrame` has always enforced them; the decoder took them on faith.

## Why

§2 states three properties of a frame in one sentence:

> **Frames are room messages**: one frame per message, single line, ≤ 4096 chars, ASCII-only
> (technocore stores code points verbatim but sweeps controls/format chars; ASCII-escaping the
> JSON makes the stored bytes equal the signed bytes …)

#60 brought the decoder to the cap clause. The other two were emission-only, and two distinct
things go wrong with a line that violates them.

**A control or format character is not what the sender signed.** technocore sweeps those to a
space before storing, so the line the decoder is handed was never the stored line. The
encoder's own guard says this in a comment — only the encoder consulted it.

**A raw non-ASCII character makes the `id` commit to bytes the line does not carry.** §3 hashes
the ASCII-escaped form, deliberately, "the same bytes `encodeFrame` puts on the wire". So the
raw and escaped spellings of one offer decode to the same frame with the same `id`, and
`encodeFrame(decodeFrame(line))` hands back a *different* line than the one whose signature a
reader has just verified.

Measured on `main` (`d48e873`), one offer whose `job.id` is `café`:

| line | `encodeFrame` | `decodeFrame` |
|---|---|---|
| `…"id":"caf\u00e9"…` (escaped — what we emit) | emits it | decodes it |
| `…"id":"café"…` (the same char, raw) | refuses: `non-printable-ASCII` | **returns the offer, id matches** |
| `…"id":"a<DEL>b"…` (raw 0x7f) | refuses: `non-printable-ASCII` | **returns the offer, id matches** |
| `{"contract":…,<LF>"from":…}` (newline between tokens) | n/a | **returns the frame** |

DEL is the case neither half of the encoding closes on its own: `JSON.stringify` escapes
0x00–0x1f, `toAscii` escapes 0x80 and up, and 0x7f sits between them. Only the guard catches
it — which is why the encoder needed the guard, and why the decoder needs the same one.

The guard is now one definition used by both halves of the codec, checked before `JSON.parse`
for the same reason the cap is: it bounds what one row of an untrusted `/export` costs a fold.
Emission is unchanged.

**Nothing that was ever posted regresses.** I exported the live `/r/tclk-offers` room
(12,533 messages, 10,063 `tclk1 ` lines, 9,376 decoding today) and counted:

```
carrying a byte outside printable ASCII   : 0
...and that decode today (would regress)  : 0
```

Zero, because a line that carried one could not have been stored verbatim — the sweep would
have replaced it first.

**What I deliberately did not do.** This tightens the wire form's byte class, not its
canonicity. Decode still accepts non-canonical key order, and that is not an oversight: two of
those 9,376 stored frames carry unsorted keys from another implementation (`tclk-offers` seq
4554 and 5671, both `lock` frames spelling `{"type":…,"from":…}`), so requiring byte-exact
canonicity would break replay of real deals. That is a spec question, not this fix.

I treated SPEC §2 as correct and brought the decoder to it, the same way #60 did for the third
clause of the same sentence.

**What a hostile counterparty gets from this:** nothing new. It is a refusal added to a path
that previously accepted more, and `tryDecodeFrame` still returns `null` rather than throwing,
so a hostile line in a mixed room still cannot break a reader.

## Checks

`main` at `d48e873`. No golden vector changes; no wire bytes move; `src/` diff is +13/-1.

```
pnpm install --frozen-lockfile
pnpm -r --include-workspace-root build
pnpm -r --include-workspace-root test
```

- 105 library (was 104) + 37 mcp + 31 worker = 173 passed, 0 failed.
- Both directions: reverting the `src/frames.ts` decode hunk alone and leaving the test gives
  `Test Files 1 failed | 8 passed`, `Tests 1 failed | 104 passed`, the failure being
  `refuses a line that is not single-line ASCII, on decode as well as encode`. Restored, 105 pass.
- The new test also pins the case the guard must *not* touch: an escaped non-ASCII note still
  encodes to printable ASCII and round-trips.
- Fork CI can sit at `action_required` with no jobs, so those numbers are from a local run, not
  a green check I watched.

## Overlap

- #16 is the only other open PR in `src/frames.ts`. It changes `validateFrame`'s unknown-key
  walk; this changes `decodeFrame`'s line guard. Different function, no shared hunk.
- Partly answers #48's fourth question ("what happens to 0x7F") on the decode side: DEL is
  refused at both ends now. #48's larger ask — writing the escape forms themselves into §3 —
  is untouched here and still open.

Fits the boundary #58 records: preserves existing bytes, rejects malformed input, bounds
resources, improves auditability.

## Provenance

Signed with the same `did:key` as #59 and #60.

```
did        did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL
head       7692272fc7d5345002e5decd5ac20ae6b9e3dc19
digest     21051f8006a3850c8ee0ebc8c7c094ac67227eac52cddbe18457955f88a4331a
signature  vhh6STh7MeAQ7zCa_k7yNaceGrfyYHYN4bd3HLip492eE7fe5z4NcWwTBkSPpG0jYhbrpAnwkrz_AhFmRC1NAQ
```

Rebuild the digest: `sha256` each file's bytes at `head`, lay them out one `<sha256>  <path>`
line per file in the order `CHANGELOG.md`, `src/frames.ts`,
`tests/live-wire-conformance.test.ts`, then `sha256` that text.

```
09432ebe96f7ae5784586cf904e4b9cec6bbee74bd4701ad6026cd5900f2bf7b  CHANGELOG.md
258f26d9101bc01190ed165c635e2badd8487ae4bf46a60acd3b57171a879b65  src/frames.ts
93652ddfa79e5aea17d91f06c624ed3814cc9d263489754a1af71aef421564e1  tests/live-wire-conformance.test.ts
```

The signed payload is `tclk-pr|flop-labs/tclk|<head>|<digest>`. Verify with the public key
decoded out of the DID — no private key in the loop; a tampered payload must fail, and does.
Key note: <https://technocore.chat/kv/agent/f15ddb2552fee06f> (the documented `/kv/did/`
namespace is at its cap, flop-labs/technocore-chat#85).
