### PR TITLE
docs(spec): pin canonical JSON escaping rules and add golden vector (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project are documented here. Format follows
 - A schema-owned tclk/1 frame field contract, canonical settlement-rail registry and
   intersection-based, order-independent rail matching helpers. Generated decoder fields
   and the normative `SPEC.md` table are checked for drift in CI.
+- SPEC §3 canonical JSON string escaping conventions are now explicitly specified
+  (RFC 8785 §3.2.2.2 rules: lowercase hex digits, JSON short escapes, surrogate pair
+  escaping for code points above U+FFFF, unescaped solidus, and DEL forbidden), and a
+  cross-implementation golden vector pins these rules (#48).
 - A signed `heartbeat` frame for non-authoritative liveness while a contract is accepted
   or locked, without abusing terminal receipts or changing contract state.
 - A hosted deployment of the MCP server at `https://tclk.technocore.chat/mcp`, streamable

--- a/SPEC.md
+++ b/SPEC.md
@@ -107,10 +107,20 @@ the public manual (`/llms.txt`), and any self-hosted deployment works identicall
 ## 3. Wire format
 
 A frame is the 6 chars `tclk1 ` followed by one JSON object, serialized canonically:
-object keys sorted, `,`/`:` separators only, `undefined`-valued keys dropped, every non-ASCII
-character `\uXXXX`-escaped. The prefix is the version; incompatible revisions change it
-(`tclk2 `), never the field semantics. Decoding is fail-closed: a known frame type with an
-unknown key, a missing field, or a malformed value is rejected, never coerced.
+object keys sorted lexicographically, `,`/`:` separators only (no whitespace outside strings),
+`undefined`-valued keys dropped.
+
+String escaping follows RFC 8785 §3.2.2.2 conventions:
+- Quotation mark `\"` and reverse solidus `\\` use two-character escapes.
+- Standard whitespace control characters use short escapes: `\b`, `\f`, `\n`, `\r`, `\t`.
+- Other C0 control characters (< 0x20) are escaped as `\u00xx` using lowercase hex digits.
+- Solidus `/` is NOT escaped.
+- Non-ASCII code points (≥ 0x80) are escaped as `\uxxxx` using lowercase hex digits. Astral code points (above U+FFFF) are represented as UTF-16 surrogate pairs (`\udxxx\udxxx`).
+- Non-printable ASCII (0x7F / DEL) is forbidden in frame strings.
+
+The prefix is the version; incompatible revisions change it (`tclk2 `), never the field semantics.
+Decoding is fail-closed: a known frame type with an unknown key, a missing field, or a malformed
+value is rejected, never coerced.
 
 Common field shapes:
 

--- a/tests/vectors.test.ts
+++ b/tests/vectors.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect } from "vitest";
 
-import { encodeFrame, makeAccept, makeOffer } from "../src/index.js";
+import { decodeFrame, encodeFrame, makeAccept, makeOffer } from "../src/index.js";
 
 const PAYER_DID = "did:key:z6Mk" + "f".repeat(44);
 
@@ -92,5 +92,38 @@ describe("tclk golden vectors", () => {
     expect(line).toMatch(/^[\x20-\x7e]*$/);
     expect(line).toContain(String.raw`\u00e2`);
     expect(offer.id).toBe(NON_ASCII_OFFER_ID);
+  });
+
+  // Issue #48: Pin exact canonical JSON escaping forms (C0 controls, short escapes,
+  // non-ASCII BMP, surrogate pairs for astral code points, quotes, and backslashes).
+  it("pins canonical JSON escaping across C0 controls, short escapes, and surrogate pairs", () => {
+    const c = String.fromCharCode;
+    const jobId = "a\nb\tc\"d\\e/f" + c(7) + "g" + c(0xe9) + "h" + c(0xd83d, 0xde00);
+    const complexOffer = makeOffer({
+      from: "did:key:z6Mk" + "a".repeat(44),
+      role: "payer",
+      amount: "1",
+      asset: "FLOP",
+      lock: "hash",
+      rails: ["flop-htlc"],
+      claimByMs: 1_760_003_600_000,
+      refundAfterMs: 1_760_007_200_000,
+      expiresMs: 1_760_000_600_000,
+      job: { proto: "a2a", id: jobId },
+      nonce: "9f2c81d04c9e1f7a",
+    });
+
+    const expectedId = "0x6d256c211f927c2c23a874d35f4b5372de66b4642274ed8a8b62b73ca5bf6a58";
+    const expectedLine =
+      'tclk1 {"amount":"1","asset":"FLOP","claimByMs":1760003600000,"expiresMs":1760000600000,' +
+      '"from":"did:key:z6Mkaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",' +
+      `"id":"${expectedId}",` +
+      '"job":{"id":"a\\nb\\tc\\"d\\\\e/f\\u0007g\\u00e9h\\ud83d\\ude00","proto":"a2a"},' +
+      '"lock":"hash","nonce":"9f2c81d04c9e1f7a","rails":["flop-htlc"],"refundAfterMs":1760007200000,' +
+      '"role":"payer","type":"offer"}';
+
+    expect(complexOffer.id).toBe(expectedId);
+    expect(encodeFrame(complexOffer)).toBe(expectedLine);
+    expect(decodeFrame(expectedLine).id).toBe(expectedId);
   });
 });


### PR DESCRIPTION
## What

1. Explicitly defines canonical JSON string escaping in `SPEC.md` §3 following RFC 8785 §3.2.2.2 conventions:
   - `\"` and `\\` use two-character escapes.
   - Standard whitespace control characters use short escapes: `\b`, `\f`, `\n`, `\r`, `\t`.
   - Other C0 control characters (< 0x20) are escaped as `\u00xx` using lowercase hex digits.
   - Solidus `/` is left unescaped.
   - Non-ASCII code points (≥ 0x80) are escaped as `\uxxxx` using lowercase hex digits. Code points above U+FFFF are represented as UTF-16 surrogate pairs (`\udxxx\udxxx`).
   - Non-printable ASCII (0x7F / DEL) is forbidden in frame strings (matching existing `encodeFrame` printable ASCII checks).
2. Adds a comprehensive golden vector in `tests/vectors.test.ts` covering C0 control characters, short escapes, astral surrogate pairs, quotes, solidus, and backslashes, pinning `offerId`, `encodeFrame`, and `decodeFrame` across cross-language implementations.
3. Adds `CHANGELOG.md` entry.

Closes #48.

## Checks

- [x] `pnpm build`
- [x] `pnpm test` (105 passed in root)
- [x] `pnpm --filter @flop-labs/tclk-mcp test` (40 passed)
- [x] Worker test suite (33 passed)
- [x] Schema & SPEC documentation sync checks passed
