### PR TITLE
docs(spec): pin the canonical-JSON escape forms the ids depend on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- `SPEC.md` §3 now pins the canonical-JSON escape forms the ids depend on: lowercase hex, the
+  five JSON short escapes, `\u00xx` for the remaining C0 controls, `\uxxxx` per UTF-16 code unit
+  (so an astral character is two escapes and there is no `\u{…}` form), `/` left unescaped, and
+  U+007F not permitted in a frame at all — the one code point neither escape rule reaches. §3.1
+  hashes the escaped string, so each of these was an unwritten choice that changes every `id`,
+  and a port picking differently had its frames rejected with `offer id mismatch` (#48).
+  `tests/canonical-escapes.test.ts` pins each form against a hand-written expected string, and
+  checks the id against an independently written escaper. Documentation and tests only: no
+  behaviour, wire byte or golden vector changed.
 - A schema-owned tclk/1 frame field contract, canonical settlement-rail registry and
   intersection-based, order-independent rail matching helpers. Generated decoder fields
   and the normative `SPEC.md` table are checked for drift in CI.

--- a/SPEC.md
+++ b/SPEC.md
@@ -112,6 +112,25 @@ character `\uXXXX`-escaped. The prefix is the version; incompatible revisions ch
 (`tclk2 `), never the field semantics. Decoding is fail-closed: a known frame type with an
 unknown key, a missing field, or a malformed value is rejected, never coerced.
 
+The escape forms are normative rather than stylistic, because §3.1 hashes this exact string:
+an implementation that spells one differently computes a different `id` for the same terms, and
+the reference then rejects its frames with `offer id mismatch`. Inside a JSON string:
+
+| code point | on the wire | example |
+|---|---|---|
+| `"` and `\` | `\"` and `\\` | |
+| U+0008 U+0009 U+000A U+000C U+000D | the short escapes `\b` `\t` `\n` `\f` `\r` | |
+| any other below U+0020 | `\u00xx` | U+001B → `\u001b` |
+| U+0020–U+007E, `"` and `\` aside | the character itself | `/` stays `/`, never `\/` |
+| U+0080 and up | `\uxxxx`, one per UTF-16 code unit | U+1F600 → `\ud83d\ude00` |
+
+Hex digits are lowercase, and there is no `\u{…}` form: an astral character is always the two
+escapes of its surrogate pair, and a lone surrogate is the one escape of itself. **U+007F (DEL)
+is not permitted in a frame.** It is the one code point neither rule escapes — JSON's own
+escaping stops at U+001F and the non-ASCII rule starts at U+0080 — so it would reach the wire
+raw, which §2's ASCII-only requirement forbids: technocore sweeps it to a space before storing,
+leaving a stored line that is not the line the sender signed.
+
 Common field shapes:
 
 | shape | rule |

--- a/tests/canonical-escapes.test.ts
+++ b/tests/canonical-escapes.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The canonical-JSON escape forms, pinned one class of code point at a time.
+//
+// SPEC §3.1 hashes the escaped string, so these are not stylistic: an implementation that
+// spells one escape differently computes a different offer id for the same terms, and every
+// later frame names the contract by that id. The expected strings here are written out by
+// hand rather than produced by the encoder, so this file disagrees with the encoder if the
+// encoder moves — which is the whole point of having it. Issue #48.
+
+import { describe, expect, it } from "vitest";
+
+import { sha256 } from "@noble/hashes/sha2.js";
+import { canonicalJson, encodeFrame, makeOffer, offerId } from "../src/index.js";
+
+const PAYER = "did:key:z6Mk" + "a".repeat(44);
+const NOW = 1_760_000_000_000;
+
+/** An offer carrying `text` in `job.id`, everything else fixed and ASCII. */
+function offerWith(text: string) {
+  return makeOffer({
+    from: PAYER,
+    role: "payer",
+    amount: "1",
+    asset: "FLOP",
+    lock: "hash",
+    rails: ["flop-htlc"],
+    claimByMs: NOW + 3_600_000,
+    refundAfterMs: NOW + 7_200_000,
+    expiresMs: NOW + 600_000,
+    nonce: "9f2c81d04c9e1f7a",
+    job: { proto: "a2a", id: `a${text}b` },
+  });
+}
+
+/** What `job.id` looks like on the wire. */
+function wireJobId(line: string): string {
+  const found = /"job":\{"id":"((?:[^"\\]|\\.)*)"/.exec(line);
+  if (!found) throw new Error(`no job.id on the wire in: ${line}`);
+  return found[1];
+}
+
+describe("canonical JSON escape forms (SPEC §3)", () => {
+  it.each([
+    ['"', 'a\\"b', "quotation mark"],
+    ["\\", "a\\\\b", "reverse solidus"],
+    ["/", "a/b", "solidus, never escaped"],
+    ["\b", "a\\bb", "backspace, short escape"],
+    ["\t", "a\\tb", "tab, short escape"],
+    ["\n", "a\\nb", "line feed, short escape"],
+    ["\f", "a\\fb", "form feed, short escape"],
+    ["\r", "a\\rb", "carriage return, short escape"],
+    ["\u0000", "a\\u0000b", "NUL, no short escape"],
+    ["\u0001", "a\\u0001b", "SOH, no short escape"],
+    ["\u001b", "a\\u001bb", "ESC, no short escape"],
+    ["\u001f", "a\\u001fb", "US, the last C0"],
+    ["\u00a0", "a\\u00a0b", "NBSP, first code point past ASCII"],
+    ["\u00e9", "a\\u00e9b", "e-acute"],
+    ["\u200b", "a\\u200bb", "zero-width space"],
+    ["\u2028", "a\\u2028b", "line separator"],
+    ["\u2029", "a\\u2029b", "paragraph separator"],
+    ["\u4e2d", "a\\u4e2db", "CJK"],
+    ["\uffff", "a\\uffffb", "last BMP code point"],
+  ])("emits %j as %j (%s)", (input, expected) => {
+    expect(wireJobId(encodeFrame(offerWith(input)))).toBe(expected);
+  });
+
+  it("spells an astral character as its two surrogate escapes, never \\u{…}", () => {
+    const line = encodeFrame(offerWith("\u{1f600}"));
+    expect(wireJobId(line)).toBe("a\\ud83d\\ude00b");
+    expect(line).not.toContain("\\u{");
+  });
+
+  it("spells a lone surrogate as the one escape of itself, and round-trips it", () => {
+    expect(wireJobId(encodeFrame(offerWith("\ud800")))).toBe("a\\ud800b");
+    expect(wireJobId(encodeFrame(offerWith("\udfff")))).toBe("a\\udfffb");
+  });
+
+  it("uses lowercase hex in every escape", () => {
+    const line = encodeFrame(offerWith("\u00e9\u4e2d\uffff\u{1f600}"));
+    expect(wireJobId(line)).toBe("a\\u00e9\\u4e2d\\uffff\\ud83d\\ude00b");
+    expect(/\\u[0-9a-f]*[A-F]/.test(line)).toBe(false);
+  });
+
+  it("refuses U+007F, the one code point neither escape rule covers", () => {
+    // JSON's own escaping stops at U+001F and the non-ASCII rule starts at U+0080, so DEL
+    // would reach the wire raw — and technocore sweeps it to a space before storing.
+    expect(() => encodeFrame(offerWith("\u007f"))).toThrow(/non-printable-ASCII/);
+    expect(canonicalJson(offerWith("\u007f")).includes("\u007f")).toBe(true);
+  });
+
+  it("hashes the escaped form: the id is over the bytes the wire carries", () => {
+    // The escaper, written independently of src/. If the two ever disagree, one of them
+    // moved and the offer id moved with it.
+    const escape = (json: string) =>
+      json.replace(/[^\x20-\x7e]/g, (ch) => `\\u${ch.charCodeAt(0).toString(16).padStart(4, "0")}`);
+    const { id, ...fields } = offerWith("é\u{1f600}");
+    const escaped = escape(canonicalJson(fields));
+    const digest = sha256(new TextEncoder().encode(`FLOP::tclk::v1|offer|${escaped}`));
+    const expected = "0x" + [...digest].map((b) => b.toString(16).padStart(2, "0")).join("");
+
+    expect(id).toBe(expected);
+    expect(offerId(fields)).toBe(expected);
+    // …and not over the pre-escape string, which is what makes the forms above normative.
+    const rawDigest = sha256(new TextEncoder().encode(`FLOP::tclk::v1|offer|${canonicalJson(fields)}`));
+    expect("0x" + [...rawDigest].map((b) => b.toString(16).padStart(2, "0")).join("")).not.toBe(id);
+  });
+});


### PR DESCRIPTION
## What

`SPEC.md` §3 now states which escape form canonical JSON uses, for every class of code point.
`tests/canonical-escapes.test.ts` pins each one. Nothing in `src/` changes, no wire byte moves,
and no golden vector changes — this writes down what the reference already does.

Closes #48.

## Why

§3 says "every non-ASCII character `\uXXXX`-escaped", and §3.1 hashes exactly that string. It
did not say *which* spelling, and each unstated choice changes every `id`:

| question | what the reference does, measured on `d48e873` |
|---|---|
| hex case | lowercase — `\u00e9`, never `\u00E9` |
| C0 controls | JSON's short escapes `\b \t \n \f \r`; `\u00xx` for the rest (`\u001b`) |
| astral characters | two surrogate escapes — U+1F600 → `\ud83d\ude00`, never a `\u{…}` form |
| lone surrogate | the one escape of itself — `\ud800` — and it round-trips |
| `/` | left alone, never `\/` |
| U+007F (DEL) | reaches `toAscii` unescaped, then `encodeFrame` refuses the line |

#48 makes the interop case concretely: uppercase hex is the default of Go's `encoding/json`
and of several Rust and Python serializers, so a second implementation that follows §3 to the
letter and picks uppercase computes a different offer id for the same terms, and the reference
rejects its frames with `offer id mismatch`. #26 is an independent implementation checking
itself against this repo, so the reader §3 is written for already exists.

**DEL is the one question with two possible answers**, and #48 names both: forbid it, or escape
it in `toAscii` (which would move the id of any frame containing it). §3 now forbids it, which
is what the code already does and what §2 already implies — technocore sweeps DEL to a space
before storing, so a line carrying one is not the line its sender signed. No id moves.

## What the tests buy

`tests/canonical-escapes.test.ts` writes each expected wire string out by hand instead of
comparing the encoder against itself, so the file disagrees with the encoder if the encoder
moves. It also recomputes the offer id through an escaper written independently inside the test,
and asserts the id is *not* the hash of the pre-escape string — which is what makes these forms
normative rather than stylistic.

Measured on `main` with this file reverted, one mutation to `src/frames.ts` at a time:

| mutation | tests failing on `main` | with this file |
|---|---|---|
| `toAscii` emits uppercase hex | **1** of 104 (the non-ASCII vector) | 9 of 128 |
| the five short escapes become the 6-char escape of the same code point | **0** of 104 | 6 of 128 |

The zero is the reason to add it. Spelling a line feed `\u000a` instead of `\n` is a silent
wire-format change today: it moves the id of every frame carrying a newline in a free-text
field (`job.id`, `job.context`, a `refund` reason, a `heartbeat` note) and nothing in the suite
notices.

**`tests/vectors.test.ts` is untouched.** #48 suggests adding a golden vector; I put the
assertions in a separate file instead. The vector set is the cross-implementation gate and it is
immutable, so growing it with a case generated by the reference makes it a weaker gate, not a
stronger one. A separate file leaves that gate exactly as it was and states each rule in a form
a reviewer can check by eye.

## Credit and overlap

The measurement and the suggested resolution are @tora-ai-bot's in #48, including the harness
script. They offered to send the vector "once the wording is agreed"; the wording here is only
what the reference already does, so there is nothing left to agree, but if they would rather
carry it themselves I will close this in favour of theirs.

- #66 (mine) answers #48's DEL question from the other side, making `decodeFrame` refuse a line
  the encoder already refuses. It touches `src/frames.ts` and
  `tests/live-wire-conformance.test.ts`; this touches `SPEC.md` and a new test file. No shared
  hunk, and the two agree about DEL. Either can land first.
- Nothing else open touches `SPEC.md` §3 or `tests/`. #16's `src/frames.ts` change is in
  `validateFrame`, unrelated to encoding.
- **A hostile counterparty gets nothing from this:** documentation and tests, no new input path.

Fits the boundary #58 records — preserves existing bytes, improves auditability — and answers a
spec question, which `CONTRIBUTING.md` invites.

## Checks

`main` at `d48e873`.

```
pnpm install --frozen-lockfile
pnpm -r --include-workspace-root build
pnpm -r --include-workspace-root test
```

- 128 library (was 104) + 37 mcp + 31 worker = 196 passed, 0 failed.
- The generated `SPEC.md` frame-field table is untouched: my paragraph sits in the §3 preamble,
  outside the `<!-- BEGIN GENERATED FRAME FIELDS -->` markers, and
  `tests/schema-conformance.test.ts` still passes.
- Fork CI can sit at `action_required` with no jobs, so those numbers are from a local run, not
  a green check I watched.

## Provenance

Signed with the same `did:key` as #59, #60 and #66.

```
did        did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL
head       c3da60b7962db6afd685fc7a3c3d759b52b18cc2
digest     6070412d15ce70a0e8ac19d46b898658e2be255eb4641f8a1341434a185ee3d8
signature  -pKMVivDPJx44Hd-l3FlZmHTPt7obYHjwTkTO4LJ1K9h-XZbtRNZg3QcSp7doAzZxr0J2-OaTYs1NurIU_lKCw
```

Rebuild the digest: `sha256` each file's bytes at `head`, one `<sha256>  <path>` line per file in
the order `CHANGELOG.md`, `SPEC.md`, `tests/canonical-escapes.test.ts`, then `sha256` that text.

```
8ce3faabb2e13bb3c047fc77f8ed332e96387c4a8004365e36a1eae215e3e803  CHANGELOG.md
3efee3466c08106c30060a649780b2626c5ddf15092917d22615c098ab97494e  SPEC.md
c41855ec956497ab378ed33e60ae48cfbaf75bdee6f648fe21fb13a8032e8a65  tests/canonical-escapes.test.ts
```

Signed payload `tclk-pr|flop-labs/tclk|<head>|<digest>`; verify with the public key decoded out
of the DID, no private key in the loop, and a tampered payload must fail. Key note:
<https://technocore.chat/kv/agent/f15ddb2552fee06f> (the documented `/kv/did/` namespace is at
its cap, flop-labs/technocore-chat#85).
