### PR TITLE
fix(mcp): validate the room before signing or minting a challenge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ All notable changes to this project are documented here. Format follows
   the file rather than hand back a transcript with a hole in it. A window claims only a
   bounded view and already reports `lastSeq`, so naming the seq it could not read keeps
   that slice honest.
+- `tclk_post_frame` now checks `room` against the room grammar `/^[a-z0-9][a-z0-9_-]{0,47}$/`
+  before it builds a canonical string, instead of leaving that check to `postSigned` a round
+  trip later. The Ed25519 signature covers `<room>|<nonce>|<text>`, which parses one way only
+  because a room name cannot hold `|` — nothing enforced that on the write path. A `room` of
+  `tclk-offers|1` therefore produced a signing challenge, handed to the caller under "Sign
+  `canonical` exactly", byte-identical to a legal post in `tclk-offers` whose nonce is the
+  digits hidden in that `room` and whose text is the challenge nonce ahead of the caller's own
+  line. That post is the signed string's only valid reading, since `verifyTranscriptRecord`
+  refuses a record whose room is not a room name, while the post actually asked for was refused
+  only on the following call, after that signature had been spent; with
+  `TECHNOCORE_SIGNING_KEY` set, the server key signed the same string before the transport
+  rejected the room. Every name the venue accepts behaves as before: no wire byte and no golden
+  vector moves.
 - `applyFrame` now rejects `receipt` frames whose `rail` or `ref` contradicts the contract's
   locked settlement terms, or that assert a settlement rail on a `cancelled` contract where
   no lock was ever established.

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -39,6 +39,7 @@ import {
 
 import { canonicalMessage, loadSigner, nextNonce, sweep, type Signer } from "./signing.js";
 import {
+  assertRoomName,
   createClient,
   DEFAULT_TECHNOCORE_URL,
   type FetchLike,
@@ -366,6 +367,11 @@ export function createHandlers(options: HandlerOptions = {}) {
      * call that cannot sign is a request for a signature, not an empty failure.
      */
     async tclk_post_frame(input: PostFrameInput) {
+      // The room is checked here and not only in `postSigned`, which is a round trip too
+      // late: it is the first field of the `<room>|<nonce>|<text>` a signature covers, so a
+      // room holding `|` makes one signed string parse two ways — as the room asked for, and
+      // as a legal room with an attacker's nonce and text. Tier 3 hands that string out.
+      assertRoomName(input.room);
       // A frame that does not decode must never reach the room: rooms are the shared
       // transcript, and a malformed line there is a permanent record no one can fold.
       decodeFrame(input.line);

--- a/mcp/tests/transport.test.ts
+++ b/mcp/tests/transport.test.ts
@@ -146,6 +146,28 @@ describe("tclk_post_frame — tier 2, server-signed", () => {
   });
 });
 
+describe("tclk_post_frame — room name", () => {
+  // The signature covers `<room>|<nonce>|<text>` (SPEC §2, "Fold records, not detached
+  // lines"), and that tuple parses one way only because a room name cannot hold `|`.
+  // Nothing here enforced the grammar: `assertRoomName` ran first inside `postSigned`, a
+  // round trip later, so tier 3 handed back a challenge for `tclk-offers|1` byte-identical
+  // to a legal post in `tclk-offers` with an attacker-chosen nonce and text.
+  it("refuses a room the grammar rejects before minting a canonical string", async () => {
+    const line = offerLine();
+    expect(canonicalMessage("tclk-offers|1", 5, line)).toBe(canonicalMessage("tclk-offers", 1, `5|${line}`));
+
+    for (const room of ["tclk-offers|1", "Lobby!"]) {
+      const { calls, fetchLike } = fakeFetch([]);
+      const noKey = createHandlers({ env: {}, fetch: fetchLike });
+      const serverKey = createHandlers({ env: { TECHNOCORE_SIGNING_KEY: PAYER_SEED }, fetch: fetchLike });
+
+      await expect(noKey.tclk_post_frame({ room, line })).rejects.toThrow(/bad room name/);
+      await expect(serverKey.tclk_post_frame({ room, line })).rejects.toThrow(/bad room name/);
+      expect(calls).toHaveLength(0);
+    }
+  });
+});
+
 describe("tclk_read_room", () => {
   it("returns complete records without dropping unsigned or malformed frame lines", async () => {
     const line = offerLine();


### PR DESCRIPTION
## What

`tclk_post_frame` now validates `room` against the room grammar `/^[a-z0-9][a-z0-9_-]{0,47}$/` as its first statement, reusing the `assertRoomName` that `mcp/src/technocore.ts` already exports. One code line, its import and a four-line comment — `+6/-0` in `mcp/src/tools.ts`; the zod schema, the generated Worker manifest and every wire byte are untouched.

The only room check before this was `assertRoomName` inside `postSigned` — the transport, one call later, after the canonical string had been built and, in tier 2, signed. All three tiers now refuse identically, before `decodeFrame` and before a canonical string exists.

## Why

The Ed25519 signature covers `<room>|<nonce>|<text>` (SPEC.md §2, "Fold records, not detached lines"), and that tuple parses one way only because a room name cannot hold `|` — the invariant `mcp/src/signing.ts` states in its header ("the free-form field is last and the others cannot contain `|`, so it parses one way only") and `NAME_RE` (`mcp/src/technocore.ts:12`) defines. The read side enforces it: `src/transcript.ts:80` and `:122` gate `room` against `ROOM_NAME` before building the identical string. The write side did not, and the published schema already described the grammar nothing was checking — `mcp/src/server.ts:24` documents `room` as "A technocore room name, /^[a-z0-9][a-z0-9_-]{0,47}$/.", and the generated manifest carries that sentence for `tclk_post_frame` (`mcp/worker/src/tool-manifest.generated.ts:718`) and `tclk_read_room` (`:770`) with no `pattern` beside it.

So `room: "tclk-offers|4102444800000"` produced a tier-3 reply carrying `canonical` and ``hint: "Sign `canonical` exactly…"`` for a room the venue can never accept. That string is byte-identical to `canonicalMessage("tclk-offers", 4102444800000, "<challenge nonce>|<frame line>")`: one signature whose only valid reading is a legal post in `tclk-offers`, under the nonce the caller hid in `room` and a text carrying the caller's own line behind the challenge nonce — not the room the caller asked for, which `verifyTranscriptRecord` refuses on its name (`{"ok":false,"reason":"record has an invalid room name"}`). For the `tclk-offers` reading it returns `{"ok":true}`, and that text survives the sweep unchanged at 375 chars for this suite's fixture offer, well inside the 4096-char room-message cap. The post actually requested was refused only on the following call — after the signature had been spent.

Exactly what that record is worth: its text `<challenge nonce>|tclk1 {…}` is not a frame line — `decodeFrame` throws `tclk: not a tclk/1 line` and `tryDecodeFrame` returns `null` — so a reader treats it as data, not a commitment. What it is, is a valid signature by the signing key over a message in the rendezvous room at a nonce the caller chose, and `mcp/src/signing.ts`'s header records the venue's rule that "the nonce must exceed the last one this key used in that room" (the service's behaviour, which this repo mirrors but cannot test offline). AGENTS.md's load-bearing rule for this path is "Fail closed everywhere on the money path" — validation "rejects unknown keys and malformed values rather than coercing". A room name the venue cannot accept is a malformed value, and the artifact this path produces is a signature, so failing closed means failing before that signature exists.

Measured, same inputs before and after (scratch repro, injected `fetch`, no network):

| | before | after |
| --- | --- | --- |
| tier 3, no key | returns `canonical` + "Sign `canonical` exactly", 0 fetches | throws `bad room name`, 0 fetches |
| tier 2, `TECHNOCORE_SIGNING_KEY` set | server key signs that string — 1 UTF-8 encode of it, counted through `TextEncoder.prototype.encode` — then `postSigned` throws | 0 canonical strings encoded, throws first |
| tier 1, caller `did`+`sig`+`nonce` | `decodeFrame` speaks first: a bad room with a non-frame line gives `tclk: not a tclk/1 line`, and the room fails later inside `postSigned` | `tclk-mcp: bad room name` in both cases |
| `verifyTranscriptRecord`, forged record in `tclk-offers` | `{"ok":true}` | the signature is never minted |
| the same signature, record in the room asked for | `{"ok":false,"reason":"record has an invalid room name"}` | unchanged |
| `tclk-offers` / `mb-p-tclk-deadbeefdeadbeef` / `lobby` | challenge returned, `canonical` equals `canonicalMessage(room, nonce, line)`, 0 fetches | identical |

The guard belongs in the handler rather than in the zod `room`: the handler is what the stdio server, the Worker and any `createHandlers` library caller all go through, and `mcp/README.md:76` documents that third route. Adding `.regex()` to the schema would also mean regenerating `mcp/worker/src/tool-manifest.generated.ts`, whose header points at `tests/manifest.test.ts` for exactly that drift. The Worker gets this for free — it has no tier 2, so tier 3 is its main path, and its `catch` already returns a handler throw as an `isError` tool result with the same text and logs nothing.

Not included on purpose, one problem per pull request: the optional `|` guard inside `canonicalMessage`. The room grammar already excludes `|`, and the other field is either `nextNonce()`'s own integer or a `/^[0-9]{1,19}$/`-checked string, so it would be a second change needing its own test.

## Checks

Run locally from the worktree root, exactly the three CI commands. I have not seen a CI result for this branch.

```
pnpm install --frozen-lockfile
pnpm -r --include-workspace-root build
pnpm -r --include-workspace-root test
```

| suite | on `origin/main` | test without the src hunk | with it |
| --- | --- | --- | --- |
| library (root) | 104 passed (9 files) | 104 passed (9 files) | 104 passed (9 files) |
| `mcp` | 40 passed (6 files) | 1 failed \| 40 passed (41) | 41 passed (6 files) |
| `mcp/worker` | 33 passed (2 files) | not reached (`vitest run && vitest run --config worker/…`) | 33 passed (2 files) |

`pnpm` exits 0 in the outer columns and 1 in the middle one. `origin/main` is this branch's base and its parent commit (#55).

Both ways. Reverting only `mcp/src/tools.ts` — the import alone does not compile — and keeping the test:

```
FAIL tests/transport.test.ts > tclk_post_frame — room name >
     refuses a room the grammar rejects before minting a canonical string
AssertionError: promise resolved "{ posted: false, …(6) }" instead of rejecting
❯ tests/transport.test.ts:164:58
```

with `room: "tclk-offers|1"` and the challenge's `canonical`/`hint` in the received object. Restored, the same run is `104 / 41 / 33` and pnpm exits 0.

Golden vectors: `tests/vectors.test.ts` is untouched — the same blob as `origin/main`, `42b2218` — and passes. The diff is `+41/-0` across three files: `+6/-0` in `mcp/src/tools.ts`, `+22/-0` in `mcp/tests/transport.test.ts` (a new `describe` between two existing ones), `+13/-0` in `CHANGELOG.md` under `[Unreleased]`. No existing test was edited.

What a hostile counterparty gets from the new surface: nothing. It is one refusal from a guard that already governed every HTTP call this server makes, with the same grammar and the same message — which quotes only the caller's own `room`, never the frame line, the nonce or key material. Every name the venue accepts still passes, so it cannot be turned into a denial of a legal post.

## Overlap

Every state below was re-checked with `gh` as of 2026-09-03T19:59Z. Ruled out against the open, merged and closed work this touches:

- **#55** (merged 2026-09-03T17:43Z, `fix(mcp): preserve exact string nonces in tclk_post_frame`) — the `nonce` field's type and formatting through `signing.ts`/`server.ts`/`tools.ts`/`worker.ts`. This is the `room` field's shape: a different parameter and a different guard, landing above #55's nonce plumbing, which is left as-is. It is in `origin/main` and is this branch's parent commit.
- **#54** (closed unmerged 2026-09-03T19:23Z, `fix(mcp): cap the venue response body, as the Worker already caps the request`) — response-body caps in `mcp/src/technocore.ts` (`fail`/`readRoom` body size), not `assertRoomName`'s call order. It was open when this body was first drafted, and it is not now; nothing here depends on it either way.
- **#62** (open, `feat(transcript): offer-room fallback for the deal-room binding`) — which room a frame belongs in. This says nothing about which room is correct, only that a string that is not a room name at all must be refused before a signature covers it. It does edit `mcp/src/tools.ts` as well: `type RoomBinding` added to the `@flop-labs/tclk` import list, and a `roomBinding` option on `tclk_apply_transcript` (`+3/-2` in that file). Both sites are away from `tclk_post_frame` and from the `./technocore.js` import this diff extends — the only line the two touched ranges share is the blank line between the two import statements — and `git merge-tree` reports no conflict between the two heads in either argument order.
- **#65** (open, `examples: fall back to OFFER_ROOM for lock+reveal when the derived deal room is refused`) — the same subject as #62 in one file, `examples/live-deal.mjs`. No file in common; merges clean against this head.
- **#52** (merged 2026-09-03T17:27Z) — window-read isolation in `tclk_read_room`; that tool was already gated by `assertRoomName` inside `readRoom`/`exportRoom` and is unchanged here.
- **#16** (open) — `validateFrame` nested-object unknown keys in `src/frames.ts`, a file this diff does not touch.
- **#60 / #59 / #63** (all merged 2026-09-03, 17:16Z–17:21Z) — frame cap, published schema patterns, hex echoes. #59's Worker-side `pattern` check does run (`checkProperty`, `mcp/worker/src/worker.ts:269`), but the generated `room` property carries no `pattern`, so it does not reach this.

Of the 13 pull requests open at that timestamp, #62 is the only one that touches `mcp/src/tools.ts`, none touches `mcp/tests/transport.test.ts`, and ten touch `CHANGELOG.md`. This entry is inserted behind the `tclk_read_room` window-read bullet (#52's), not at the top of the list, to keep those insertion points apart.

Mine, and going out with this one: five sibling branches with no pull request open yet — `fix/worker-body-cap-in-bytes` (`mcp/worker/src/worker.ts`), `fix/paper-rail-refuses-an-unreadable-record` (`src/paper-rail.ts`), `fix/rail-validates-the-clock-reading` (`src/rail.ts`, `src/paper-rail.ts`), `fix/schema-point-lock-payment-key-and-ms-bounds` (`schema/tclk1-frames.schema.json`), `fix/export-the-shipped-schema-path` (`package.json`) — plus #66 and #68, which are already open and also mine. None of the seven touches `mcp/src/tools.ts` or `mcp/tests/transport.test.ts`. Every one of them adds a `CHANGELOG.md` bullet, each behind its own anchor: this branch's hunk shares no context line with any of theirs. `git merge-tree` reports no conflict between this head and any of the seven, measured pairwise.

## Provenance

Signed with the same `did:key` as #59, #60, #66 and #68.

```
did        did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL
head       e1720167579ee96627b364e7a7aa1835b3f9e436
digest     c7b40ea7184945a3c9f819c6336039eb0b94fd8cd6587efaca4da3216c456ed5
signature  0gUzz_Nxm-uQ0Sbhlu_IdnDETSwXpKc-gYvZd9uQpgpa4CO6bGevG6d6AbXRGtznqbSUS9YLKf7Q6aUF-h8vBw
```

Rebuild the digest: `sha256` each file's bytes at `head`, one `<sha256>  <path>` line per file
in the order CHANGELOG.md, mcp/src/tools.ts, mcp/tests/transport.test.ts, then `sha256` that text.

```
0b9b86eddf8bc090402782cc7614554fc48d12feff5188553604608837a5a475  CHANGELOG.md
fec48d2e20b00a8e8f194c8dd8fd53d3fee3312b11d6acf005b6ee3f21e3133a  mcp/src/tools.ts
26e7c58af1402290780b043826ad3b0e264aba772b756206b2fb6197eebf0610  mcp/tests/transport.test.ts
```

Signed payload `tclk-pr|flop-labs/tclk|<head>|<digest>`. Verify with the public key decoded out
of the DID — no private key in the loop, and a tampered payload must fail. Key note:
<https://technocore.chat/kv/agent/f15ddb2552fee06f> (the documented `/kv/did/` namespace is at
its cap, flop-labs/technocore-chat#85).
