### PR TITLE
fix(rail): validate the clock reading before every deadline guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,15 @@ All notable changes to this project are documented here. Format follows
   unvalidated offer timestamps before doing arithmetic. A negative-infinite clock or an
   infinite refund deadline could previously manufacture a safe-looking window even though
   the helper promises to fail closed.
+- `MemoryRail` and `PaperRail` now validate the clock reading before every deadline guard.
+  An injected `clock` was compared straight against `refundAfterMs`, and a NaN reading
+  (`Date.parse` of a string that is not a date, `Number()` of an unset variable) loses that
+  comparison in both directions — so `lock` escrowed into an already-open refund window,
+  `refund` ran before the window opened and `claim` ran after it closed, voiding all three
+  predicates SPEC §5 says a rail enforces. A negative or infinite reading is not a time at
+  all; those comparisons resolve, so the rail believed them instead — escrowing at a nonsense
+  time, or refunding two hours before the window. Both now throw, under the rule `applyFrame`
+  already applies to its `nowMs`. Finite clocks, wire bytes and golden vectors are unchanged.
 - `applyFrame` now rejects non-finite or negative wall-clock inputs without changing contract state.
 - `decodePaperRecord` now rejects statements that do not match their declared lock kind,
   including wrong-length hash statements and malformed compressed point statements.

--- a/src/paper-rail.ts
+++ b/src/paper-rail.ts
@@ -21,7 +21,7 @@
 
 import { isValidStatement, type LockKind } from "./frames.js";
 import { verifySecret } from "./locks.js";
-import type { LockTerms, SettlementRail } from "./rail.js";
+import { railNow, type LockTerms, type SettlementRail } from "./rail.js";
 
 /** The record version, so a later shape cannot be mistaken for this one. */
 export const PAPER_RECORD_PREFIX = "tclkpaper1" as const;
@@ -111,7 +111,7 @@ export class PaperRail implements SettlementRail {
   }
 
   async lock(terms: LockTerms): Promise<string> {
-    if (this.clock() >= terms.refundAfterMs) {
+    if (railNow(this.clock) >= terms.refundAfterMs) {
       throw new Error("tclk: refusing to lock into an already-open refund window");
     }
     const { ns, key } = paperNote(terms.contract);
@@ -140,7 +140,7 @@ export class PaperRail implements SettlementRail {
 
   async claim(ref: string, secret: string): Promise<void> {
     const { current, record } = await this.requireLocked(ref, "claim");
-    if (this.clock() >= record.refundAfterMs) throw new Error("tclk: claim after refundAfterMs");
+    if (railNow(this.clock) >= record.refundAfterMs) throw new Error("tclk: claim after refundAfterMs");
     if (!verifySecret(record.lock, record.statement, secret)) {
       throw new Error("tclk: secret does not open the statement");
     }
@@ -149,7 +149,7 @@ export class PaperRail implements SettlementRail {
 
   async refund(ref: string): Promise<void> {
     const { current, record } = await this.requireLocked(ref, "refund");
-    if (this.clock() < record.refundAfterMs) throw new Error("tclk: refund before refundAfterMs");
+    if (railNow(this.clock) < record.refundAfterMs) throw new Error("tclk: refund before refundAfterMs");
     await this.advance(ref, current, { ...record, status: "refunded" });
   }
 

--- a/src/rail.ts
+++ b/src/rail.ts
@@ -43,6 +43,21 @@ export function lockTerms(state: ContractState): LockTerms {
   };
 }
 
+/**
+ * Read the injected clock as the operand of a deadline guard. A reading that is not a finite
+ * non-negative time cannot be compared meaningfully: `NaN` makes every comparison false in
+ * both directions, so a guard is skipped rather than failed, and a negative or infinite
+ * reading answers the comparison confidently about a time that never existed. This is the
+ * rule `applyFrame` already applies to its own `nowMs`.
+ */
+export function railNow(clock: () => number): number {
+  const now = clock();
+  if (!Number.isFinite(now) || now < 0) {
+    throw new Error("tclk: rail clock must read a finite non-negative number");
+  }
+  return now;
+}
+
 export interface SettlementRail {
   /** Rail id as advertised in `offer.rails` (e.g. "flop-htlc", "x402"). */
   readonly id: CanonicalRailId;
@@ -84,7 +99,7 @@ export class MemoryRail implements SettlementRail {
     if (this.locks.has(terms.contract)) {
       throw new Error(`tclk: rail already holds a lock for ${terms.contract}`);
     }
-    if (this.clock() >= terms.refundAfterMs) {
+    if (railNow(this.clock) >= terms.refundAfterMs) {
       throw new Error("tclk: refusing to lock into an already-open refund window");
     }
     this.locks.set(terms.contract, { terms, status: "locked" });
@@ -102,7 +117,7 @@ export class MemoryRail implements SettlementRail {
 
   async claim(ref: string, secret: string): Promise<void> {
     const held = this.requireLocked(ref, "claim");
-    if (this.clock() >= held.terms.refundAfterMs) {
+    if (railNow(this.clock) >= held.terms.refundAfterMs) {
       throw new Error("tclk: claim after refundAfterMs");
     }
     if (!verifySecret(held.terms.lock, held.terms.statement, secret)) {
@@ -113,7 +128,7 @@ export class MemoryRail implements SettlementRail {
 
   async refund(ref: string): Promise<void> {
     const held = this.requireLocked(ref, "refund");
-    if (this.clock() < held.terms.refundAfterMs) {
+    if (railNow(this.clock) < held.terms.refundAfterMs) {
       throw new Error("tclk: refund before refundAfterMs");
     }
     this.locks.set(ref, { ...held, status: "refunded" });

--- a/tests/paper-rail.test.ts
+++ b/tests/paper-rail.test.ts
@@ -112,6 +112,27 @@ describe("paper rail — the predicates a real rail must enforce", () => {
     await expect(rail.lock(terms().terms)).rejects.toThrow(/already-open refund window/);
   });
 
+  // A rail clock is injected, so a bad reading is ordinary input: Date.parse of a server
+  // date header that is not a date returns NaN, and NaN loses every comparison.
+  it("refuses to lock, claim or refund on a clock reading that is not finite", async () => {
+    const badClock = /rail clock must read a finite non-negative number/;
+    const { rail, setNow } = railAt();
+    const deal = terms();
+    const ref = await rail.lock(deal.terms);
+
+    setNow(Date.parse("not-a-date"));
+    await expect(rail.claim(ref, deal.secret)).rejects.toThrow(badClock);
+    await expect(rail.refund(ref)).rejects.toThrow(badClock);
+    expect((await rail.read(ref))?.status).toBe("locked");
+
+    // The lock guard runs before the write, so a bad reading must not spend the note slot.
+    const { rail: railNaN, notes } = railAt(Number.NaN);
+    const fresh = terms();
+    await expect(railNaN.lock(fresh.terms)).rejects.toThrow(badClock);
+    const { ns, key } = paperNote(fresh.terms.contract);
+    expect(notes.raw(ns, key)).toBeUndefined();
+  });
+
   it("carries the point-lock path too — the witness opens it", async () => {
     const { rail } = railAt();
     const deal = terms("point");

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -460,6 +460,27 @@ describe("tclk MemoryRail (reference rail predicates)", () => {
     expect(await rail.verifyLock(terms, ref)).toBe(false);
   });
 
+  // The clock reading is an operand of all three deadline guards. `NaN` is the reading that
+  // voids all three, because every comparison with it is false in both directions; a negative
+  // or infinite reading instead answers each comparison confidently about a time that never
+  // existed. Neither is a time, so the rail must refuse the reading rather than compare it.
+  it.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["negative", -1],
+  ])("refuses to lock, claim or refund on a %s clock reading", async (_label, bad) => {
+    const badClock = /rail clock must read a finite non-negative number/;
+    const { rail, lock, terms, setNow } = railFixture();
+    const ref = await rail.lock(terms);
+
+    setNow(bad);
+    await expect(rail.claim(ref, lock.preimage)).rejects.toThrow(badClock);
+    await expect(rail.refund(ref)).rejects.toThrow(badClock);
+    expect(rail.status(ref)).toBe("locked");
+
+    await expect(new MemoryRail("memory", () => bad).lock(terms)).rejects.toThrow(badClock);
+  });
+
   it("verifyLock is fail-closed on unknown refs and mismatched terms", async () => {
     const { rail, terms } = railFixture();
     expect(await rail.verifyLock(terms, terms.contract)).toBe(false);


### PR DESCRIPTION
## What

`MemoryRail` and `PaperRail` each read an injected `clock()` straight into three deadline comparisons. All six reads now go through one guard, `railNow`, which refuses a reading that is not a finite non-negative number — the rule `applyFrame` already applies to its `nowMs` (`src/machine.ts:101`), `validateDeadlines` applies to the same operand (`src/locks.ts:74-75`), and `transcriptRecord` applies to `Date.parse(message.ts)` before the fold hands that value to `applyFrame` as `nowMs` (`src/transcript.ts:132`, consumed at `:308`).

Behaviour on a finite clock is unchanged, boundaries included: `lock` still refuses at `refundAfterMs`, `claim` refuses at it, `refund` is allowed at it. `verifyLock` reads no clock and is untouched.

## Why

A comparison with NaN is false in both directions, so a NaN reading does not fail a deadline guard, it deletes it. A reading that is a number but not a time is a smaller, separate defect: the comparison resolves normally, so the rail believes it.

Measured in this worktree against its own build, on contract terms with `refundAfterMs = T0 + 7_200_000`. Each row is paired with a control that changes only the reading, because the rail has no time source but its clock:

| operation | at this moment | control: good reading | on `main`, NaN reading | on this branch |
|---|---|---|---|---|
| `MemoryRail.lock` | refund window already open | throws `tclk: refusing to lock into an already-open refund window` | escrows, returns the ref | throws, nothing recorded |
| `MemoryRail.claim` | at/after `refundAfterMs` | throws `tclk: claim after refundAfterMs` | succeeds, status `claimed` | throws, status stays `locked` |
| `MemoryRail.refund` | 2 h before `refundAfterMs` | throws `tclk: refund before refundAfterMs` | succeeds, status `refunded` | throws, status stays `locked` |
| `PaperRail.refund` | 2 h before the window | throws `tclk: refund before refundAfterMs` | succeeds, record `refunded` (reading `Date.parse("not-a-date")`) | throws, record stays `locked` |
| `PaperRail.lock` | refund window already open | throws, note slot unspent | writes the record, spends the one-shot `ifAbsent` slot | throws, slot unspent |

The other class, measured the same way on `main`: `-1` and `-Infinity` let `lock` escrow and `claim` run, while `refund` correctly refuses; `+Infinity` is the mirror — `lock` and `claim` refuse, and `refund` runs 2 h before the window opens. No comparison is voided there, the rail is just told a nonsense time and acts on it. `undefined` from a JavaScript caller coerces to NaN and behaves exactly like the NaN rows above. On this branch every one of them throws.

SPEC §5 calls `MemoryRail` "the executable spec of what a real rail must enforce", and the class doc in `src/rail.ts` says "All violations throw (fail closed)". With a NaN clock it enforced none of its three predicates. §5's `paper` row promises refund as "CAS an expired record to refunded"; it refunded a record that had not expired.

The reading is ordinary input, not a value nobody produces. The constructor takes the clock so a caller can supply one, and this library's own venue-time path is `Date.parse` of a venue timestamp string (`src/transcript.ts:131`), validated on the next line before the fold can hand it to a deadline. A caller who builds a clock the same way from a string that is not a date gets NaN, as `Number()` of an unset variable does. The rail layer was the last clock surface that compared first and validated never.

One helper rather than two copies, so the rail layer has one rule; `PaperRail` keeps its guard ahead of the write, because that write spends the note's `ifAbsent` slot in a world-writable namespace and cannot be taken back — the `PaperRail.lock` row above is that slot, measured on both sides.

**SPEC vs code:** I treated SPEC §5 as correct and the code as wrong. No SPEC change is in this PR.

**Hostile counterparty:** nothing. `railNow` is exported from `src/rail.ts` because the other rail, `PaperRail`, lives in `src/paper-rail.ts` and imports it; it is not re-exported by `src/index.ts`, which is unchanged, so the package's public surface is the same. No new field, no input widened, no byte moved — six comparisons that could silently pass now throw. The case it closes is self-inflicted: your own bad clock reading releasing or refunding a lock at the wrong time.

## Checks

The three CI commands, run locally in this worktree on the branch commit. Fork CI is not claimed — nothing has been pushed yet.

```
pnpm install --frozen-lockfile
pnpm -r --include-workspace-root build
pnpm -r --include-workspace-root test
```

| suite | on `origin/main` (5cc4ab9) | with this branch |
|---|---|---|
| library (`tests/`) | 104 passed, 9 files | 108 passed, 9 files |
| `mcp/` | 40 passed, 6 files | 40 passed, 6 files |
| `mcp/worker/` | 33 passed, 2 files | 33 passed, 2 files |

Both ways. Reverting both `src/` files — `git checkout origin/main -- src/rail.ts src/paper-rail.ts`, eight hunks across the two — and leaving both tests in place:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  tests/paper-rail.test.ts > paper rail — the predicates a real rail must enforce > refuses to lock, claim or refund on a clock reading that is not finite
AssertionError: promise resolved "undefined" instead of rejecting
 FAIL  tests/tclk.test.ts > tclk MemoryRail (reference rail predicates) > refuses to lock, claim or refund on a NaN clock reading
 FAIL  tests/tclk.test.ts > tclk MemoryRail (reference rail predicates) > refuses to lock, claim or refund on a negative clock reading
AssertionError: promise resolved "undefined" instead of rejecting
 FAIL  tests/tclk.test.ts > tclk MemoryRail (reference rail predicates) > refuses to lock, claim or refund on a Infinity clock reading
AssertionError: expected [Function] to throw error matching /rail clock must read a finite non-neg…/ but got 'tclk: claim after refundAfterMs'
 Test Files  2 failed | 7 passed (9)
      Tests  4 failed | 104 passed (108)
```

Restored: `108 passed (108)`, plus `40` and `33`. Diff is +20/-7 under `src/`, +40 test lines, +9 changelog lines. `tests/vectors.test.ts` is byte-identical to `origin/main` (blob `42b2218` on both sides) and no frame, id or paper-note line changes bytes; a rail holds no wire format.

## Overlap

- Not #14 (merged 2026-09-03, `f3eb89c`, `CHANGELOG.md` + `src/machine.ts` + `tests/tclk.test.ts`): same bug class, the machine half. It validated the `nowMs` a caller passes `applyFrame`; a rail's own reading stayed unguarded.
- Not #34 (merged 2026-09-03, `04c7911`, `src/locks.ts`): `validateDeadlines` already returns `false` for exactly this operand. That is the precedent this follows, not the same fix.
- Not #29 (merged 2026-09-03, `528190f`, `src/paper-rail.ts`): `decodePaperRecord` statement validation, a different function with no clock; the three clock reads were untouched by it.
- No open pull request touches `src/rail.ts` or `src/paper-rail.ts`. As of 2026-09-03T20:01Z the open list is #13, #16 (`src/frames.ts`), #21 (adds `src/evm-hash-rail.ts`, a new file), #28, #32 (`src/machine.ts`), #50, #56, #58, #62 (`src/transcript.ts`), #65, #66 (`src/frames.ts`, mine), #67 (`tests/vectors.test.ts`), #68 (mine), and I checked each one's file list. I re-checked that list after #54 closed unmerged at 19:23Z, so #54 is not in it. #21's new rail would inherit the same rule if it adopts the helper; nothing here conflicts with it.
- **One of my own branches does touch `src/paper-rail.ts`**, and goes out in the same batch as this PR: "fix(paper-rail): refuse to write a record the rail cannot read back". It rewrites `encodePaperRecord` and its doc comment (`src/paper-rail.ts:60-67` on `origin/main`, +12/-1) and adds test blocks below mine in `tests/paper-rail.test.ts`; my four hunks are the import at line 24 and the three clock reads at 114, 143 and 152. `git merge-tree --write-tree` on the two tips exits 0 in both directions, so this is disclosure, not a conflict. The four others touch one library file each that this PR does not — `mcp/worker/src/worker.ts`, `mcp/src/tools.ts`, `schema/tclk1-frames.schema.json`, `package.json` — but all six touch `CHANGELOG.md`, anchored after six different existing bullets so the hunks do not overlap. All five merge cleanly with this branch, checked the same way, in both orders.
- #58 (open, docs-only) proposes the near-term merge boundary. `TCLK2-PROPOSAL.md` states it as "Continue merging tclk/1 fixes that preserve existing bytes, reject malformed input, bound resources, or improve auditability." and "Do not add a new value-bearing rail or a large new tclk/1 client before the tclk/2 contract is settled." This is validation inside two rails that already exist: it preserves every byte, rejects malformed input, and adds no rail.

Deliberately out of scope, so this stays one problem: a hand-built `LockTerms` whose `refundAfterMs` is itself NaN is still accepted by `lock` — measured, it returns a ref under a good clock. That is the *other* operand of the same comparison, it reaches the rail only by bypassing the builders (`makeOffer` throws `tclk: refundAfterMs must be a positive unix-ms integer`) and `validateDeadlines` returns `false` for it today. It belongs in its own change.

## Provenance

Signed with the same `did:key` as #59, #60, #66 and #68.

```
did        did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL
head       0026c9eeb37bf43e1b57856bbcd291d6cf3f5773
digest     a59ce83afb37cba9eef9422d57d0777698c11d0e84b1d8d117b8eb3bb5e3d190
signature  hZC6ZBFLe5M88wWWe6if6ulwV8iyLouYxjlH-eMIazroveUVqe4DYT86nWqDyzjnvNifEl1kuagMe5JnSXYJBw
```

Rebuild the digest: `sha256` each file's bytes at `head`, one `<sha256>  <path>` line per file
in the order CHANGELOG.md, src/rail.ts, src/paper-rail.ts, tests/tclk.test.ts, tests/paper-rail.test.ts, then `sha256` that text.

```
65dd07fa04fdef0a6718bd8eeb683d22c47899117392a4b772aa6b31b4751b2f  CHANGELOG.md
24b1c585d13a6a21fe34f3d5c13ee5051934838e8babf6082c46afcd14c94d27  src/rail.ts
4e9ea7127174166e648f4f543a86a84d9d0e5c09306325bcf66693cce5a99621  src/paper-rail.ts
c3c2f0adc9d33e323eea2d3dc82d67768c3406678b863df8050abebef07e72d4  tests/tclk.test.ts
e3f7581fcdf3cd80a9fc8c604fc5a9ac5c6e612ac7e11de89a07a85deb2e7791  tests/paper-rail.test.ts
```

Signed payload `tclk-pr|flop-labs/tclk|<head>|<digest>`. Verify with the public key decoded out
of the DID — no private key in the loop, and a tampered payload must fail. Key note:
<https://technocore.chat/kv/agent/f15ddb2552fee06f> (the documented `/kv/did/` namespace is at
its cap, flop-labs/technocore-chat#85).
