### PR TITLE
fix(paper-rail): refuse to write a record the rail cannot read back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,16 @@ All notable changes to this project are documented here. Format follows
 - `applyFrame` now rejects non-finite or negative wall-clock inputs without changing contract state.
 - `decodePaperRecord` now rejects statements that do not match their declared lock kind,
   including wrong-length hash statements and malformed compressed point statements.
+- `encodePaperRecord` now refuses a record its own decoder would reject, so `PaperRail` can
+  no longer write a note line it will never read back. `verifySecret` takes either hex case
+  and raw witness bytes by design, while SPEC §3 spells a statement and a secret as
+  lowercase hex, so a claim with an uppercase preimage passed that guard and then wrote a
+  line `decodePaperRecord` returns null for: `read` went null, `verifyLock` false, `refund`
+  and a retry `claim` threw on the unreadable line, and a fresh `lock` threw on the spent
+  `ifAbsent` slot, so nothing the rail exposes could repair it. The check runs before both
+  `notes.set` calls, so a refused claim leaves the record `locked` and claimable with the
+  canonical spelling, and the refusal names the status rather than the secret. Records that
+  already round-tripped encode to the same bytes and no golden vector changes.
 - `SPEC.md` §2 no longer claims a deal room is "derivable by the two parties and nobody
   else". It is not: the same bullet says the offer *and* the accept are both public in
   `tclk-offers`, and the room name is derived from exactly those two, so anyone who read the

--- a/src/paper-rail.ts
+++ b/src/paper-rail.ts
@@ -60,10 +60,21 @@ const CONTRACT_ID = /^0x[0-9a-f]{64}$/;
 /**
  * Serialize a record to one note line. Single-line and space-separated so a human, a
  * shell, or an agent with only a fetch tool can read the state without a parser.
+ *
+ * Refuses a record this module's own decoder would reject, because this rail cannot repair
+ * the write: the `ifAbsent` slot is spent, `read` is null for every later poll, and only
+ * an unconditional note write from outside the rail can replace the line. `verifySecret`
+ * accepts either hex case and raw bytes, while SPEC.md §3 spells a statement and a secret
+ * as lowercase hex, so a claim that opens the statement can still carry a secret this
+ * grammar refuses. The refusal names the status only — the secret must not reach a log.
  */
 export function encodePaperRecord(record: PaperRecord): string {
   const head = `${PAPER_RECORD_PREFIX} ${record.status} ${record.lock} ${record.statement} ${record.refundAfterMs}`;
-  return record.secret === undefined ? head : `${head} ${record.secret}`;
+  const line = record.secret === undefined ? head : `${head} ${record.secret}`;
+  if (decodePaperRecord(line) === null) {
+    throw new Error(`tclk: refusing to write an unreadable paper record (${record.status})`);
+  }
+  return line;
 }
 
 /**

--- a/tests/paper-rail.test.ts
+++ b/tests/paper-rail.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect } from "vitest";
 
+import { hexToU8a } from "../src/hex.js";
 import {
   MemoryNoteStore,
   PaperRail,
@@ -119,6 +120,52 @@ describe("paper rail — the predicates a real rail must enforce", () => {
     await rail.claim(ref, deal.secret);
     expect((await rail.read(ref))?.status).toBe("claimed");
   });
+
+  it("refuses a claim it cannot record, and the lock stays claimable", async () => {
+    const { rail, notes } = railAt();
+    const deal = terms();
+    const ref = await rail.lock(deal.terms);
+    const { ns, key } = paperNote(ref);
+    const locked = notes.raw(ns, key);
+
+    // Both spellings open the statement — `verifySecret` decodes the secret through `isHex`,
+    // which takes either hex case, and takes raw bytes from an untyped caller — but SPEC §3
+    // spells a secret as 64 lowercase hex, which is the grammar decodePaperRecord enforces,
+    // so neither can be written down.
+    for (const [spelling, secret] of [
+      ["uppercase hex", "0x" + deal.secret.slice(2).toUpperCase()],
+      ["raw 32 bytes", hexToU8a(deal.secret)],
+    ] as const) {
+      const refused = await rail.claim(ref, secret as string).then(
+        () => "resolved",
+        (err: Error) => err.message,
+      );
+      expect(refused, spelling).toMatch(/refusing to write an unreadable paper record/);
+      // Whatever catches this refusal logs it, so it names the status, not the secret.
+      expect(refused.toLowerCase()).not.toContain(deal.secret.slice(2, 18));
+      expect(notes.raw(ns, key)).toBe(locked);
+    }
+
+    await rail.claim(ref, deal.secret);
+    expect((await rail.read(ref))?.status).toBe("claimed");
+  });
+
+  it("refuses to lock terms it cannot record, leaving the slot unspent", async () => {
+    const { rail, notes } = railAt();
+    const deal = terms();
+    const { ns, key } = paperNote(deal.terms.contract);
+    const shouted: LockTerms = {
+      ...deal.terms,
+      statement: "0x" + deal.terms.statement.slice(2).toUpperCase(),
+    };
+
+    // The first write spends the ifAbsent slot, so a line no reader can decode is terminal
+    // for this rail: no later lock replaces it — only an unconditional note write can.
+    await expect(rail.lock(shouted)).rejects.toThrow(/refusing to write an unreadable/);
+    expect(notes.raw(ns, key)).toBeUndefined();
+    expect(await rail.lock(deal.terms)).toBe(deal.terms.contract);
+    expect(await rail.verifyLock(deal.terms, deal.terms.contract)).toBe(true);
+  });
 });
 
 describe("paper rail — reads are anonymous input", () => {
@@ -182,6 +229,28 @@ describe("paper rail — reads are anonymous input", () => {
       },
     ] as const) {
       expect(decodePaperRecord(encodePaperRecord(record))).toEqual(record);
+    }
+  });
+
+  it("refuses to emit a line its own decoder would reject", () => {
+    const statement = "0x" + "ab".repeat(32);
+    const shouted = "0x" + "AB".repeat(32);
+    // One check per field the emitter can spell in a way the grammar refuses: the
+    // statement's hex case, a deadline that stringifies as `1e+21`, the secret's hex case.
+    for (const record of [
+      { status: "locked", lock: "hash", statement: shouted, refundAfterMs: REFUND_AFTER },
+      { status: "locked", lock: "hash", statement, refundAfterMs: 1e21 },
+      {
+        status: "claimed",
+        lock: "hash",
+        statement,
+        refundAfterMs: REFUND_AFTER,
+        secret: "0x" + "CD".repeat(32),
+      },
+    ] as const) {
+      expect(() => encodePaperRecord(record), JSON.stringify(record)).toThrow(
+        /unreadable paper record/,
+      );
     }
   });
 


### PR DESCRIPTION
## What

`encodePaperRecord` now decodes the line it just built and refuses the record when that
returns `null`, so `PaperRail` can no longer write a note line it will never read back.
A record that already round-tripped encodes to exactly the same bytes.

+12/-1 in `src/paper-rail.ts` (7 of the added lines are the doc comment), +68 in
`tests/paper-rail.test.ts`, +10 in `CHANGELOG.md`. Nothing else is touched.

## Why

`decodePaperRecord` requires `/^0x[0-9a-f]{64}$/` for the secret field, and SPEC.md §3
spells both a statement and a secret as `0x` + lowercase hex, so the decoder's grammar is
the half that is right. The guard `claim` runs one line before the write is deliberately
wider, and not because of any statement-side normalization: `verifySecret` decodes the
revealed secret through `hexToU8a`, whose `isHex` matches `/^0x[\da-fA-F]+$/`
(`src/hex.ts:16` — a tolerance #63 left in place when it rewrote the rest of that
function), and both lock kinds take the raw 32 bytes as readily as hex, a point witness
lifted straight from a `PointWitnessRevealed` event (`src/points.ts` header). A secret
could therefore open the statement and still be unwritable — and the write went ahead
anyway.

Measured on both builds, one contract per row, `MemoryNoteStore` so the venue is not
involved:

| `claim` secret | `verifySecret` | before: `claim()` | before: `read()` | before: recovery | after: `claim()` | after: `read()` |
|---|---|---|---|---|---|---|
| lowercase hex (canonical) | true | resolves | `claimed` | n/a | resolves, unchanged | `claimed` |
| uppercase hex preimage | true | resolves | `null` | none through the rail | throws `refusing to write an unreadable paper record (claimed)` | `locked` |
| uppercase hex witness, point lock | true | resolves | `null` | none through the rail | throws, same message | `locked` |
| the 32 secret bytes, untyped caller | true | resolves | `null` | none through the rail | throws, same message | `locked` |

The last row holds for a hash preimage and for a point witness alike; I ran both.

"None through the rail" is the exact scope of it. Once the line is unparseable, every
route `PaperRail` exposes is closed:

```
rail.refund(ref)       -> threw: tclk: refund on an unreadable paper record 0x0dcd…
rail.claim(ref, lower) -> threw: tclk: claim on an unreadable paper record 0x0dcd…
rail.lock(terms) again -> threw: tclk: paper rail already has a record for 0x0dcd…
```

Recovery does exist, one level down: these records are world-writable — the module header
says so, "anyone can overwrite any status on any contract" — so a single unconditional
`notes.set(ns, key, line)` puts the `locked` line back and the canonical claim then
resolves. I ran that on the pre-fix build for every non-canonical spelling above (four
runs, counting both raw-bytes variants) and it recovered every one. But `SettlementRail`
exposes no unconditional write, `PaperRail` keeps its `NoteStore` private, and its own
`advance` is a compare-and-set, so a client written against the interface has no route
back: it needs whoever owns the note surface to step outside the rail and repair a line the
rail itself produced. Until someone does, the counterparty polling that note sees the deal
as absent, even though the claim reported success.

After the fix the same three lines read `refund before refundAfterMs` (the ordinary
predicate), `claim … -> resolved` with the canonical spelling, and `already has a record` —
the lock survived the refusal and is still claimable.

`lock` had the same hole for a hand-built `LockTerms`, and `encodePaperRecord` emitted
three shapes its own decoder refuses:

| record | line `encodePaperRecord` wrote | `decodePaperRecord` of that line |
|---|---|---|
| `claimed`, `secret: "0x" + "CD".repeat(32)` | `tclkpaper1 claimed hash 0xabab… 1756707200000 0xCDCD…` | `null` |
| `locked`, `statement: "0x" + "AB".repeat(32)` | `tclkpaper1 locked hash 0xABAB… 1756707200000` | `null` |
| `locked`, `refundAfterMs: 1e21` | `tclkpaper1 locked hash 0xabab… 1e+21` | `null` |

<details><summary>repro (public API only, after <code>pnpm -r --include-workspace-root build</code>)</summary>

```js
import { PaperRail, MemoryNoteStore, generateHashLock, makeOffer, makeAccept,
  applyFrame, openContract, lockTerms, verifySecret, paperNote } from "./dist/index.js";
const T0 = 1_756_700_000_000;
const hash = generateHashLock();
const offer = makeOffer({ from: "did:key:z6Mk" + "f".repeat(44), role: "payer", lock: "hash",
  amount: "1000000", asset: "PAPER", rails: ["paper"], claimByMs: T0 + 3_600_000,
  refundAfterMs: T0 + 7_200_000, expiresMs: T0 + 600_000, nonce: "9f2c81d04c9e1f7a" });
const accept = makeAccept(offer, { from: "did:key:z6Mk" + "g".repeat(44), statement: hash.hash });
const terms = lockTerms(applyFrame(openContract(offer), accept, T0).state);
const notes = new MemoryNoteStore();
const rail = new PaperRail(notes, () => T0);
const ref = await rail.lock(terms);
const { ns, key } = paperNote(ref);
const locked = notes.raw(ns, key);                     // the good line, kept aside
const shouted = "0x" + hash.preimage.slice(2).toUpperCase();
console.log(verifySecret("hash", terms.statement, shouted)); // true, before and after
await rail.claim(ref, shouted).catch((e) => console.log(e.message)); // silent on main
console.log(await rail.read(ref));                     // null on main; locked now
await rail.refund(ref).catch((e) => console.log(e.message)); // on main: "unreadable"
await notes.set(ns, key, locked);                       // the repair the rail lacks
console.log((await rail.read(ref))?.status);           // locked, on either build
```

The point-lock and raw-bytes rows are the same script with `generatePointLock()` (plus a
`paymentKey` on both frames) and with the secret passed as `Uint8Array`.
</details>

### Cost

The self-check is one `decodePaperRecord` of the line just built, which is what `read` and
`verifyLock` already pay on every poll, and it is dominated by the same
`isValidPointStatement` curve parse for a point record either way. I measured it at tens of
microseconds for a point record and a fraction of one for a hash record on a developer
machine, but I am not putting the table in: the spread between runs was wider than the
difference I would be claiming, and a number that does not reproduce on a second machine is
worth less than no number. The structural claim is the one that holds — one decode, in front
of a note write that is an HTTP round trip to the venue.

### Alternatives rejected

Lowercasing the secret in `claim` would coerce a malformed value on the money path, which
AGENTS.md rules out, and would store a spelling the caller never revealed. Guarding only
in `claim` leaves `lock` free to write an unreadable line on a contract's first write.
Putting the check in the emitter also means it inherits every future tightening of the
decoder rather than restating the grammar in a second place.

## Checks

Run locally in this worktree; I have not seen a CI run for this branch.

| command | result |
|---|---|
| `pnpm install --frozen-lockfile` | `Already up to date` |
| `pnpm -r --include-workspace-root build` | `tsc -p tsconfig.json` clean for both packages |
| `pnpm -r --include-workspace-root test` | library `107 passed (107)` in 9 files, `mcp` `40 passed (40)` in 6 files, `mcp/worker` `33 passed (33)` in 2 files |

`tests/vectors.test.ts` is untouched (`git diff origin/main..HEAD -- tests/vectors.test.ts`
is empty) and its 3 tests pass, as does the existing assertion at
`tests/paper-rail.test.ts:81` that pins the exact stored `locked` line. No wire byte moves:
the paper record grammar is unchanged and no frame is involved.

Both ways, tests kept in place:

- revert only the `src/paper-rail.ts` hunk → `Test Files 1 failed | 8 passed (9)`,
  `Tests 3 failed | 104 passed (107)`, and `pnpm -r` stops there, so the `mcp` suites do
  not run:
  - `tests/paper-rail.test.ts:142` — `AssertionError: uppercase hex: expected 'resolved' to match /refusing to write an unreadable paper…/`
  - `tests/paper-rail.test.ts:163` — `AssertionError: promise resolved "'0x8c560e5cbdc6b5f4e89659792cf7b089588…'" instead of rejecting`
  - `tests/paper-rail.test.ts:250` — `AssertionError: {"status":"locked","lock":"hash","statement":"0xABAB…","refundAfterMs":1756707200000}: expected [Function] to throw an error`
- restore it → `107 passed (107)`, `40 passed (40)`, `33 passed (33)`, all three green.

## SPEC or code

SPEC. SPEC.md §3's field table pins the spelling — the row reads "hash statement / secret |
`0x` + 64 lowercase hex (32 bytes)" — and the rule above it is normative too: "Decoding is
fail-closed: a known frame type with an unknown key, a missing field, or a malformed value
is rejected, never coerced". `decodePaperRecord` already matched both; `encodePaperRecord`
did not. No SPEC text needed changing, and the class doc's own promise — that the rail
"enforces the same predicates a real rail must … so a client written against this rail is
written correctly" — is what a silent unreadable write broke.

## Hostile counterparty

Before: a counterparty who hands the preimage over out of band in uppercase gets the
claimer's own record bricked while `claim()` reports success — the `claimed` evidence never
appears in the namespace, `read` is `null`, and no method on the rail puts a readable line
back, so the claimer needs out-of-band access to the note surface to undo a line the rail
wrote for them. A `reveal` frame cannot carry that spelling (`validateFrame` pins `secret`
to `HEX32`, `src/frames.ts:156` and `:343`), so the venue would not have shown it either.
It costs the griefer nothing.

After: nothing. The write is refused before it happens, state is unchanged, and a retry
with the canonical spelling claims normally. No value moves in either direction — the
paper rail holds none, and what the old behaviour destroyed was the rehearsal record.

The only new surface is a refusal: `encodePaperRecord` can now throw, which is the API
change the `CHANGELOG` entry describes. Its message names the record status and nothing
else, per the no-echo rule `src/hex.ts` states for the same class of value.

## Overlap

Every state below is from `gh` on 2026-09-04, not from when I wrote the patch.

- **#29** "Reject malformed PaperRail statements during decode" (merged 2026-09-03,
  `528190f`) changed one decode line to `isValidStatement(lock, statement)`, tightening what
  the decoder accepts. This is the opposite direction — what the emitter produces — and it
  reuses that same call rather than restating the grammar, so the two compose: the emitter
  now inherits every tightening the decoder gets.
- **#53** "fix(commitments): accept uppercase hex, as the rest of the library does" is
  **closed unmerged** (2026-09-03). It proposed the other cure for a hex-case mismatch,
  widening `src/commitments.ts`; sv closed it with one line, "collapses byte-distinct
  salts". Nothing here widens a grammar. `decodePaperRecord` keeps its exact field rules and
  the emitter stops producing lines outside them, so byte-distinct spellings stay distinct
  and the non-canonical one is refused rather than folded.
- **#63** (merged 2026-09-03, `9acc318`, `src/hex.ts`) rewrote `hexToU8a`'s empty-string
  hole and its refusal message and left `HEX_REGEX`'s `a-fA-F` untouched, so the case
  tolerance the Why section points at reads the same after that PR as before it. Nothing
  here narrows it. Its no-echo rule is why the new refusal names the status only.
- **#51**, **#52** and **#55** (all merged 2026-09-03; receipt rail/ref contradiction,
  MCP window read, nonce preservation) touch none of these paths. This branch is one commit
  on `origin/main` at `5cc4ab9`, which is #55.
- Of the 13 pull requests open as of 2026-09-04, none touches `src/paper-rail.ts`. The ones
  that touch library `src/` at all are #66 and #16 (`src/frames.ts`), #62 (`src/index.ts`,
  `src/transcript.ts`), #32 (`src/machine.ts`) and #21 (adds `src/evm-hash-rail.ts`).
- **My own siblings, disclosed because they go out together.** Six branches of mine are
  queued: `fix/worker-body-cap-in-bytes` (`mcp/worker/src/worker.ts`), this one
  (`src/paper-rail.ts`), `fix/rail-validates-the-clock-reading` (`src/rail.ts` and
  `src/paper-rail.ts`), `fix/mcp-validates-the-room-before-signing` (`mcp/src/tools.ts`),
  `fix/schema-point-lock-payment-key-and-ms-bounds`
  (`schema/tclk1-frames.schema.json`) and `fix/export-the-shipped-schema-path`
  (`package.json`). Three files are shared and I would rather name them than have them
  found: all six touch `CHANGELOG.md`, and `fix/rail-validates-the-clock-reading` shares
  both `src/paper-rail.ts` (it swaps `this.clock()` for `railNow(this.clock)` in `lock`,
  `claim` and `refund`, lines away from `encodePaperRecord`) and `tests/paper-rail.test.ts`
  (its new test lands in the same `describe`, eight lines above mine). I ran `git merge-tree
  --write-tree` between this branch and each of the other five in both orders: ten clean
  merges, and the merged tree carries both `src/paper-rail.ts` edits and all four new tests.
  The `CHANGELOG.md` entries do not collide because each is anchored next to the behaviour it
  extends rather than at the top of `Fixed`, so the six land at six different points.

## Provenance

Signed with the same `did:key` as #59, #60, #66 and #68.

```
did        did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL
head       d73ef29f66cea65cd2ba571c399c8f03bc26aa0a
digest     dbc2aecc194dc59ed3ae54ecb97e088d25ae49c5242c9cdab5bd2abcf5143c09
signature  HmdX3WXEGouBoqoo73RTPfJmTvnEPh9RVRcY2CLTwOUvDIybdXHE4Ab9kQ4OZQHbzqjemHZxCffCAp1x5KyBCw
```

Rebuild the digest: `sha256` each file's bytes at `head`, one `<sha256>  <path>` line per file
in the order CHANGELOG.md, src/paper-rail.ts, tests/paper-rail.test.ts, then `sha256` that text.

```
c13bc7ee7a9cfcb3319ccb909c8d6a89f1d4f3fa17db6d94da20ec53d70781a1  CHANGELOG.md
b748b826a7f86cd46ab80fdfb6893f98565b2d7fe12482c83338565396495f7b  src/paper-rail.ts
1e424e3d48999fc696c762564867795dd0b2bdb0081417032239012d6b1eb083  tests/paper-rail.test.ts
```

Signed payload `tclk-pr|flop-labs/tclk|<head>|<digest>`. Verify with the public key decoded out
of the DID — no private key in the loop, and a tampered payload must fail. Key note:
<https://technocore.chat/kv/agent/f15ddb2552fee06f> (the documented `/kv/did/` namespace is at
its cap, flop-labs/technocore-chat#85).
