### PR TITLE
fix(schema): bound the unix-ms leaves, require point-lock paymentKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,16 @@ All notable changes to this project are documented here. Format follows
   decoder uses and the package ships it, so an independent implementation validating
   against the schema was being told to emit frames the reference refuses. Only the schema
   moved. No decoder behaviour, wire byte or golden vector changed.
+- `schema/tclk1-frames.schema.json` also admitted two `offer` shapes the decoder rejects, in
+  the leaves #59's string sweep could not reach. A `point` lock with no `paymentKey`
+  validated, where SPEC §3.1 makes the key required for point locks and `validateFrame`
+  refuses the frame; and `claimByMs`, `refundAfterMs` and `expiresMs` were `minimum: 1` with
+  no ceiling, so every integer above 2^53 - 1 — the largest `requireMs` accepts, and the
+  point where a JSON number stops round-tripping to a distinct integer — was schema-valid
+  and decoder-invalid. The three leaves now carry `maximum: 9007199254740991` and the offer
+  definition carries the point-lock rule as `if`/`then`. Only the schema moved: the generated
+  field contract and the SPEC table are byte-identical, and no wire byte or golden vector
+  changed.
 - `decodeFrame` now enforces the same `MAX_FRAME_CHARS` room-message cap `encodeFrame` does.
   SPEC §2 states the cap as a property of a frame, and technocore refuses a longer text, so a
   longer line was never a stored room message. The check runs before `JSON.parse`, which bounds

--- a/schema/tclk1-frames.schema.json
+++ b/schema/tclk1-frames.schema.json
@@ -76,9 +76,9 @@
           "minItems": 1,
           "items": { "$ref": "#/$defs/rail" }
         },
-        "claimByMs": { "type": "integer", "minimum": 1 },
-        "refundAfterMs": { "type": "integer", "minimum": 1 },
-        "expiresMs": { "type": "integer", "minimum": 1 },
+        "claimByMs": { "type": "integer", "minimum": 1, "maximum": 9007199254740991 },
+        "refundAfterMs": { "type": "integer", "minimum": 1, "maximum": 9007199254740991 },
+        "expiresMs": { "type": "integer", "minimum": 1, "maximum": 9007199254740991 },
         "paymentKey": { "$ref": "#/$defs/hex33" },
         "job": { "$ref": "#/$defs/job" },
         "nonce": { "$ref": "#/$defs/nonce" },
@@ -87,7 +87,9 @@
       "required": [
         "type", "from", "role", "amount", "asset", "lock", "rails", "claimByMs",
         "refundAfterMs", "expiresMs", "nonce", "id"
-      ]
+      ],
+      "if": { "properties": { "lock": { "const": "point" } }, "required": ["lock"] },
+      "then": { "required": ["paymentKey"] }
     },
     "accept": {
       "type": "object",

--- a/tests/schema-conformance.test.ts
+++ b/tests/schema-conformance.test.ts
@@ -21,32 +21,44 @@ const CONTRACT = "0x" + "11".repeat(32);
 const PRESIG_NONCE = "0x02" + "11".repeat(32);
 
 /**
- * Evaluate one schema string leaf against a value, following at most one `$ref`. Every
- * constraint checked below is a string leaf, so `minLength` and `pattern` are the whole
- * surface this needs; it is deliberately not a general JSON Schema validator.
+ * Evaluate one schema leaf against a value, following at most one `$ref`. Every constraint
+ * checked below is a string or integer leaf, so `minLength`/`pattern` and `minimum`/`maximum`
+ * are the whole surface this needs; it is deliberately not a general JSON Schema validator.
  */
-function schemaAdmits(definition: string, field: string, value: string): boolean {
+function schemaAdmits(definition: string, field: string, value: string | number): boolean {
   const property = schema.$defs[definition].properties[field];
   const leaf = property.$ref ? schema.$defs[property.$ref.split("/").at(-1)] : property;
-  if (leaf.type !== "string") throw new Error(`${definition}.${field} is not a string leaf`);
+  if (leaf.type === "integer") {
+    if (typeof value !== "number" || !Number.isInteger(value)) return false;
+    if (leaf.minimum !== undefined && value < leaf.minimum) return false;
+    return leaf.maximum === undefined || value <= leaf.maximum;
+  }
+  if (leaf.type !== "string" || typeof value !== "string") {
+    throw new Error(`${definition}.${field} is not a string or integer leaf`);
+  }
   if (leaf.minLength !== undefined && value.length < leaf.minLength) return false;
   return leaf.pattern === undefined || new RegExp(leaf.pattern).test(value);
 }
 
+const OFFER_FIELDS = {
+  from: PAYER_DID,
+  role: "payer",
+  amount: "1000000",
+  asset: "FLOP",
+  lock: "hash",
+  rails: ["paper"],
+  claimByMs: 1_756_800_000_000,
+  refundAfterMs: 1_756_886_400_000,
+  expiresMs: 1_756_713_600_000,
+  nonce: "9f2c81d04c9e1f7a",
+} as const;
+
 function offerWithJob(job: JobRef) {
-  return () => makeOffer({
-    from: PAYER_DID,
-    role: "payer",
-    amount: "1000000",
-    asset: "FLOP",
-    lock: "hash",
-    rails: ["paper"],
-    claimByMs: 1_756_800_000_000,
-    refundAfterMs: 1_756_886_400_000,
-    expiresMs: 1_756_713_600_000,
-    nonce: "9f2c81d04c9e1f7a",
-    job,
-  });
+  return () => makeOffer({ ...OFFER_FIELDS, job });
+}
+
+function offerWithMs(field: "claimByMs" | "refundAfterMs" | "expiresMs", value: number) {
+  return () => makeOffer({ ...OFFER_FIELDS, [field]: value });
 }
 
 function lockWithPresigScalar(s: string) {
@@ -95,5 +107,26 @@ describe("protocol schema", () => {
       expect(offerWithJob(job)).toThrow(new RegExp(`job\\.${field}`));
     }
     expect(offerWithJob({ proto: "a2a", id: "task-3f", context: "ctx-1" })).not.toThrow();
+  });
+
+  it("admits no unix-ms field the decoder rejects", () => {
+    // 2^53 is the first value above the range `requireMs` accepts (safe integers only);
+    // `minimum: 1` already refused 0, but nothing capped the top until now.
+    for (const field of ["claimByMs", "refundAfterMs", "expiresMs"] as const) {
+      for (const value of [0, Number.MAX_SAFE_INTEGER + 1, 1e16]) {
+        expect(schemaAdmits("offer", field, value), `schema admits offer.${field} ${value}`).toBe(false);
+        expect(offerWithMs(field, value)).toThrow(new RegExp(`${field} must be a positive unix-ms integer`));
+      }
+    }
+    expect(schemaAdmits("offer", "expiresMs", Number.MAX_SAFE_INTEGER)).toBe(true);
+    expect(offerWithMs("expiresMs", Number.MAX_SAFE_INTEGER)).not.toThrow();
+  });
+
+  it("requires paymentKey on a point-lock offer, as SPEC §3.1 and the decoder do", () => {
+    // A conditional rather than a leaf, and no JSON Schema validator ships here, so the
+    // keyword pair is asserted structurally the way the `uniqueItems` case above is.
+    expect(schema.$defs.offer.if?.properties?.lock?.const).toBe("point");
+    expect(schema.$defs.offer.then?.required).toContain("paymentKey");
+    expect(() => makeOffer({ ...OFFER_FIELDS, lock: "point" })).toThrow(/point locks require paymentKey/);
   });
 });


### PR DESCRIPTION
## What

`schema/tclk1-frames.schema.json` no longer admits two `offer` shapes `validateFrame` rejects: a `point` lock with no `paymentKey`, and a `claimByMs`, `refundAfterMs` or `expiresMs` above `Number.MAX_SAFE_INTEGER`. Nothing in `src/` changes.

## Why

SPEC §3 calls this file "the same artifact the decoder uses" and `files[]` ships it, so an independent implementation validates against the schema rather than against `src/`. Every row below is measured against ajv's JSON Schema 2020-12 validator, out of tree, on the whole document. Three of the five are also asserted in the suite through the leaf evaluator the conformance test ships (`schemaAdmits`, which reads one leaf's `minLength`/`pattern`/`minimum`/`maximum`); the point-lock rows are not, because that helper sees one leaf at a time and the conditional is not a leaf — those are asserted structurally instead, the way the existing `uniqueItems` case is, which agrees row for row.

| offer | schema on main | schema here | decoder, unchanged |
|---|---|---|---|
| `expiresMs = 9007199254740992` (2^53) | valid | `maximum` | `tclk: expiresMs must be a positive unix-ms integer` |
| `refundAfterMs = 1e16` | valid | `maximum` | `tclk: refundAfterMs must be a positive unix-ms integer` |
| `expiresMs = 9007199254740991` | valid | valid | accepted |
| `lock: "point"` with no `paymentKey` | valid | `paymentKey` required | `tclk: point locks require paymentKey` |
| unmodified hash offer | valid | valid | accepted |

The ajv run is a cross-check, not a test: no JSON Schema validator is a dependency of this repo — ajv 8.20.0 sits in the pnpm store as a transitive dependency of `@modelcontextprotocol/sdk` and does not resolve as `ajv` from the root or from `mcp/` — so the shipped assertions stay dependency-free. It is also where the one control `schemaAdmits` cannot express comes from — an unknown key failing `additionalProperties`, which is a document-level keyword. The leaf controls are asserted through the helper in the suite: `job.proto = "A2A"` fails `pattern` and `expiresMs = 0` fails `minimum`, each of them in both states, before and after. Under the new schema the golden-vector `offer` and `accept` frames still validate as whole documents, as does a `point` offer whose `paymentKey` is a real compressed key from `generatePointLock()`.

`requireMs` accepts only a safe integer, and above 2^53 - 1 a JSON number stops round-tripping to a distinct integer, so `minimum: 1` with no ceiling was the looser half. If putting that bound in a wire schema reads like leaking a JavaScript limit into the protocol: merged #55, the commit this branch is based on, made the same call one layer out — "Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema boundary rather than silently rounded." SPEC §3.1 says `paymentKey` is "required for `point` locks — adaptor signatures need it", where the schema left it optional for every lock kind. SPEC and the decoder already agreed, so I treated both as correct and moved the schema.

The drift gate cannot see either defect: `scripts/generate-frame-fields.mjs` reads each frame's property names, its own `required` array and the rail registry, never a value constraint, so `--check` exits 0 against the old schema and against this one. What changed is `maximum` inside three existing properties plus an offer-level `if`/`then`, which leaves both of those sets alone — `src/frame-fields.generated.ts` and SPEC's generated field table are byte-identical.

Precedent for the shape: merged #59 is the same file and the same defect class, and it landed four string leaves in one PR (`presig.s`, `job.proto`, `job.id`, `job.context`). Those stay fixed here, and these two are what it could not reach — its `schemaAdmits` threw on any leaf that is not a string, and the point-lock rule is not a property leaf at all. That helper now evaluates `minimum`/`maximum` as well, and the conditional is asserted structurally beside the decoder's refusal.

Overlap, checked 2026-09-03 20:00 UTC: no open pull request touches `schema/` or `tests/schema-conformance.test.ts`. The nearest by subject, #16 (open), moves `src/frames.ts` and `tests/tclk.test.ts` — the decoder's unknown-key check, not the schema. Most open PRs do add a `CHANGELOG.md` bullet, as this one does; ours anchors directly after the #59 entry, and no open PR's `CHANGELOG.md` hunk carries that entry as context. Trial merges (`git merge-tree --write-tree`) against all thirteen open heads give exactly the conflict sets each already has against `origin/main`, identical file for file — including the three already conflicted there (#16, #21, #50) — so this branch adds none.

Also mine, unpushed and going out beside this one: five sibling branches, touching `mcp/worker/src/worker.ts`; `src/paper-rail.ts`; `src/rail.ts` and `src/paper-rail.ts`; `mcp/src/tools.ts`; and `package.json` (that last one exports this schema's path). None of them touches `schema/` or `tests/schema-conformance.test.ts`; each adds its own `CHANGELOG.md` bullet, and all six merge onto `origin/main` in sequence with no conflict, with this bullet still directly after the #59 entry in the result. Two more of mine are already open, #66 and #68, and neither touches these two files either.

Reverting the schema hunk alone, both new tests left in place, gives `2 failed | 104 passed (106)` at `tests/schema-conformance.test.ts:117` ("schema admits offer.claimByMs 9007199254740992: expected true to be false") and `:128` ("expected undefined to be 'point'"). In that same state `--check` still exits 0 and the `mcp` package stays green — 40 tests, plus 33 under the Worker config — which is what "nothing outside the library reads this file" looks like from the outside.

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` (106 root, was 104; 40 mcp; 33 worker)
- [x] Golden vectors untouched — `tests/vectors.test.ts` is byte-identical to `origin/main`, nothing at runtime reads the schema (only `scripts/generate-frame-fields.mjs` and `tests/schema-conformance.test.ts` open it), and both golden frames still validate under the new one
- [x] `CHANGELOG.md` has an `[Unreleased]` entry for anything user-visible
- [x] Docs that would now be wrong are updated: none of `SPEC.md`, `README.md`, `mcp/README.md`, `mcp/worker/README.md`, `AGENTS.md` states a constraint this changes. SPEC's generated table still lists `paymentKey` among `offer`'s optional fields and is byte-identical (`node scripts/generate-frame-fields.mjs --check`, exit 0); that table has only ever carried unconditional field sets, and the conditional rule it cannot express is the §3.1 sentence this change now matches
- [x] New surface on the money path: nothing. No decoder answer differs before or after, so a hostile counterparty gets exactly what it got already; the change only stops an honest third-party implementation from being told to emit an offer the reference refuses

The three commands above were run in this worktree at d7a844b. No GitHub Actions run has been observed for this branch yet.

## Provenance

Signed with the same `did:key` as #59, #60, #66 and #68.

```
did        did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL
head       d7a844b23eb72f798eb627660304333dad44bb40
digest     1be5b6d46167e838403b09ca202eb0d176d13aee056c998baf7aa04b2687b732
signature  WaoLZusLCuMX8OHeYdH8NGUcPKb1yroJC8u7KQ9fipx22RjTWqlgrQGb2y-cS1afnNatMX_2B7ZK6_31AnpLDQ
```

Rebuild the digest: `sha256` each file's bytes at `head`, one `<sha256>  <path>` line per file
in the order CHANGELOG.md, schema/tclk1-frames.schema.json, tests/schema-conformance.test.ts, then `sha256` that text.

```
73766b052aea12b504fcc81ed74638572e85ab2c5d93eedfc6fd55b68737acbd  CHANGELOG.md
2266dc03e37f7b45dff7559dc419ecf1e92b76a34760840020b62be972236586  schema/tclk1-frames.schema.json
e48914b9fe9926ef7613899eb37a168f1ad9f73be57e4b597cb2eec12e930b46  tests/schema-conformance.test.ts
```

Signed payload `tclk-pr|flop-labs/tclk|<head>|<digest>`. Verify with the public key decoded out
of the DID — no private key in the loop, and a tampered payload must fail. Key note:
<https://technocore.chat/kv/agent/f15ddb2552fee06f> (the documented `/kv/did/` namespace is at
its cap, flop-labs/technocore-chat#85).
