### PR TITLE
fix(worker): measure the request-body cap in bytes, not UTF-16 units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,14 @@ All notable changes to this project are documented here. Format follows
 - Technocore note parsers now reject capability lists with empty rail entries and state
   pointers with malformed rail references, matching the encoders and keeping world-writable
   note input fail-closed.
+- The hosted Worker now measures its 1 MiB request-body cap in UTF-8 bytes, the unit
+  `MAX_BODY_BYTES` and the 413 it returns are both named in. The post-read re-check compared
+  `body.length`, a UTF-16 code-unit count, so 1,048,500 three-byte code points were read,
+  parsed and served as a 3,145,560-byte body — just under three times the cap the same reply
+  reports, out of the same constant the `content-length` check above it already measured in
+  bytes. That re-check is the only size check that fires for a chunked body, which carries no
+  `content-length` to check first. Worker HTTP framing only: no wire bytes move and no golden
+  vector changes.
 - Unknown lock kinds now fail closed in statement validation and secret verification.
 - `validateDeadlines` now rejects malformed clocks, non-finite safety margins, and
   unvalidated offer timestamps before doing arithmetic. A negative-infinite clock or an

--- a/mcp/worker/src/worker.ts
+++ b/mcp/worker/src/worker.ts
@@ -547,8 +547,11 @@ export async function handleRequest(
     return rpcError(null, PARSE_ERROR, "could not read the request body", 400);
   }
   // Re-checked after reading: `content-length` is the client's claim, and a chunked body
-  // does not carry one at all.
-  if (body.length > MAX_BODY_BYTES) {
+  // does not carry one at all. Measured in UTF-8 bytes, the unit `MAX_BODY_BYTES` and the
+  // 413 both name — `body.length` counts UTF-16 code units, so 1,048,500 three-byte code
+  // points passed as a 3,145,560-byte body and the cap moved with the caller's alphabet.
+  // UTF-8 is never shorter than the code-unit count, so `body.length` stays a fast reject.
+  if (body.length > MAX_BODY_BYTES || new TextEncoder().encode(body).byteLength > MAX_BODY_BYTES) {
     return jsonResponse({ error: `body exceeds ${MAX_BODY_BYTES} bytes` }, 413);
   }
 

--- a/mcp/worker/tests/worker.test.ts
+++ b/mcp/worker/tests/worker.test.ts
@@ -435,6 +435,32 @@ describe("HTTP and JSON-RPC framing", () => {
     );
     expect(response.status).toBe(413);
   });
+
+  it("413s a body over the cap in bytes whose UTF-16 code units are under it", async () => {
+    // `MAX_BODY_BYTES` is named in bytes and the 413 reports bytes, so the alphabet the
+    // padding is written in must not change where the cap falls. '한' is one UTF-16 code
+    // unit and three UTF-8 bytes.
+    const padded = (count: number) =>
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping", params: { pad: "한".repeat(count) } });
+    const post = (body: string) =>
+      handleRequest(
+        new Request(url, { method: "POST", headers: { "content-type": "application/json" }, body }),
+        ENV,
+      );
+
+    const over = padded(400_000);
+    expect(over.length).toBe(400_060);
+    expect(new TextEncoder().encode(over).byteLength).toBe(1_200_060);
+    const refused = await post(over);
+    expect(refused.status).toBe(413);
+    expect(((await refused.json()) as { error: string }).error).toBe("body exceeds 1048576 bytes");
+
+    // The other direction, so this is a cap and not a ban on multi-byte text: the same
+    // padding under the byte cap is still served.
+    const under = padded(300_000);
+    expect(new TextEncoder().encode(under).byteLength).toBe(900_060);
+    expect((await post(under)).status).toBe(200);
+  });
 });
 
 describe("no environment variable this build refuses is ever recommended", () => {


### PR DESCRIPTION
## What

`mcp/worker/src/worker.ts` measured its 1 MiB request-body cap with `body.length` after reading the body — a count of UTF-16 code units, not bytes. The comparison now measures UTF-8 bytes, the unit `MAX_BODY_BYTES` is named in and the unit its own 413 reports. One condition, the comment above it from two lines to five, one test.

## Why

`MAX_BODY_BYTES` is `1_048_576`, the reply is `body exceeds ${MAX_BODY_BYTES} bytes`, and the `content-length` check fifteen lines above it — with the body read in between — compares that same constant against `Number(declared)`, which is definitionally a byte count. So one constant was being applied in two units inside one function, and the looser of the two was the fallback. Every BMP code point above U+07FF is three UTF-8 bytes to one UTF-16 code unit, so a body of 1,048,500 such code points inside a 60-character ASCII JSON-RPC envelope is 1,048,560 code units and 3,145,560 bytes — and it passed a 1,048,576-byte cap.

The post-read check is the half where this matters. Its own comment says why it exists — "a chunked body does not carry one at all" — and for that framing it is the only size check that fires, because nothing above it fires when there is no `content-length` to read.

Measured against `handleRequest` directly, in my own run: esbuild bundles of `mcp/worker/src/worker.ts` at `origin/main` and at this commit, driven with synthetic `Request`s. No `content-length` header on any shot, so all three land on the post-read check. Body `{"jsonrpc":"2.0","id":1,"method":"ping","params":{"pad":"…"}}`:

| pad | UTF-16 code units | UTF-8 bytes | before | after |
| --- | --- | --- | --- | --- |
| `"x".repeat(1_100_000)` | 1,100,060 | 1,100,060 | 413 | 413 |
| `"한".repeat(1_048_500)` | 1,048,560 | 3,145,560 | 200, `{"jsonrpc":"2.0","id":1,"result":{}}` | 413 |
| `"한".repeat(300_000)` | 300,060 | 900,060 | 200 | 200 |

The fix can only refuse more, never less, and that is exhaustive rather than sampled: every one of the 65,536 single UTF-16 code units encodes to 1–3 UTF-8 bytes, and every one of the 1,048,576 surrogate pairs encodes to 4 bytes for its 2 units, so byte length is never below code-unit count for any string. (A lone surrogate is one unit and three bytes, as U+FFFD.) The same bound read the other way is why the cheap comparison stays in front as a fast reject: at most 3 bytes per code unit, and the encode only runs on a body of at most 1,048,576 code units, so the added allocation is bounded by 3 MiB instead of growing with the body.

Cost of the added measurement — my own run, node v22.22.2 on a developer machine rather than the Workers runtime: about 0.8 µs to encode the 361-byte `tools/call tclk_make_offer` body this repo's own fixtures produce, and 0.2–0.4 ms across repeated rounds for a 1 MiB body at the cap. The 3 MiB worst case the fast reject still admits is about 2 ms.

`TextEncoder` is a Workers global, and the deployed bundle already contains three other `new TextEncoder()` call sites (`src/hex.ts`, `src/transcript.ts`, `mcp/src/signing.ts`), so nothing new is asked of the runtime and `wrangler.jsonc`'s "No `nodejs_compat`, and that is a checked fact rather than an omission" note still holds.

Which one I treated as correct: **the code**, specifically the constant's name plus the byte-measured `content-length` check beside it. `SPEC.md` says nothing about the hosted Worker's HTTP body cap. SPEC §2's "≤ 4096 chars" is the per-frame room-message cap, and `src/frames.ts` enforces that one in `line.length` — correctly, because a canonical frame is ASCII-only, so chars and bytes coincide there. A JSON-RPC body is arbitrary client-supplied UTF-8, which is where the two units come apart. `SPEC.md` is untouched.

What a hostile counterparty gets: **nothing**. No tool, no argument, no money-path surface is added; the HTTP layer only accepts less. What it takes away is the `JSON.parse` and dispatch of a body three times over the cap — that middle row came back `200` with a dispatched result, not just read. The read itself is unchanged: `await request.text()` runs first either way, bounded by `content-length` when the client declares one and by nothing when the body is chunked. It does add one UTF-8 copy of an admitted body inside the isolate, and three tools served on this path take secret material as an argument (`tclk_make_reveal`, `tclk_verify_secret`, `tclk_adaptor_adapt`), so that copy can hold a preimage or a witness. It is transient, never logged and never stored — `assertNoCustody` still refuses to serve at all when a signing or payment key is bound — but "nothing passes through this path" would be the wrong claim to make.

What changes for a caller: a body over 1,048,576 bytes now gets the 413 it always claimed to get, whatever alphabet it is written in. A well-behaved caller is unaffected, measured rather than asserted — a signed transcript record built from this repo's own fixtures (line, room, seq, timestamp, sender, nonce, signature) is 655 bytes of JSON for an offer and 628 for an accept, so a `tclk_apply_transcript` body carrying 1,000 of them measures 658,004 bytes: under the cap in either unit, with room to spare in the unit that now binds.

## Checks

The three CI commands, run locally from the worktree root. I have not seen a GitHub Actions run for this branch and am not claiming one.

```
pnpm install --frozen-lockfile              → Already up to date
pnpm -r --include-workspace-root build      → both projects, tsc clean, exit 0
pnpm -r --include-workspace-root test       → below, exit 0
```

Both directions, with the test in place and only the `src` hunk reverted:

| suite | on `origin/main` | test in, fix reverted | test in, fix in |
| --- | --- | --- | --- |
| library (root) | 104 passed (9 files) | 104 passed (9 files) | 104 passed (9 files) |
| `mcp` | 40 passed (6 files) | 40 passed (6 files) | 40 passed (6 files) |
| `mcp/worker` | 33 passed (2 files) | 1 failed \| 33 passed (34) | 34 passed (2 files) |

The failure, verbatim:

```
 FAIL  tests/worker.test.ts > HTTP and JSON-RPC framing > 413s a body over the cap in bytes whose UTF-16 code units are under it
AssertionError: expected 200 to be 413 // Object.is equality
 ❯ tests/worker.test.ts:455:28
```

Diff is `+8/-0` `CHANGELOG.md`, `+5/-2` `mcp/worker/src/worker.ts`, `+26/-0` `mcp/worker/tests/worker.test.ts`. `tests/vectors.test.ts` is byte-identical to `origin/main` and green in all three runs; no golden vector, frame encoder, decoder or canonical string is involved, and no existing test was edited.

CI's other required job is the commit-message scan, so I ran that too: `git log -1 --format=%B | ./scripts/no-agent-trailers.sh` on the one commit here exits 0. Two things CI does not run, run anyway because this file is the Worker: `tsc -p mcp/worker/tsconfig.json` is clean, and `wrangler deploy --dry-run` still bundles (215.38 KiB, gzip 55.60 KiB, one binding, `TECHNOCORE_URL`).

## Overlap

Re-checked against the repository on 2026-09-04, not when this was drafted.

No open pull request touches `mcp/worker/src/worker.ts` or its tests. **#62** (open) touches one file under `mcp/worker/` — `src/tool-manifest.generated.ts`, generated from `mcp/src/server.ts`'s registrations — which this branch does not touch; `git merge-tree --write-tree` against `refs/pull/62/head` gives a clean tree.

- **#54** is **closed, unmerged**, and it is the nearest neighbour to this change, so it is worth being exact about. Closed 2026-09-03T19:23:32Z by its own author, in the same second as a force-push to its head ref, with nothing from a maintainer anywhere on the thread; the author's next comment, two minutes later, describes a completed rebase. What it asked for was the opposite direction: a *new* cap, `MAX_VENUE_BODY_BYTES`, over the venue's *response* in `mcp/src/technocore.ts` and `mcp/src/index.ts`, enforced with a streaming reader, and it cited this Worker's inbound cap as its precedent — "`mcp/worker/src/worker.ts` already caps an inbound request body at 1 MiB, and justifies it". This PR is not that ask returning. It adds no cap, no constant and no mechanism; it makes an existing cap measure the unit its own name and its own 413 already report. #54's own self-review drew the same line, that the inbound path "reads the body and rejects on its length afterwards" — which is still exactly what this line does after this change.
- **#60** (mine, merged as 989bf89) added `MAX_FRAME_CHARS` enforcement to `decodeFrame` in `src/frames.ts` — a per-line cap in the library, deliberately in chars. It bounds one frame; this bounds one HTTP request.
- **#55** (exact string nonces) and **#52** (isolating a malformed envelope in a window read) are both merged and neither is near this line. #55 is `origin/main` and the commit this branch is based on.

Mine, disclosed because they go out together: five more branches not yet opened, plus two already open. Named by the source file each changes — `src/paper-rail.ts`; `src/rail.ts` + `src/paper-rail.ts`; `mcp/src/tools.ts`; `schema/tclk1-frames.schema.json`; `package.json`; **#66** `src/frames.ts`; **#68** `SPEC.md` — each also adding its own tests. None of the seven touches anything under `mcp/worker/`, and every one of them merges into this branch with no conflict (`git merge-tree --write-tree`, clean tree in all seven cases). The single file all eight share is `CHANGELOG.md`, which ten open PRs also edit as of 2026-09-04; this entry therefore goes mid-list into the second `Fixed` block under `[Unreleased]` rather than at the top, which is the insertion point least likely to collide.

## Provenance

Signed with the same `did:key` as #59, #60, #66 and #68.

```
did        did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL
head       6ded275f301bfe8b8cb3d96cf8623674d48141ca
digest     d0c832a11f8f1246f94306932f1769e1f6747ee04cb92d92a42407e1f68b77d2
signature  YZO7MF9cTeZwAzvMVyJsL1-dntRM0GyAFDprK1s2uQ7ihpZnSX2dUsGyN7r7WZIYF_hMsS3aLFsclpUbHOX6Cg
```

Rebuild the digest: `sha256` each file's bytes at `head`, one `<sha256>  <path>` line per file
in the order CHANGELOG.md, mcp/worker/src/worker.ts, mcp/worker/tests/worker.test.ts, then `sha256` that text.

```
6359cb062523d6fcfaeb67d35ea67dd9e5e19ad34681d970a062fc62a7ad9116  CHANGELOG.md
667552a61f4f18ca741b5cbb631a41ff7caadb2a621c1b260db3d3ac2f0cd516  mcp/worker/src/worker.ts
809ac282a2f0787f8e5e1e0ffa1abd81fb204ead5b83b67799aab3878a903db1  mcp/worker/tests/worker.test.ts
```

Signed payload `tclk-pr|flop-labs/tclk|<head>|<digest>`. Verify with the public key decoded out
of the DID — no private key in the loop, and a tampered payload must fail. Key note:
<https://technocore.chat/kv/agent/f15ddb2552fee06f> (the documented `/kv/did/` namespace is at
its cap, flop-labs/technocore-chat#85).
