### PR TITLE
fix(build): export the frame schema the package ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ All notable changes to this project are documented here. Format follows
   stdio build remains the right choice wherever a local process can run — `mcp/worker/`
   documents what a shared instance costs, including that frames leave from its IP and share
   one rate budget.
+- `@flop-labs/tclk/schema/tclk1-frames.schema.json` as an exported subpath, so an installed
+  consumer can load the schema the package ships. `exports` named only `"."`, and an
+  `exports` map denies every subpath it does not name, so the file SPEC §3 calls "the same
+  artifact the decoder uses" — in `files` since #42 — answered
+  `ERR_PACKAGE_PATH_NOT_EXPORTED` under both the ESM and CJS resolvers, and the only route
+  left was a relative URL off the resolved entry point, which hardcodes the internal
+  `dist/` layout. Only that one shipped file is named, not the `schema/` directory. Only
+  the manifest moved: no decoder behaviour, wire byte or golden vector changed.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./schema/tclk1-frames.schema.json": "./schema/tclk1-frames.schema.json"
   },
   "files": [
     "dist",

--- a/tests/packaging.test.ts
+++ b/tests/packaging.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPEC §3 calls `schema/tclk1-frames.schema.json` "the same artifact the decoder uses" and
+// the package ships it in `files`, so an independent implementation validates against the
+// installed copy rather than against `src/`. An `exports` map hides every subpath it does
+// not name, so the specifier a consumer writes is resolved here — through this package's
+// own map, by self-reference — and a map that stops naming the schema fails in this suite
+// instead of in someone's install.
+
+import { readFileSync, realpathSync } from "node:fs";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SCHEMA_SPECIFIER = "@flop-labs/tclk/schema/tclk1-frames.schema.json";
+
+const nodeRequire = createRequire(import.meta.url);
+const shipped = fileURLToPath(new URL("../schema/tclk1-frames.schema.json", import.meta.url));
+
+describe("published package surface", () => {
+  it("resolves the shipped frame schema by its package specifier", () => {
+    // Both sides through realpath: the resolver returns the real path, so a checkout
+    // reached by a symlink would otherwise compare unequal.
+    expect(realpathSync(nodeRequire.resolve(SCHEMA_SPECIFIER))).toBe(realpathSync(shipped));
+
+    const schema = JSON.parse(readFileSync(nodeRequire.resolve(SCHEMA_SPECIFIER), "utf8"));
+    expect(schema.$id).toBe("https://github.com/flop-labs/tclk/schema/tclk1-frames.schema.json");
+    expect(schema.$defs.offer).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

One entry added to the root `exports` map:

```json
"./schema/tclk1-frames.schema.json": "./schema/tclk1-frames.schema.json"
```

plus `tests/packaging.test.ts` (new, 29 lines) and an 8-line `[Unreleased]` entry. `package.json` is +2/-1; there is no `src/` line in the diff.

## Why

The package ships `schema/tclk1-frames.schema.json` on purpose. It is in `files` (since #42), SPEC §3 calls it "the same artifact the decoder uses" and links it, and #59 tightened its constraints precisely so an independent implementation validating against the schema stops being told to emit frames the reference refuses. That only pays off if an installed consumer can load it.

Once a package has an `exports` map, Node denies every subpath the map does not name. The map named only `"."`, so the shipped artifact was unreachable by any specifier the manifest named, and `./package.json` was denied with it — which also removes the usual locate-the-package-root fallback. What was left is `new URL("../schema/tclk1-frames.schema.json", import.meta.resolve("@flop-labs/tclk"))`: it works only because the entry point happens to sit one directory deep, in `dist/`. It hardcodes that depth — build to `dist/esm/index.js` instead and the same expression points at `dist/schema/tclk1-frames.schema.json`, which does not exist — and nothing in the published contract says the depth is stable.

Measured on a real install — `pnpm pack`, extracted into a scratch consumer's `node_modules`, probed with `import.meta.resolve`, `createRequire().resolve` and, for the JSON rows, `import(spec, { with: { type: 'json' } })`:

| specifier | before | after |
|---|---|---|
| `@flop-labs/tclk` | resolves to `dist/index.js` | unchanged |
| `@flop-labs/tclk/schema/tclk1-frames.schema.json` | `ERR_PACKAGE_PATH_NOT_EXPORTED` from all three | resolves; JSON parses, `$id` is the schema's |
| `@flop-labs/tclk/schema` | `ERR_PACKAGE_PATH_NOT_EXPORTED` | `ERR_PACKAGE_PATH_NOT_EXPORTED`, deliberately |
| `@flop-labs/tclk/package.json` | `ERR_PACKAGE_PATH_NOT_EXPORTED` | unchanged, deliberately |
| files in the tarball | 51 | 51 |

Naming the one file rather than a `./schema/*` wildcard keeps the exported surface to exactly the artifact SPEC §3 links; a wildcard would also export whatever lands in that directory later. `./package.json` stays unexported: that is a separate question, and reaching the schema no longer depends on it.

I treated SPEC and the `files` list as correct and the manifest as wrong. Nothing in SPEC.md, README.md or CONTRIBUTING.md documents the encapsulation as intended — none of the three mentions the `exports` field or subpath visibility at all — and `exports` with only `"."` predates `schema` entering `files`, so this is an omission rather than a decision. No SPEC line changed.

**What a hostile counterparty gets: nothing.** The bytes are already in the tarball and in the public repository. The entry changes which specifier Node's resolver accepts for a file the consumer already has on disk — no new code path, no runtime behaviour, no frame field. The decoder remains the authority: schema-valid still does not imply decodable — a `paymentKey` of `0x02` followed by 32 `ff` bytes matches the schema's 33-byte hex pattern and `makeOffer` throws `tclk: paymentKey is not a valid secp256k1 point`. `tests/schema-conformance.test.ts` asserts the other direction, that the schema admits nothing the decoder rejects; nothing there weakens the decoder's word.

## Checks

The three CI commands, run locally in this worktree on Node v22.22.2 / pnpm 11.25.0. Fork CI has not run yet, so nothing here reports a CI result.

| run | test files | tests |
|---|---|---|
| library (root), with the entry | 10 passed | 105 passed |
| library, manifest hunk reverted, new test kept | 1 failed, 9 passed | 1 failed, 104 passed |
| `mcp` | 6 passed | 40 passed |
| `mcp/worker` | 2 passed | 33 passed |

Both ways. Reverting only the `package.json` hunk, with `tests/packaging.test.ts` left in place, fails at `tests/packaging.test.ts:23:37` with

```
Error: Package subpath './schema/tclk1-frames.schema.json' is not defined by "exports" in
<repo>/package.json imported from <repo>/tests/packaging.test.ts
```

— and the recursive run stops there (`ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`) before `mcp` executes. Restoring the one line: 105/105, 40/40, 33/33 as in the table. The pre-fix consumer install fails with the same code and the same sentence, differing only in the two paths it names (`<consumer>/node_modules/@flop-labs/tclk/package.json`), so the tripwire reproduces the consumer's failure rather than something adjacent to it.

The tripwire resolves that specifier through this package's own `exports` map by self-reference, so it needs no pack step in CI. `tests/vectors.test.ts` is untouched and green; no wire byte moves.

## Overlap

`git log -- package.json` returns five commits ever, the newest being #42 (103a1b9) — also the commit that put `schema` in `files` without extending `exports`. The `exports` map itself is byte-identical to the initial commit (ba370bd); nothing has edited it since.

Merged, ruled out: #59 is the closest and is a different defect — it changed the constraints *inside* `schema/tclk1-frames.schema.json` (`presig.s` byte pairs, `job.proto`/`job.id`/`job.context`); this touches no byte of that file and fixes whether a consumer can load it at all, and #59's own changelog entry is the basis that makes the reachability a defect. Of the rest: #63 `src/hex.ts`, #60 `src/frames.ts`, #55/#52 `mcp/`, #51 `src/machine.ts` + `src/adaptor.ts`, #35/#34/#27/#15/#14 `src/` behaviour — none of those touched `package.json` at all. Two of the merged ones did touch the manifest, neither anywhere near `exports`: #42 added `schema` to `files` plus two `scripts` entries, and #40 (162b331) added the `@scure/base` dependency.

Open, checked 2026-09-03 19:56 UTC: 13 pull requests are open (#68, #67, #66, #65, #62, #58, #56, #50, #32, #28, #21, #16, #13) and exactly one of them touches `package.json`.

That one is **#21** ("feat(rail): add EvmHashRail", open, last updated 2026-09-03T02:18:00Z), which adds `"./evm-hash-rail"` to this same `exports` map immediately after the `"."` block. GitHub reports it `CONFLICTING` against `main` on its own right now — its manifest pre-image is the blob from before #40 and #42 — so it needs a rebase whatever happens here. Rebased, its entry and this one land in the same place: a three-way merge of the two manifests against `origin/main` produces exactly one conflict region, whose base is the single `"."`-block closing brace that both sides give a comma, and the resolution is to keep both keys. The two subpaths do not interact. Flagging it here rather than leaving it for the queue.

The other twelve touch no manifest: #68/#67 SPEC + escape vectors, #66 `src/frames.ts`, #65/#56 `examples/live-deal.mjs`, #62 `src/transcript.ts` + mcp, #58 the tclk/2 proposal docs, #50 `examples/htlc-walkthrough.md`, #32 `src/machine.ts`, #28/#13 `examples/*.py`, #16 `src/frames.ts`. #66 and #68 are mine; neither goes near the manifest. #54 (`mcp/src/technocore.ts`) was open while this was being written and is not any more — it closed unmerged at 2026-09-03T19:23:32Z, so it is off the list.

Ten of the thirteen also add to `CHANGELOG.md`'s `[Unreleased]` block, as this does. That is routine here, it merges additively, and nothing in this diff edits an existing bullet.

Mine, going out alongside this one: five sibling branches, none of which touches `package.json`. Source file each; every one of them also adds tests and its own `[Unreleased]` bullet.

- `fix/worker-body-cap-in-bytes` — `mcp/worker/src/worker.ts`
- `fix/paper-rail-refuses-an-unreadable-record` — `src/paper-rail.ts`
- `fix/rail-validates-the-clock-reading` — `src/rail.ts`, `src/paper-rail.ts`
- `fix/mcp-validates-the-room-before-signing` — `mcp/src/tools.ts`
- `fix/schema-point-lock-payment-key-and-ms-bounds` — `schema/tclk1-frames.schema.json`

The last is the one worth naming: it edits the contents of the same file this PR exports. The two are independent — this one changes only which specifier resolves, that one only the constraints inside — and either order works. Each of the five merges cleanly with this branch (checked with `git merge-tree --write-tree`: no conflict, and the merged `CHANGELOG.md` is exactly the sum of both bullet insertions every time), so no landing order is forced.

## Provenance

Signed with the same `did:key` as #59, #60, #66 and #68.

```
did        did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL
head       56db0684bfacd549aed5bc531dbc58c32f5659d5
digest     a9a06b8a2a1a4db856b6efc0830cca48b9f7ef5e3baa9a101a83410593222d0a
signature  ddBilwfWOZnM_zQzMQKA8GKWY141VZd2yScTDce9XprLKjuXOgYYBus8Bp_6tcnMKHO4KUaPKKvIT8W68EcJDw
```

Rebuild the digest: `sha256` each file's bytes at `head`, one `<sha256>  <path>` line per file
in the order CHANGELOG.md, package.json, tests/packaging.test.ts, then `sha256` that text.

```
d29a1c6a79802d8790fa614f05eef27186ca012756c266997c25d6023ef0b253  CHANGELOG.md
f8d80eb77d6a8eeec290a5ecdde9553727a0a8c23e63d4147058c1e062a8e9b7  package.json
af6db83501167e1fe61c91b4a679cce2f2e76940ec3e33167f63382fb8e3504b  tests/packaging.test.ts
```

Signed payload `tclk-pr|flop-labs/tclk|<head>|<digest>`. Verify with the public key decoded out
of the DID — no private key in the loop, and a tampered payload must fail. Key note:
<https://technocore.chat/kv/agent/f15ddb2552fee06f> (the documented `/kv/did/` namespace is at
its cap, flop-labs/technocore-chat#85).
