### PR TITLE
fix(machine): reject late accept after refund window

### DIFF
--- a/src/machine.ts
+++ b/src/machine.ts
@@ -118,6 +118,7 @@ export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number
       if (accept.ref !== state.offer.id) return reject(state, "accept.ref names a different offer");
       if (accept.from === state.offer.from) return reject(state, "cannot accept own offer");
       if (nowMs >= state.offer.expiresMs) return reject(state, "offer has expired");
+      if (nowMs >= state.offer.refundAfterMs) return reject(state, "refund window is already open");
       const expected = contractId(state.offer, {
         from: accept.from,
         ref: accept.ref,


### PR DESCRIPTION
Closes #75

### What
`src/machine.ts` `accept` now also fails-closed when `nowMs >= refundAfterMs`.

### Why
An offer can be built with `expiresMs` far after `refundAfterMs` (e.g. 10h vs 2h). `accept` only checked `expiresMs`, so a late `accept` at 3h (after refund window, before expiry) entered `accepted` while `lock` is correctly rejected at `refund window is already open` — stuck `accepted` that can only `cancel`.

### Checks
- [x] `pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` — tclk/transcript 45 passed