### PR TITLE
fix(rail): snapshot terms when opening a memory lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `MemoryRail` now snapshots lock terms when a lock is opened, so mutating the caller's
+  object cannot rewrite the amount, statement, or deadlines of an existing lock.
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema

--- a/src/rail.ts
+++ b/src/rail.ts
@@ -87,7 +87,7 @@ export class MemoryRail implements SettlementRail {
     if (this.clock() >= terms.refundAfterMs) {
       throw new Error("tclk: refusing to lock into an already-open refund window");
     }
-    this.locks.set(terms.contract, { terms, status: "locked" });
+    this.locks.set(terms.contract, { terms: { ...terms }, status: "locked" });
     return terms.contract;
   }
 

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -468,6 +468,23 @@ describe("tclk MemoryRail (reference rail predicates)", () => {
     await expect(rail.lock(terms)).rejects.toThrow(/already holds/);
   });
 
+  it("snapshots terms when a lock is opened", async () => {
+    const { rail, lock, terms } = railFixture();
+    const original = { ...terms };
+    const replacement = generateHashLock();
+    const ref = await rail.lock(terms);
+
+    terms.statement = replacement.hash;
+    terms.amount = "999";
+    terms.refundAfterMs += 60_000;
+
+    expect(await rail.verifyLock(original, ref)).toBe(true);
+    expect(await rail.verifyLock(terms, ref)).toBe(false);
+    await expect(rail.claim(ref, replacement.preimage)).rejects.toThrow(/secret/);
+    await rail.claim(ref, lock.preimage);
+    expect(rail.status(ref)).toBe("claimed");
+  });
+
   it("lockTerms refuses a contract that is not accepted yet", () => {
     expect(() => lockTerms(openContract(baseOffer()))).toThrow(/not accepted/);
   });


### PR DESCRIPTION
## What

MemoryRail now stores a copy of LockTerms when a lock is opened. Changing the caller's object later no longer changes an existing lock.

## Why

MemoryRail.lock() kept the supplied object by reference. After opening a lock, a caller could modify fields such as statement, amount, or refundAfterMs, and the rail would treat those values as the original lock terms.

That made verifyLock() accept the modified terms and made claim() check a different statement from the one supplied when the lock was opened.

This treats the existing spec as correct: lock terms are fixed when the lock is created. MemoryRail holds no real value, but it is the reference implementation for settlement-rail behavior.

## Checks

- [x] pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build
- [x] pnpm -r --include-workspace-root test (105 core, 40 MCP, 33 Worker)
- [x] Golden vectors untouched
- [x] CHANGELOG.md updated
- [x] Existing docs remain accurate
- [x] New money-path surface: nothing new