### PR TITLE
fix(commitments): reject a verdict the venue rewrites before it strands a vote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `voteCommitment` rejects a verdict containing a character technocore rewrites — control,
+  format, line- or paragraph-separator. The venue replaces these with a space before it
+  stores a message, and SPEC 8.3 opens a commitment by posting the verdict into a room, so
+  such a verdict committed successfully and could then never be reopened: the reveal that
+  came back was not the string that was hashed, stranding the juror's vote with no
+  diagnostic. `encodeFrame` already refuses these on the frame path; arbitration reached
+  the same hazard by another route. Visible non-ASCII verdicts are unaffected — the venue
+  stores code points verbatim and only rewrites the invisible classes.
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema

--- a/src/commitments.ts
+++ b/src/commitments.ts
@@ -19,6 +19,19 @@ import { SECP256K1_N } from "./points.js";
 
 const HEX32 = /^0x[0-9a-f]{64}$/;
 
+/**
+ * Characters technocore rewrites to a space before it stores a message: control,
+ * format, line- and paragraph-separator. The same hazard `encodeFrame` refuses to
+ * emit, reached by a different path — SPEC 8.3 opens a commitment by posting the
+ * verdict into a room, so the verdict makes that round trip too.
+ *
+ * Deliberately narrower than the frame guard's printable-ASCII rule: a frame line is
+ * ASCII because canonical JSON escapes it, but a verdict is hashed and posted raw, and
+ * a visible non-ASCII verdict ("si", "\u306f\u3044") survives the venue untouched.
+ * Only the invisible classes are a problem.
+ */
+const VENUE_REWRITES = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u;
+
 function requireSecret(value: string, name: string): Uint8Array {
   if (!HEX32.test(value)) throw new Error(`tclk: ${name} must be 32 bytes of 0x-hex`);
   return hexToU8a(value);
@@ -44,6 +57,12 @@ export function voteCommitment(contract: string, verdict: string, salt: string):
   if (!HEX32.test(contract)) throw new Error("tclk: contract must be a 0x-hex contract id");
   if (verdict.length === 0) throw new Error("tclk: verdict must not be empty");
   if (verdict.includes("|")) throw new Error("tclk: verdict must not contain '|'");
+  // A verdict carrying one of these commits fine and can then never be reopened: the
+  // venue swaps it for a space in the reveal round, so the string that comes back is
+  // not the string that was hashed. Refuse at commit time rather than strand the vote.
+  if (VENUE_REWRITES.test(verdict)) {
+    throw new Error("tclk: verdict must not contain characters the venue rewrites");
+  }
   requireSecret(salt, "salt");
   return u8aToHex(
     sha256(stringToU8a(`${TCLK_DOMAIN}|commit|${contract}|${verdict}|${salt}`)),

--- a/tests/commitments.test.ts
+++ b/tests/commitments.test.ts
@@ -36,6 +36,41 @@ describe("commit–reveal voting", () => {
     expect(verifyVoteCommitment("0x" + "00".repeat(32), CONTRACT, "yes", salt)).toBe(false);
   });
 
+  it("refuses a verdict carrying a character the venue rewrites", () => {
+    // technocore replaces controls and format characters with a space before storing.
+    // SPEC 8.3 opens a commitment by posting the verdict into a room, so such a verdict
+    // commits fine and can then never be reopened: what comes back is not what was
+    // hashed. encodeFrame already refuses these on the frame path; this is the same
+    // hazard reached through arbitration.
+    const chr = (n: number) => String.fromCharCode(n);
+    const stranded = [
+      ["newline", "yes" + chr(0x0a)],
+      ["DEL", "yes" + chr(0x7f)],
+      ["zero-width space", "y" + chr(0x200b) + "es"],
+      ["zero-width joiner", "yes" + chr(0x200d)],
+      ["bidi override", chr(0x202e) + "yes"],
+      ["soft hyphen", "y" + chr(0x00ad) + "es"],
+      ["BOM", chr(0xfeff) + "yes"],
+      ["line separator", "yes" + chr(0x2028)],
+    ] as const;
+
+    for (const [label, verdict] of stranded) {
+      expect(() => voteCommitment(CONTRACT, verdict, generateSalt()), label).toThrow(
+        /venue rewrites/,
+      );
+    }
+  });
+
+  it("still accepts a visible non-ASCII verdict, which the venue leaves alone", () => {
+    // The venue stores code points verbatim and only rewrites the invisible classes, so
+    // the guard must not become an ASCII-only rule and lock out non-English juries.
+    for (const verdict of ["si", "\u306f\u3044", "\u043d\u0435\u0442", "\u2713"]) {
+      const salt = generateSalt();
+      const commitment = voteCommitment(CONTRACT, verdict, salt);
+      expect(verifyVoteCommitment(commitment, CONTRACT, verdict, salt)).toBe(true);
+    }
+  });
+
   it("binds to the contract, so a verdict cannot be lifted to another deal", () => {
     const salt = generateSalt();
     const commitment = voteCommitment(CONTRACT, "yes", salt);


### PR DESCRIPTION
## The problem

technocore replaces control and format characters with a space before it stores a message. SPEC §8.3 opens a commit–reveal vote by posting the verdict into a room in a second round — so the verdict makes that round trip.

A verdict carrying one of those characters commits successfully and can then **never be reopened**. The string that comes back is not the string that was hashed, so `verifyVoteCommitment` returns `false` with nothing to distinguish it from a juror who simply lied. The vote is stranded and the failure is silent.

Reproduced against `main` before writing the fix:

```
plain "yes"          committed=ok  altered_by_room=false reopens=true
trailing newline     committed=ok  altered_by_room=true  reopens=false
zero-width space     committed=ok  altered_by_room=true  reopens=false
zero-width joiner    committed=ok  altered_by_room=true  reopens=false
bidi override RLO    committed=ok  altered_by_room=true  reopens=false
DEL                  committed=ok  altered_by_room=true  reopens=false
BOM / ZWNBSP         committed=ok  altered_by_room=true  reopens=false
soft hyphen          committed=ok  altered_by_room=true  reopens=false

7 of 8 verdicts commit fine but can never be reopened.
```

## Why it looks like an oversight rather than a design choice

`encodeFrame` already refuses exactly these characters, and the comment names this exact reason:

```ts
// Sweep guard: technocore replaces controls/format chars with spaces before storing,
// which would silently change the bytes a reader re-verifies. Refuse to emit them.
if (!/^[\x20-\x7e]*$/.test(line)) fail("frame line contains non-printable-ASCII characters");
```

The frame path is guarded. Arbitration reaches the same hazard by another route and was not. This adds the guard there, failing at commit time rather than stranding the vote in the reveal round.

## One deliberate difference from the frame guard

The check rejects `Cc/Cf/Zl/Zp` only — **not** all non-ASCII.

A frame line is ASCII because canonical JSON escapes it, but a verdict is hashed and posted raw, and the venue stores code points verbatim. A visible non-ASCII verdict (`"sí"`, `"はい"`, `"нет"`) survives the venue untouched, so copying the printable-ASCII rule would lock out non-English juries for no benefit. Only the invisible classes are actually rewritten, so only those are refused.

If you would rather this match `encodeFrame` exactly and be ASCII-only, say so and I will change it — but the round-trip test for non-ASCII verdicts in this PR would then need to go.

## Scope

| file | change |
|---|---|
| `src/commitments.ts` | `VENUE_REWRITES` guard in `voteCommitment` |
| `tests/commitments.test.ts` | 8 stranding characters; visible non-ASCII still round-trips |
| `CHANGELOG.md` | `[Unreleased]` entry |

`verifyVoteCommitment` is unchanged and stays fail-closed — it already wraps `voteCommitment` in `try/catch`, so a stranded verdict arriving from another agent still returns `false` rather than throwing.

## Verified

- `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build && pnpm -r --include-workspace-root test` — 106 + 40 + 33 pass
- **Golden vectors untouched.** No wire format change; nothing in `frames.ts` or the encoding is touched.
- The new test fails on `main` and passes with the fix (reverted and re-ran to confirm it is not vacuous).