### PR TITLE
fix(mcp): a string nonce must be canonical decimal, as a fold requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `tclk_post_frame`'s string nonce must now be canonical decimal — no leading zero — the same
+  spelling `verifyTranscriptRecord` accepts. The 1-19 digit pattern admitted `0000001730000000001`,
+  and the caller-signed tier sends a string nonce to the venue verbatim, so the tool wrote a record
+  this package then refuses to fold: either the venue echoes the padded nonce back and the read path
+  calls it "not canonical decimal", or it normalizes to the bare number and the signature over
+  `room|0000001730000000001|text` no longer verifies. A posted frame cannot be taken back, so the
+  write path is now no looser than the read path. `0` remains valid; a numeric nonce is unaffected.
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -9,7 +9,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
-import { createHandlers, type HandlerOptions, type Handlers } from "./tools.js";
+import { CANONICAL_NONCE, createHandlers, type HandlerOptions, type Handlers } from "./tools.js";
 
 export { createHandlers } from "./tools.js";
 export type { Handlers, HandlerOptions, TclkEnv } from "./tools.js";
@@ -335,10 +335,13 @@ export function createServer(options: HandlerOptions = {}): McpServer {
         nonce: z
           .union([
             z.number().int().safe().nonnegative(),
-            z.string().regex(/^[0-9]{1,19}$/, "1 to 19 decimal digits"),
+            z.string().regex(CANONICAL_NONCE, "1 to 19 decimal digits, no leading zero"),
           ])
           .optional()
-          .describe("Signed-lane nonce; safe integer or 1-19 decimal digit string."),
+          .describe(
+            "Signed-lane nonce; safe integer, or canonical decimal text of up to 19 " +
+              "digits with no leading zero — the spelling a fold accepts back.",
+          ),
       },
     },
     (args) => run(() => h.tclk_post_frame(args)),

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -60,6 +60,13 @@ function fail(msg: string): never {
   throw new Error(`tclk-mcp: ${msg}`);
 }
 
+/**
+ * A signed-lane nonce as text: canonical decimal, no leading zero, at most 19 digits so
+ * the venue's 64-bit counter round-trips. The same spelling `verifyTranscriptRecord`
+ * accepts, bounded — one written any other way cannot be folded back.
+ */
+export const CANONICAL_NONCE = /^(?:0|[1-9][0-9]{0,18})$/;
+
 /** 0x-prefixed lowercase 32-byte hex, the spelling the core's crypto expects. */
 function normalizeScalar(spec: string, name: string): string {
   const trimmed = spec.trim();
@@ -377,11 +384,18 @@ export function createHandlers(options: HandlerOptions = {}) {
         fail("pass all three of `did`, `sig` and `nonce`, or none of them");
       }
 
+      // A string nonce goes to the venue verbatim, and the signature covers the spelling
+      // as written. `verifyTranscriptRecord` in the library accepts only canonical decimal
+      // (`/^(?:0|[1-9][0-9]*)$/`), so a leading-zero nonce yields a record this same package
+      // refuses to fold: either the venue echoes `007` back and the read path calls it "not
+      // canonical decimal", or it normalizes to `7` and the signature over `room|007|text`
+      // no longer verifies. Neither is recoverable — the frame is on the board and cannot
+      // move state. Admit only the spelling the read path accepts.
       if (input.nonce !== undefined) {
         const isSafe = typeof input.nonce === "number" && Number.isSafeInteger(input.nonce) && input.nonce >= 0;
-        const isDecimal = typeof input.nonce === "string" && /^[0-9]{1,19}$/.test(input.nonce);
+        const isDecimal = typeof input.nonce === "string" && CANONICAL_NONCE.test(input.nonce);
         if (!isSafe && !isDecimal) {
-          fail("`nonce` must be a non-negative safe integer or a 1-19 decimal digit string");
+          fail("`nonce` must be a non-negative safe integer or 1-19 decimal digits with no leading zero");
         }
       }
 

--- a/mcp/tests/server.test.ts
+++ b/mcp/tests/server.test.ts
@@ -66,7 +66,7 @@ describe("createServer", () => {
     await client.close();
   });
 
-  it("validates tclk_post_frame nonce: accepts safe int or 1-19 digit string, rejects unsafe numbers and malformed strings", async () => {
+  it("validates tclk_post_frame nonce: accepts safe int or canonical 1-19 digit string, rejects unsafe numbers, malformed and leading-zero strings", async () => {
     const client = await connect();
 
     // 1. Safe integer is accepted (schema validation passes; error comes from frame validation)
@@ -108,6 +108,15 @@ describe("createServer", () => {
     });
     expect(validStr.isError).toBe(true);
     expect((validStr.content as { text: string }[])[0].text).toMatch(/not a tclk\/1 line/);
+
+    // 6. A leading zero is rejected at the schema: the record it would post is one the
+    //    library's own `verifyTranscriptRecord` calls "not canonical decimal".
+    const paddedStr = await client.callTool({
+      name: "tclk_post_frame",
+      arguments: { room: "lobby", line: "gm", did: "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX", sig: "x".repeat(86), nonce: "0000001730000000001" },
+    });
+    expect(paddedStr.isError).toBe(true);
+    expect((paddedStr.content as { text: string }[])[0].text).toMatch(/Invalid arguments/);
 
     await client.close();
   });

--- a/mcp/tests/transport.test.ts
+++ b/mcp/tests/transport.test.ts
@@ -5,6 +5,8 @@
 import { describe, expect, it } from "vitest";
 import { ed25519 } from "@noble/curves/ed25519.js";
 
+import { transcriptRecord, verifyTranscriptRecord } from "@flop-labs/tclk";
+
 import { canonicalMessage, signerFromSeed } from "../src/signing.js";
 import { createHandlers } from "../src/tools.js";
 import { HASH_OFFER, PAYER_SEED, fakeFetch, hexToBytes } from "./fixtures.js";
@@ -115,6 +117,54 @@ describe("tclk_post_frame — tier 2, server-signed", () => {
     expect(body.nonce).not.toBe(String(Number(nonce19)));
   });
 
+  it("refuses a nonce spelling the library's own fold would reject", async () => {
+    const { calls, fetchLike } = fakeFetch([{ body: "ok 15" }]);
+    const h = createHandlers({ env: {}, fetch: fetchLike });
+    const line = offerLine();
+    // Canonical decimal is the whole rule: `verifyTranscriptRecord` accepts
+    // /^(?:0|[1-9][0-9]*)$/ and nothing else, and `postSigned` sends the string through
+    // verbatim. Posting `0000001730000000001` put a record on the board that this same
+    // package then refuses to fold, and the frame cannot be taken back.
+    const padded = "0000001730000000001";
+    await expect(
+      h.tclk_post_frame({
+        room: ROOM,
+        line,
+        did: signer.did,
+        sig: signer.sign(canonicalMessage(ROOM, padded, line)),
+        nonce: padded,
+      }),
+    ).rejects.toThrow(/no leading zero/);
+    expect(calls).toHaveLength(0);
+
+    // The reason it must be refused, stated as the round trip it breaks.
+    const record = transcriptRecord(ROOM, {
+      seq: 1,
+      ts: "2026-09-04T00:00:00Z",
+      from: signer.did,
+      nonce: padded,
+      sig: signer.sign(canonicalMessage(ROOM, padded, line)),
+      text: line,
+    });
+    expect(verifyTranscriptRecord(record)).toMatchObject({
+      ok: false,
+      reason: "record nonce is not canonical decimal",
+    });
+
+    // `0` itself is canonical and still accepted.
+    const zero = fakeFetch([{ body: "ok 16" }]);
+    const h0 = createHandlers({ env: {}, fetch: zero.fetchLike });
+    const posted = await h0.tclk_post_frame({
+      room: ROOM,
+      line,
+      did: signer.did,
+      sig: signer.sign(canonicalMessage(ROOM, "0", line)),
+      nonce: "0",
+    });
+    expect(posted.posted && posted.tier).toBe("caller-signed");
+    expect(JSON.parse(String(zero.calls[0].init?.body)).nonce).toBe("0");
+  });
+
   it("rejects an unsafe numeric nonce or malformed string in the shared handler", async () => {
     const { fetchLike } = fakeFetch([{ body: "ok 14" }]);
     const h = createHandlers({ env: {}, fetch: fetchLike });
@@ -126,7 +176,7 @@ describe("tclk_post_frame — tier 2, server-signed", () => {
       did: signer.did,
       sig: "x".repeat(86),
       nonce: 9007199254740992,
-    })).rejects.toThrow(/must be a non-negative safe integer or a 1-19 decimal digit string/);
+    })).rejects.toThrow(/must be a non-negative safe integer or 1-19 decimal digits with no leading zero/);
 
     await expect(h.tclk_post_frame({
       room: ROOM,
@@ -134,7 +184,7 @@ describe("tclk_post_frame — tier 2, server-signed", () => {
       did: signer.did,
       sig: "x".repeat(86),
       nonce: "123bad",
-    })).rejects.toThrow(/must be a non-negative safe integer or a 1-19 decimal digit string/);
+    })).rejects.toThrow(/must be a non-negative safe integer or 1-19 decimal digits with no leading zero/);
   });
 
   it("surfaces the venue's refusal instead of swallowing it", async () => {

--- a/mcp/worker/src/tool-manifest.generated.ts
+++ b/mcp/worker/src/tool-manifest.generated.ts
@@ -738,10 +738,10 @@ export const TOOLS: readonly ManifestTool[] = [
             },
             {
               "type": "string",
-              "pattern": "^[0-9]{1,19}$"
+              "pattern": "^(?:0|[1-9][0-9]{0,18})$"
             }
           ],
-          "description": "Signed-lane nonce; safe integer or 1-19 decimal digit string."
+          "description": "Signed-lane nonce; safe integer, or canonical decimal text of up to 19 digits with no leading zero — the spelling a fold accepts back."
         }
       },
       "required": [

--- a/mcp/worker/tests/worker.test.ts
+++ b/mcp/worker/tests/worker.test.ts
@@ -297,6 +297,17 @@ describe("no custody", () => {
     expect(tooLongRes.body.error).toBeDefined();
     expect(tooLongRes.body.error.code).toBe(-32602);
     expect(calls).toHaveLength(0);
+
+    // A leading zero is not canonical decimal, so `verifyTranscriptRecord` would refuse the
+    // record this posts. The manifest pattern the Worker checks must say so too.
+    const paddedRes = await rpc(
+      "tools/call",
+      { name: "tclk_post_frame", arguments: { room: ROOM, line, did: PAYER_DID, sig: "x".repeat(86), nonce: "0000001730000000001" } },
+      fetchLike,
+    );
+    expect(paddedRes.body.error).toBeDefined();
+    expect(paddedRes.body.error.code).toBe(-32602);
+    expect(calls).toHaveLength(0);
   });
 
   it("tclk_adaptor_presign refuses structurally, naming where pre-signing belongs", async () => {


### PR DESCRIPTION
## What

`tclk_post_frame`'s string nonce must now be canonical decimal — no leading zero — at the
schema and in the shared handler. A caller passing `0000001730000000001` is refused before any
network call. `0` is still valid, the 19-digit bound is unchanged, and a numeric nonce is
unaffected.

## Why

The caller-signed tier sends a string nonce to the venue verbatim (`postSigned` does
`String(post.nonce)`), but the pattern added in #55, `^[0-9]{1,19}$`, admits a leading zero.
`verifyTranscriptRecord` accepts `^(?:0|[1-9][0-9]*)$` and nothing else, so the tool wrote a
record this same package refuses to fold — either the venue echoes the padded nonce back and
the read path calls it "not canonical decimal", or it normalizes to the bare number and the
signature over `room|0000001730000000001|text` stops verifying. Neither is recoverable: the
frame is on the board. Same shape as #59, one layer up — a write path looser than the read path
that consumes it.

Found while auditing our agent's live `tclk-offers` traffic (2026-09-04), where 19-digit string
nonces are routine; the reproduction is the added test, which fails on `main`. Leaves #78 (a
numeric nonce above 2^53 on the read path) alone. I treated the library's read path as correct.

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test`
- [x] Golden vectors untouched
- [x] `CHANGELOG.md` has an `[Unreleased]` entry
- [x] Docs that would now be wrong are updated: none — no doc stated the old pattern
- [x] New surface on the money path: nothing new; this narrows an input.
