### PR TITLE
fix(transcript): preserve exact nonces above 2^53 in export and room parsing (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- Preserve exact unrounded digit strings for bare numeric nonces above Number.MAX_SAFE_INTEGER
+  (2^53 - 1, up to 19 digits) in `parseTranscriptExport`, `parseRecordJson`, and `readRoom`.
+  Previously, standard `JSON.parse` rounded nanosecond-clock nonces and caused
+  `transcriptRecord` to reject valid rows as non-safe integers, refusing full-board exports
+  on the live venue (#78).
 - `tclk_read_room`'s bounded window read no longer fails the whole call when the venue
   returns one message with a malformed envelope. A room is world-writable, so a single
   hostile line — a `nonce` that is not decimal text, a non-string `from` — used to throw

--- a/mcp/src/technocore.ts
+++ b/mcp/src/technocore.ts
@@ -7,7 +7,7 @@
 // Fail-closed on the wire: a non-2xx answer throws with the status and the venue's own
 // first line (its 400s name the offending field), never a silently empty result.
 
-import { parseTranscriptExport, type TranscriptRecord } from "@flop-labs/tclk";
+import { parseRecordJson, parseTranscriptExport, type TranscriptRecord } from "@flop-labs/tclk";
 
 const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,47}$/;
 
@@ -99,7 +99,8 @@ export function createClient(opts: { baseUrl?: string; fetch?: FetchLike } = {})
       if (!response.ok) await fail(response, `GET /r/${room}`);
       let view: unknown;
       try {
-        view = await response.json();
+        const text = await response.text();
+        view = parseRecordJson(text);
       } catch {
         throw new Error(`tclk-mcp: GET /r/${room} did not return JSON`);
       }

--- a/mcp/tests/transport.test.ts
+++ b/mcp/tests/transport.test.ts
@@ -264,6 +264,25 @@ describe("tclk_read_room", () => {
     expect(result.malformed).toEqual([{ seq: null, reason: expect.stringMatching(/seq/) }]);
   });
 
+  it("preserves nonces above 2^53 in window reads without marking them malformed (#78)", async () => {
+    const rawBody = JSON.stringify({
+      room: "lobby",
+      count: 1,
+      last_seq: 1,
+      messages: [],
+    }).replace(
+      '"messages":[]',
+      '"messages":[{"seq":1,"ts":"2026-01-01T00:00:00Z","from":"did:key:z6Mkaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","text":"gm","nonce":1730000000000000001,"sig":"AQ"}]',
+    );
+
+    const { fetchLike } = fakeFetch([{ body: rawBody }]);
+    const h = createHandlers({ env: {}, fetch: fetchLike });
+    const result = await h.tclk_read_room({ room: "lobby" });
+    expect(result.malformed).toHaveLength(0);
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].nonce).toBe("1730000000000000001");
+  });
+
   it("reads and strictly parses the full JSONL export", async () => {
     const line = offerLine();
     const nonce = 17;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export { TCLK_TERMINAL_STATUSES, openContract, applyFrame } from "./machine.js";
 export type { TclkStatus, ContractState, StepResult } from "./machine.js";
 
 export {
-  verifyTranscriptRecord, transcriptRecord, parseTranscriptExport,
+  verifyTranscriptRecord, transcriptRecord, parseTranscriptExport, parseRecordJson,
   findContractHandshake, foldTranscript,
 } from "./transcript.js";
 export type {

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -110,6 +110,33 @@ export function verifyTranscriptRecord(record: TranscriptRecord): TranscriptReco
   return { ok: true };
 }
 
+let supportsReviverContext = false;
+try {
+  JSON.parse('{"a":1}', ((_k: string, v: unknown, ctx?: { source?: string }) => {
+    if (ctx && typeof ctx.source === "string") supportsReviverContext = true;
+    return v;
+  }) as any);
+} catch {
+  // ignore
+}
+
+/**
+ * Parse a technocore record line or view payload to JSON while preserving exact
+ * decimal digit strings for numeric nonces above Number.MAX_SAFE_INTEGER (up to 19 digits).
+ */
+export function parseRecordJson(text: string): unknown {
+  if (supportsReviverContext) {
+    return JSON.parse(text, ((key: string, value: unknown, context?: { source?: string }) => {
+      if (key === "nonce" && typeof value === "number" && context && typeof context.source === "string") {
+        return context.source.trim();
+      }
+      return value;
+    }) as any);
+  }
+  const safe = text.replace(/(^|[{,]\s*)"nonce"\s*:\s*([0-9]{1,19})\s*([,}])/g, '$1"nonce":"$2"$3');
+  return JSON.parse(safe);
+}
+
 function object(value: unknown, where: string): Record<string, unknown> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`tclk: ${where} is not a JSON object`);
@@ -139,6 +166,8 @@ export function transcriptRecord(room: string, value: unknown): TranscriptRecord
   if (typeof message.nonce === "string") nonce = message.nonce;
   else if (typeof message.nonce === "number" && Number.isSafeInteger(message.nonce)) {
     nonce = String(message.nonce);
+  } else if (typeof message.nonce === "bigint") {
+    nonce = String(message.nonce);
   } else if (message.nonce !== undefined && message.nonce !== null) {
     throw new Error("tclk: transcript message nonce must be decimal text");
   }
@@ -167,7 +196,7 @@ export function parseTranscriptExport(room: string, jsonl: string): TranscriptRe
     if (line.trim() === "") return;
     let value: unknown;
     try {
-      value = JSON.parse(line);
+      value = parseRecordJson(line);
     } catch {
       throw new Error(`tclk: transcript export line ${index + 1} is not JSON`);
     }

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -13,6 +13,8 @@ import {
   makeAccept,
   makeOffer,
   parseTranscriptExport,
+  parseRecordJson,
+  verifyTranscriptRecord,
   type TranscriptRecord,
 } from "../src/index.js";
 
@@ -215,6 +217,19 @@ describe("trusted transcript records", () => {
     });
     expect(() => parseTranscriptExport(BOARD, withoutTimezone)).toThrow(/timezone-qualified/);
     expect(() => parseTranscriptExport(BOARD, localeTimestamp)).toThrow(/timezone-qualified/);
+  });
+
+  it("preserves exact nonces above 2^53 in export rows (#78)", () => {
+    const { offer } = deal();
+    const line = encodeFrame(offer);
+    const largeNonce = "1730000000000000001";
+    const sig = payer.sign(`${BOARD}|${largeNonce}|${line}`);
+    const rawExportLine = `{"seq":1,"ts":"2026-09-03T23:50:00Z","from":"${payer.did}","nonce":1730000000000000001,"sig":"${sig}","text":${JSON.stringify(line)}}`;
+
+    const records = parseTranscriptExport(BOARD, `${rawExportLine}\n`);
+    expect(records).toHaveLength(1);
+    expect(records[0].nonce).toBe(largeNonce);
+    expect(verifyTranscriptRecord(records[0]).ok).toBe(true);
   });
 
   it("never synthesizes offer-before-accept order while selecting a board handshake", () => {


### PR DESCRIPTION
## What

1. Adds `parseRecordJson` in `src/transcript.ts` (and exports it in `src/index.ts`) which preserves exact decimal digit string tokens for bare numeric nonces above `Number.MAX_SAFE_INTEGER` (2^53 - 1, up to 19 digits) using ES2023 `JSON.parse` reviver `context.source` with a safe token-boundary fallback for environments without context.
2. Updates `transcriptRecord` to support `bigint` nonces alongside string and safe integers.
3. Updates `parseTranscriptExport` to use `parseRecordJson` so full JSONL exports containing nanosecond-clock nonces parse without precision loss or throws.
4. Updates MCP `readRoom` in `mcp/src/technocore.ts` to parse GET response bodies with `parseRecordJson`, ensuring window reads preserve large nonces instead of marking them `malformed`.
5. Adds regression tests in `tests/transcript.test.ts` and `mcp/tests/transport.test.ts`.
6. Adds `CHANGELOG.md` entry.

Closes #78.

## Why

Technocore serializes nonces as bare JSON numbers. Signers on nanosecond clocks emit up to 19 decimal digits (exceeding `Number.MAX_SAFE_INTEGER`). Standard `JSON.parse` in JavaScript rounded these numbers, causing `Number.isSafeInteger(message.nonce)` in `transcriptRecord` to fail with `transcript message nonce must be decimal text`. On the live venue, this caused `parseTranscriptExport` to fail on valid board rows (around 40% of the live `tclk-offers` board export) and caused `readRoom` window reads to mark those records `malformed`.

## Checks

- [x] `tsc -p tsconfig.json`
- [x] `tsc -p mcp/tsconfig.json`
- [x] `pnpm test` (105/105 passed in root)
- [x] `pnpm --filter @flop-labs/tclk-mcp test` (41/41 passed in MCP)
- [x] Worker test suite (33/33 passed)
