### PR TITLE
fix(transcript): verify contract binding in findContractHandshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `findContractHandshake` now recomputes the contract id from the offer and acceptance
+  core before returning a pair. It previously returned any signed accept naming the
+  queried contract that followed its referenced offer, so an attacker could name an
+  arbitrary contract id over a victim's public offer and be reported as the
+  authenticated handshake while `applyFrame` later rejects it. Code follows SPEC §3.2;
+  the spec already requires both sides to recompute and reject on mismatch.
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -8,7 +8,8 @@
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { base58, base64urlnopad } from "@scure/base";
 
-import { decodeFrame, tryDecodeFrame } from "./frames.js";
+import { contractId, decodeFrame, isValidStatement, tryDecodeFrame } from "./frames.js";
+import type { OfferFrame } from "./frames.js";
 import { applyFrame, openContract, type ContractState } from "./machine.js";
 import { dealRoom, OFFER_ROOM } from "./technocore.js";
 
@@ -206,19 +207,42 @@ export function findContractHandshake(
 ): ContractHandshake | null {
   // Reuse the public derivation's strict contract-id validation.
   dealRoom(contract);
-  const offers = new Map<string, TranscriptRecord>();
+  const offers = new Map<string, { record: TranscriptRecord; frame: OfferFrame }>();
   let acceptPrecededOffer = false;
 
   for (const record of records) {
     const frame = authenticatedFrame(record);
     if (frame?.type === "offer") {
-      if (!offers.has(frame.id)) offers.set(frame.id, record);
+      if (!offers.has(frame.id)) offers.set(frame.id, { record, frame });
       continue;
     }
     if (frame?.type !== "accept" || frame.contract !== contract) continue;
     const offer = offers.get(frame.ref);
-    if (offer !== undefined) return { offer, accept: record };
-    acceptPrecededOffer = true;
+    if (offer === undefined) {
+      acceptPrecededOffer = true;
+      continue;
+    }
+    // The contract id binds the full offer and the acceptance core (SPEC §3.2).
+    // A signature alone does not make an accept an agreement: without this check an
+    // attacker can name any contract id over a victim's public offer and this helper
+    // would return it as the authenticated pair, while applyFrame later rejects it.
+    if (frame.from === offer.frame.from) continue;
+    if (!isValidStatement(offer.frame.lock, frame.statement)) continue;
+    if (offer.frame.lock === "point" && frame.paymentKey === undefined) continue;
+    let expected: string;
+    try {
+      expected = contractId(offer.frame, {
+        from: frame.from,
+        ref: frame.ref,
+        statement: frame.statement,
+        paymentKey: frame.paymentKey,
+        nonce: frame.nonce,
+      });
+    } catch {
+      continue;
+    }
+    if (expected !== frame.contract) continue;
+    return { offer: offer.record, accept: record };
   }
 
   if (acceptPrecededOffer) {

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -234,4 +234,23 @@ describe("trusted transcript records", () => {
       accept.contract,
     )).toEqual({ offer: offerRecord, accept: acceptRecord });
   });
+
+  it("refuses a signed accept that names a contract id the offer+accept do not derive", () => {
+    const { offer } = deal();
+    const offerRecord = record(BOARD, 1, NOW - 1, payer, encodeFrame(offer));
+    const fakeContract = `0x${"aa".repeat(32)}`;
+    const fakeAcceptLine =
+      `tclk1 ` +
+      JSON.stringify({
+        contract: fakeContract,
+        from: payee.did,
+        nonce: "bbbbbbbbbbbbbbbb",
+        ref: offer.id,
+        statement: `0x${"22".repeat(32)}`,
+        type: "accept",
+      });
+    const fakeAcceptRecord = record(BOARD, 2, NOW, payee, fakeAcceptLine);
+
+    expect(findContractHandshake([offerRecord, fakeAcceptRecord], fakeContract)).toBeNull();
+  });
 });


### PR DESCRIPTION
Fixes #83.

## What changes for a caller and why

`findContractHandshake` now recomputes the contract id from the offer and the acceptance core and only returns the pair when it equals the queried id (plus acceptor-d differs, statement fits the lock kind, point locks carry `paymentKey`). Previously any signed accept naming the queried contract that followed its referenced offer was returned, so an attacker could name an arbitrary contract id over a victim's public offer and be reported as the authenticated handshake while `applyFrame` later rejects it.

Callers that fold after finding (`examples/live-deal.mjs`, `examples/audit-export.mjs`) see no behavior change on honest transcripts; callers that trusted the finder alone stop accepting spoofed/self-accept handshakes (now `null`).

## Spec agreement

Code follows SPEC §3.2: both sides recompute the contract id and a mismatch rejects. The spec already requires this; the finder was the one not doing it. No wire-format change, no golden-vector change.

## Tests

- New regression test in `tests/transcript.test.ts` (`refuses a signed accept that names a contract id the offer+accept do not derive`) fails before the fix, passes after.
- `pnpm install --frozen-lockfile`, `pnpm -r --include-workspace-root build`, `pnpm -r --include-workspace-root test` pass locally (105 lib + 40 mcp + 33 worker). `check:protocol` clean, commit-message scan clean.
- Branch is current with `main`.
