### PR TITLE
fix(machine): compare receipt rails canonically like the lock path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `applyFrame` now compares receipt rails canonically, matching the lock path. A lock
+  stored under a registry alias (e.g. `paperrail`) previously rejected the canonical
+  receipt (`paper`) while the lock itself had been accepted by normalization. Code
+  follows SPEC §4–§5; rails are sets compared after normalization.
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema

--- a/src/machine.ts
+++ b/src/machine.ts
@@ -94,6 +94,21 @@ function tclk1OfferIncludesRail(offered: readonly string[], selected: string): b
 }
 
 /**
+ * Rail equality for receipt acknowledgments. Mirrors the lock path's canonical
+ * comparison: two spellings that normalize to the same registered id (e.g.
+ * `paperrail` vs `paper`) name the same rail, while historical custom ids that
+ * cannot be normalized only ever equal their exact spelling.
+ */
+function sameTclkRail(left: string, right: string): boolean {
+  if (left === right) return true;
+  try {
+    return normalizeRailId(left) === normalizeRailId(right);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Apply one frame at wall-clock `nowMs`. Clock and structural validation run first
  * (bad input is rejected, not thrown on); then the transition guards.
  */
@@ -213,7 +228,7 @@ export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number
       if (frame.outcome !== state.status) {
         return reject(state, `receipt outcome ${frame.outcome} does not match ${state.status}`);
       }
-      if (frame.rail !== undefined && state.rail !== undefined && frame.rail !== state.rail) {
+      if (frame.rail !== undefined && state.rail !== undefined && !sameTclkRail(frame.rail, state.rail)) {
         return reject(state, `receipt rail ${frame.rail} does not match contract rail ${state.rail}`);
       }
       if (frame.ref !== undefined && state.railRef !== undefined && frame.ref !== state.railRef) {

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -280,6 +280,34 @@ describe("tclk state machine", () => {
     expect(contradictoryReceipt.state).toBe(claimed.state);
   });
 
+  it("accepts a canonical receipt rail for a lock stored under a registry alias", () => {
+    const offer = baseOffer({ rails: ["paper"], nonce: "aabbccddeeff0011" });
+    const { lock, state } = accepted(offer);
+    const locked = applyFrame(state, {
+      type: "lock", from: PAYER_DID, contract: state.contract!, rail: "paperrail", ref: "escrow-42",
+    }, T0 + 1);
+    expect(locked.ok).toBe(true);
+    expect(locked.state.rail).toBe("paperrail");
+
+    const claimed = applyFrame(locked.state, {
+      type: "reveal", from: PAYEE_DID, contract: state.contract!, ref: "escrow-42",
+      secret: lock.preimage,
+    }, T0 + 2);
+    expect(claimed.ok).toBe(true);
+
+    const canonicalReceipt = applyFrame(claimed.state, {
+      type: "receipt", from: PAYER_DID, contract: state.contract!, outcome: "claimed",
+      rail: "paper", ref: "escrow-42",
+    }, T0 + 3);
+    expect(canonicalReceipt.ok).toBe(true);
+
+    const aliasReceipt = applyFrame(claimed.state, {
+      type: "receipt", from: PAYER_DID, contract: state.contract!, outcome: "claimed",
+      rail: "paper-rail", ref: "escrow-42",
+    }, T0 + 3);
+    expect(aliasReceipt.ok).toBe(true);
+  });
+
   it.each([
     ["NaN", Number.NaN],
     ["Infinity", Number.POSITIVE_INFINITY],


### PR DESCRIPTION
Fixes #85.

## What changes for a caller and why

Receipt rail comparison now uses the lock path's canonical rule (`sameTclkRail`): exact match wins, otherwise both sides are normalized (`paperrail`/`paper-rail`/`PaperRail` → `paper`) and compared; unnormalizable legacy customs only ever equal their exact spelling. Previously a lock stored under an alias accepted by normalization rejected the honest canonical receipt by exact compare, censoring the post-terminal acknowledgment.

Canonical-only flows are byte-identical; only alias-locked contracts change (their canonical receipts now pass, as the lock already implied).

## Spec agreement

Code follows SPEC §4–§5: rails are sets compared after normalization. The receipt guard was the one not doing it. No wire-format change, no golden-vector change.

## Tests

- New test in `tests/tclk.test.ts` (`accepts a canonical receipt rail for a lock stored under a registry alias`) fails before the fix, passes after (both alias directions).
- `pnpm install --frozen-lockfile`, `pnpm -r --include-workspace-root build`, `pnpm -r --include-workspace-root test` pass locally (105 + 40 + 33). `check:protocol` clean, commit-message scan clean.
- Branch is current with `main`.
