### PR TITLE
fix(paper-rail): harden case handling and fail-closed reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `PaperRail` now refuses a non-canonical lock statement, stores claims in canonical
+  lowercase, and reads malformed ids as absent. `verifySecret` accepts uppercase hex,
+  so an uppercase claim previously succeeded while writing a record no reader could
+  parse back; `verifyLock` threw on a malformed id instead of returning `false`.
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema

--- a/src/paper-rail.ts
+++ b/src/paper-rail.ts
@@ -114,6 +114,16 @@ export class PaperRail implements SettlementRail {
     if (this.clock() >= terms.refundAfterMs) {
       throw new Error("tclk: refusing to lock into an already-open refund window");
     }
+    // The record only stores lowercase canonical spellings (decodePaperRecord enforces
+    // them), so refuse a non-canonical statement here rather than writing a record no
+    // reader can parse back. Honest terms always come from lockTerms() over an accepted
+    // contract, where the statement already passed isValidStatement.
+    if (!isValidStatement(terms.lock, terms.statement)) {
+      throw new Error("tclk: paper rail lock statement does not fit its lock kind");
+    }
+    if (!Number.isSafeInteger(terms.refundAfterMs) || terms.refundAfterMs <= 0) {
+      throw new Error("tclk: paper rail lock refundAfterMs must be a positive unix-ms integer");
+    }
     const { ns, key } = paperNote(terms.contract);
     const record: PaperRecord = {
       status: "locked",
@@ -128,6 +138,9 @@ export class PaperRail implements SettlementRail {
 
   async verifyLock(terms: LockTerms, ref: string): Promise<boolean> {
     if (ref !== terms.contract) return false;
+    // read() returns null for malformed ids and unparseable lines, so a malformed
+    // input ends here as false. A transport failure from notes.get still throws,
+    // which is correct: that is an outage, not a negative answer.
     const record = await this.read(ref);
     return (
       record !== null &&
@@ -141,10 +154,14 @@ export class PaperRail implements SettlementRail {
   async claim(ref: string, secret: string): Promise<void> {
     const { current, record } = await this.requireLocked(ref, "claim");
     if (this.clock() >= record.refundAfterMs) throw new Error("tclk: claim after refundAfterMs");
-    if (!verifySecret(record.lock, record.statement, secret)) {
+    // verifySecret accepts uppercase hex, but the record encoding is canonical
+    // lowercase. Store the lowercase spelling so a successful claim stays readable
+    // (decodePaperRecord requires it) instead of becoming unauditable.
+    const canonicalSecret = secret.toLowerCase();
+    if (!verifySecret(record.lock, record.statement, canonicalSecret)) {
       throw new Error("tclk: secret does not open the statement");
     }
-    await this.advance(ref, current, { ...record, status: "claimed", secret });
+    await this.advance(ref, current, { ...record, status: "claimed", secret: canonicalSecret });
   }
 
   async refund(ref: string): Promise<void> {
@@ -155,7 +172,13 @@ export class PaperRail implements SettlementRail {
 
   /** The record as it stands, or null when absent or unparseable. */
   async read(ref: string): Promise<PaperRecord | null> {
-    const { ns, key } = paperNote(ref);
+    let ns: string;
+    let key: string;
+    try {
+      ({ ns, key } = paperNote(ref));
+    } catch {
+      return null;
+    }
     const value = await this.notes.get(ns, key);
     return value === null ? null : decodePaperRecord(value);
   }

--- a/tests/paper-rail.test.ts
+++ b/tests/paper-rail.test.ts
@@ -206,4 +206,29 @@ describe("paper rail — reads are anonymous input", () => {
   it("rejects a malformed contract id rather than sharding garbage", () => {
     expect(() => paperNote("nonsense")).toThrow(/malformed contract id/);
   });
+
+  it("stays fail-closed and readable on non-canonical case", async () => {
+    const { rail } = railAt();
+    const deal = terms();
+
+    // Malformed ids read as absent instead of throwing out of a polling loop.
+    await expect(rail.verifyLock({ ...deal.terms, contract: "0xZZZ" }, "0xZZZ")).resolves.toBe(false);
+    await expect(rail.read("0xZZZ")).resolves.toBeNull();
+
+    // An uppercase statement never reaches the note: honest terms are already
+    // lowercase via lockTerms(), anything else is a hand-built caller bug.
+    const upperStatement = deal.terms.statement.toUpperCase().replace("0X", "0x");
+    await expect(rail.lock({ ...deal.terms, statement: upperStatement })).rejects.toThrow(
+      /does not fit its lock kind/,
+    );
+
+    // verifySecret accepts uppercase, so claim does too — but it stores the
+    // canonical lowercase spelling, keeping a successful claim auditable.
+    const ref = await rail.lock(deal.terms);
+    const upperSecret = deal.secret.toUpperCase().replace("0X", "0x");
+    await rail.claim(ref, upperSecret);
+    const record = await rail.read(ref);
+    expect(record?.status).toBe("claimed");
+    expect(record?.secret).toBe(deal.secret.toLowerCase());
+  });
 });


### PR DESCRIPTION
Fixes #87.

## What changes for a caller and why

- `lock` now refuses a statement that does not fit its lock kind (and a non-positive `refundAfterMs`) instead of writing a note line no reader can parse back. Honest terms come from `lockTerms()` over an accepted contract and already pass, so honest flows are unchanged.
- `claim` stores the canonical lowercase spelling of the secret it verified (`verifySecret` accepts uppercase by design). Previously an uppercase claim succeeded and then read back as `null`.
- `read` returns `null` and `verifyLock` returns `false` on malformed ids per their documented fail-closed contracts. A transport failure from the note store still throws — that is an outage, not a negative answer.

## Spec agreement

No record-format change; the parser (`decodePaperRecord`) is untouched and honest lowercase flows are byte-identical. Code follows the existing fail-closed + canonical-encoding rules the module already states.

## Tests

- New test in `tests/paper-rail.test.ts` (`stays fail-closed and readable on non-canonical case`) fails before the fix, passes after.
- `pnpm install --frozen-lockfile`, `pnpm -r --include-workspace-root build`, `pnpm -r --include-workspace-root test` pass locally (105 + 40 + 33). `check:protocol` clean, commit-message scan clean.
- Branch is current with `main`.
