### PR TITLE
fix(schema): compare generated content, not checkout line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Every tracked file here is text, and two of them are compared byte for byte against
+# freshly generated output by `scripts/generate-frame-fields.mjs --check`. Pin the checkout
+# so that comparison does not depend on a contributor's `core.autocrlf`.
+* text=auto eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project are documented here. Format follows
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema
   boundary rather than silently rounded.
+- The generated-protocol drift check now compares content rather than line endings, and a
+  `.gitattributes` pins the checkout to LF, so a clone made with `core.autocrlf=true` no
+  longer fails `pnpm test` with `generated protocol fields are stale` when nothing has
+  drifted. Regenerating on such a clone previously rewrote `SPEC.md` with mixed line endings.
 
 ### Added
 

--- a/scripts/generate-frame-fields.mjs
+++ b/scripts/generate-frame-fields.mjs
@@ -56,8 +56,12 @@ if (nextSpec === spec && !spec.includes(table)) {
   throw new Error("SPEC.md has no generated frame-field markers");
 }
 
+// Line endings belong to the checkout, not to the schema. Compare with CRLF folded to LF so
+// a working tree that stores them that way does not read as protocol drift; writes stay LF.
+const sameContent = (a, b) => a.replaceAll("\r\n", "\n") === b.replaceAll("\r\n", "\n");
+
 if (process.argv.includes("--check")) {
-  if (readFileSync(generatedPath, "utf8") !== generated || spec !== nextSpec) {
+  if (!sameContent(readFileSync(generatedPath, "utf8"), generated) || !sameContent(spec, nextSpec)) {
     console.error("generated protocol fields are stale; run pnpm generate:protocol");
     process.exit(1);
   }

--- a/tests/schema-conformance.test.ts
+++ b/tests/schema-conformance.test.ts
@@ -3,7 +3,9 @@
 // generated decoder contract or the normative SPEC table from drifting away unnoticed.
 
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
@@ -60,6 +62,36 @@ describe("protocol schema", () => {
       ["scripts/generate-frame-fields.mjs", "--check"],
       { cwd: root, stdio: "pipe" },
     )).not.toThrow();
+  });
+
+  // That check compares both artefacts byte for byte, and nothing pinned the checkout's line
+  // endings, so a clone made with `core.autocrlf=true` reported the protocol as stale when
+  // only its line endings differed. Line endings are the checkout's business; what the schema
+  // says is not, and folding them away must not cost the check its teeth.
+  it("reports drift by generated content, not by checkout line endings", () => {
+    const scratch = mkdtempSync(join(tmpdir(), "tclk-eol-"));
+    try {
+      for (const dir of ["schema", "scripts", "src"]) mkdirSync(join(scratch, dir));
+      const schemaCopy = join(scratch, "schema", "tclk1-frames.schema.json");
+      const script = join(scratch, "scripts", "generate-frame-fields.mjs");
+      copyFileSync(join(root, "scripts", "generate-frame-fields.mjs"), script);
+      copyFileSync(join(root, "schema", "tclk1-frames.schema.json"), schemaCopy);
+      const generatedCopy = join(scratch, "src", "frame-fields.generated.ts");
+      for (const file of [join("src", "frame-fields.generated.ts"), "SPEC.md"]) {
+        writeFileSync(join(scratch, file), readFileSync(join(root, file), "utf8").replace(/\r?\n/g, "\r\n"));
+      }
+      const check = () => execFileSync(process.execPath, [script, "--check"], { stdio: "pipe" });
+
+      expect(readFileSync(generatedCopy, "utf8")).toContain("\r\n");
+      expect(check).not.toThrow();
+
+      const drifted = JSON.parse(readFileSync(schemaCopy, "utf8"));
+      drifted.$defs.rail["x-tclk-canonicalIds"].push("unregenerated-rail");
+      writeFileSync(schemaCopy, JSON.stringify(drifted, null, 2));
+      expect(check).toThrow();
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
   });
 
   it("keeps historical duplicate rail arrays decodable under tclk1", () => {


### PR DESCRIPTION
Fixes #90.

## What breaks

`scripts/generate-frame-fields.mjs --check` compares the generated field contract and the SPEC table byte for byte, and nothing pins the checkout's line endings. On a clone made with `core.autocrlf=true` both files hold CRLF while the generator emits LF, so the freshness check fails on an unmodified `main`:

```
generated protocol fields are stale; run pnpm generate:protocol
```

Measured at `5cc4ab9`: root suite 103/104, the one failure being `tests/schema-conformance.test.ts > has current generated decoder fields and SPEC documentation`; build clean; MCP 40/40; Worker 33/33.

Following the message's advice does not settle it. `pnpm generate:protocol` on that clone rewrites the generated block of `SPEC.md` with LF and leaves the rest of the file CRLF (CR 471 to 460). `git status` then reports both files modified with an **empty** diff, alongside `warning: LF will be replaced by CRLF the next time Git touches it` — and the next checkout restores CRLF and the failure with it. CI is `ubuntu-latest` only, so nothing upstream sees any of this.

## What I treated as correct

The schema and the committed artefacts. Their content is identical across both checkouts — #90's normalised hashes show that, and I reproduced it. The comparison is the part that was wrong: it asserted a property of the working tree that the schema does not own.

## The change

Two layers, one problem. The attribute alone would leave every existing Windows clone failing until it was renormalised; the fold alone would leave the repository's checkout unspecified.

- `--check` folds CRLF to LF on both sides before comparing. Writes are untouched and still emit LF.
- `.gitattributes` pins `* text=auto eol=lf`. Every tracked file here is text — 43 `.ts`, 10 `.md`, 7 `.json`, 5 `.yml`, 5 `.mjs`, 2 `.yaml`, one `.sh`, one `.mts`, one `.jsonc` — with no binaries and no `.bat`, `.cmd` or `.ps1`, so nothing in the tree wants CRLF.

## Regression test

#90 asks for a CRLF fixture, and the failure is otherwise invisible to Linux CI. The new case copies the script, schema, generated contract and SPEC into a temp directory with CRLF endings and runs `--check` against that root, so a Windows-only failure is reproducible on `ubuntu-latest`. It touches no tracked file, and its fixture is idempotent (`/\r?\n/g` to CRLF) so it behaves the same on a CRLF working tree.

Three rows, run on this branch:

| script under test | the new case |
|---|---|
| this branch | passes |
| `main`'s byte comparison | fails — `expected [Function check] to not throw` |
| `sameContent` forced to `true` | fails — `expected [Function check] to throw` |

The third row is what the test's second half is for: an unregenerated schema must still be caught, so the fold cannot be widened into a comparison that always agrees.

## Verification

- LF clone, the three CI commands: `install --frozen-lockfile` clean, both `tsc` builds clean, then `9 passed (9)` / `105 passed (105)`, `6/6` / `40/40`, `2/2` / `33/33`.
- The same three commands on Linux x86_64 with node `v22.22.1`, since the new case spawns a child process and writes to a temp directory and everything above was measured on Windows: identical `105` / `40` / `33`, and `scripts/no-agent-trailers.sh` passes on the commit.
- The CRLF clone that was failing, with `src/frame-fields.generated.ts` and `SPEC.md` still CRLF on disk and nothing renormalised: the same 105 / 40 / 33.
- A fresh `git -c core.autocrlf=true clone` of this branch checks out CR 0 across the tree, and `main`'s pre-fix script exits 0 there — the attribute alone is enough for a new clone.
- `scripts/no-agent-trailers.sh` passes on the commit message, with `core.hooksPath` set to `.githooks`.

No golden vectors, wire encoding, frame semantics or rail registry are touched.

Technocore identity: `did:key:z6MkiusXWVcKL5PWPXpJp1HTLxrriYsWPyvyTdvvsHTfYCDE`