### PR TITLE
feat(machine): expose whether an accepted contract can still be funded (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ All notable changes to this project are documented here. Format follows
   and the normative `SPEC.md` table are checked for drift in CI.
 - A signed `heartbeat` frame for non-authoritative liveness while a contract is accepted
   or locked, without abusing terminal receipts or changing contract state.
+- `fundingOutlook(state, nowMs)`, a derived reading of whether a contract can still be funded.
+  An accepted contract's status sits at `accepted` indefinitely when a payer walks away, so an
+  abandonment and a party being briefly offline look the same; funding itself does not, because
+  `applyFrame` already refuses a `lock` once `nowMs >= offer.refundAfterMs` and that field is
+  committed by `contractId` before either party signs. The bound was therefore already agreed and
+  simply unexposed. The reading separates an accepted contract whose window is still open from one
+  whose window shut with no lock, from one explicitly cancelled, from one already funded, which is
+  the distinction funnel accounting needs (#41). It is derived and never signed: absence of
+  funding is not something a vanished party can be made to attest, and no coordination deadline
+  field or abort frame is added. No safety margin is applied — a margin is rail-specific, so the
+  time remaining is reported and the caller applies its own. Nothing in the state machine, the
+  wire format or the golden vectors changes.
 - A hosted deployment of the MCP server at `https://tclk.technocore.chat/mcp`, streamable
   HTTP, no account and no key. It is the no-custody Worker build: it binds neither
   `TECHNOCORE_SIGNING_KEY` nor `TCLK_PAYMENT_KEY` and refuses to serve if either is present,

--- a/SPEC.md
+++ b/SPEC.md
@@ -249,6 +249,20 @@ distinct from two valid sets having no overlap. For a historical custom tclk/1 i
 normalized, replay uses the original exact-string membership rule and never treats it as equal
 to a registered rail.
 
+**Abandonment is already observable, and `refundAfterMs` is the deadline.** A contract's *status*
+stays `accepted` indefinitely when a payer walks away, which is what makes an abandonment look
+like a party being briefly offline. Funding, though, does not: the `lock` guard above refuses a
+lock once `now ≥ refundAfterMs`, and `refundAfterMs` is an offer field committed by `contractId`,
+so both parties signed the bound before either acted. tclk/1 therefore needs no coordination
+deadline field and no abort frame to make the cliff visible — `fundingOutlook(state, nowMs)`
+reports it, distinguishing an accepted contract whose window is still open from one whose window
+shut with no lock, from one explicitly cancelled, from one already funded. It is a derived
+reading, never a signed frame and never contract state: absence of funding is not something a
+vanished party can be made to attest, and a clock passing is not evidence that anyone intended to
+abort. A safety margin on top of the bound is rail-specific and belongs to the caller, which is
+why the reading reports the time remaining rather than only a verdict. `claimByMs` is not a
+boundary here: no transition guard reads it, and §3.1 calls it the payee's *safe* claim deadline.
+
 ## 5. Settlement rails
 
 A rail is anything that can hold `amount` of `asset` under the contract's statement and

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,8 @@ export {
 } from "./locks.js";
 export type { HashLock } from "./locks.js";
 
-export { TCLK_TERMINAL_STATUSES, openContract, applyFrame } from "./machine.js";
-export type { TclkStatus, ContractState, StepResult } from "./machine.js";
+export { TCLK_TERMINAL_STATUSES, openContract, applyFrame, fundingOutlook } from "./machine.js";
+export type { TclkStatus, ContractState, StepResult, FundingOutlook, FundingOutlookCode } from "./machine.js";
 
 export {
   verifyTranscriptRecord, transcriptRecord, parseTranscriptExport,

--- a/src/machine.ts
+++ b/src/machine.ts
@@ -237,3 +237,107 @@ export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number
     }
   }
 }
+
+// ── Derived funding actionability ─────────────────────────────────────────────
+
+/**
+ * Why funding is or is not still actionable. One bucket per distinguishable outcome, so a funnel
+ * can separate "locked", "explicitly cancelled", "the window shut and nothing arrived" and "still
+ * open, merely unobserved" — the four an accepted-but-unlocked contract gets confused between.
+ */
+export type FundingOutlookCode =
+  | "awaiting-accept"
+  | "offer-expired"
+  | "open"
+  | "lapsed"
+  | "funded"
+  | "settled"
+  | "cancelled"
+  | "unreadable-clock";
+
+export interface FundingOutlook {
+  /** True only while a `lock` frame would still be accepted at `nowMs`. */
+  actionable: boolean;
+  code: FundingOutlookCode;
+  /** Milliseconds until funding stops being actionable, 0 once it has. */
+  msRemaining: number;
+  reason: string;
+}
+
+/**
+ * Whether the signed transcript plus a clock still leave room to fund this contract.
+ *
+ * Derived, never signed and never stored. An accepted contract's *status* can sit at `accepted`
+ * forever, which is what makes an abandonment look like a party being briefly offline, but
+ * funding itself already has a deterministic upper bound: `applyFrame` refuses a `lock` once
+ * `nowMs >= offer.refundAfterMs`, and `refundAfterMs` is in the offer and committed by
+ * `contractId` before either party signs anything. So the deadline exists, is agreed, and needs
+ * no new field or frame — it was simply never exposed, so nothing could report it (#41).
+ *
+ * The boundary here is read off the same comparison the transition guard uses; a test pins the
+ * two together over a sweep of clocks so they cannot drift apart.
+ *
+ * No safety margin is applied. A margin is rail-specific — how long a rail takes to accept a
+ * lock, and how much slack a payee wants before `claimByMs` — so it belongs to the caller, which
+ * is why `msRemaining` is reported rather than a bare boolean. `claimByMs` is deliberately not a
+ * boundary: no transition guard reads it, and SPEC §3.1 calls it the payee's *safe* claim
+ * deadline, a margin rather than a cliff.
+ */
+export function fundingOutlook(state: ContractState, nowMs: number): FundingOutlook {
+  // Fail closed on a clock the machine itself would refuse, rather than answering from NaN —
+  // every comparison below would be false in both directions.
+  if (!Number.isFinite(nowMs) || nowMs < 0) {
+    return {
+      actionable: false,
+      code: "unreadable-clock",
+      msRemaining: 0,
+      reason: "tclk: nowMs must be a finite non-negative number",
+    };
+  }
+
+  const { expiresMs, refundAfterMs } = state.offer;
+  const closed = (code: FundingOutlookCode, reason: string): FundingOutlook => ({
+    actionable: false,
+    code,
+    msRemaining: 0,
+    reason,
+  });
+
+  switch (state.status) {
+    case "cancelled":
+      return closed("cancelled", "contract was cancelled");
+    case "claimed":
+    case "refunded":
+      return closed("settled", `contract is ${state.status}`);
+    case "locked":
+      return closed("funded", "contract is already funded");
+
+    case "proposed": {
+      // Two barriers in the order the machine hits them: accept is refused at `expiresMs`, and a
+      // lock is refused at `refundAfterMs` however the accept went. An offer may order those two
+      // either way — nothing requires `expiresMs < refundAfterMs` — so both are checked.
+      if (nowMs >= expiresMs) return closed("offer-expired", "offer expired unaccepted");
+      if (nowMs >= refundAfterMs) {
+        return closed("lapsed", "refund window opened before the offer was accepted");
+      }
+      return {
+        actionable: true,
+        code: "awaiting-accept",
+        msRemaining: Math.min(expiresMs, refundAfterMs) - nowMs,
+        reason: "offer is open and a lock would still be accepted",
+      };
+    }
+
+    case "accepted": {
+      if (nowMs >= refundAfterMs) {
+        return closed("lapsed", "refund window opened with no lock on the contract");
+      }
+      return {
+        actionable: true,
+        code: "open",
+        msRemaining: refundAfterMs - nowMs,
+        reason: "accepted and a lock would still be accepted",
+      };
+    }
+  }
+}

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -36,6 +36,7 @@ import {
   tclkStatusToA2A,
   tclkStatusToAcpPhase,
   tryDecodeFrame,
+  fundingOutlook,
   validateDeadlines,
   verifyHashPreimage,
   verifyPointWitness,
@@ -554,5 +555,105 @@ describe("tclk interop mappings", () => {
     expect(offer.job).toEqual({ proto: "acp", id: "1234" });
     expect(a2aJob("t-1")).toEqual({ proto: "a2a", id: "t-1" });
     expect(a2aJob("t-1", "c-9")).toEqual({ proto: "a2a", id: "t-1", context: "c-9" });
+  });
+});
+
+describe("fundingOutlook — derived, never signed (#41)", () => {
+  const lockFrame = (state: ContractState) => ({
+    type: "lock" as const,
+    from: PAYER_DID,
+    contract: state.contract!,
+    rail: "flop-htlc",
+    ref: "escrow-41",
+  });
+
+  // The whole point of the reading is that it agrees with the guard. If someone changes the
+  // `lock` guard's comparison and not this, one of these clocks disagrees.
+  it("agrees with the lock guard at every clock around the boundary", () => {
+    const { state } = accepted();
+    const clocks = [
+      T0,
+      REFUND_AFTER - 60_000,
+      REFUND_AFTER - 1,
+      REFUND_AFTER,
+      REFUND_AFTER + 1,
+      REFUND_AFTER + 60_000,
+    ];
+    for (const now of clocks) {
+      expect(fundingOutlook(state, now).actionable).toBe(applyFrame(state, lockFrame(state), now).ok);
+    }
+  });
+
+  it("separates the four an accepted contract gets confused between", () => {
+    const { state, lock } = accepted();
+    expect(fundingOutlook(state, T0)).toMatchObject({
+      actionable: true,
+      code: "open",
+      msRemaining: REFUND_AFTER - T0,
+    });
+
+    // The cliff #41 is about: the window shut and no lock ever arrived.
+    expect(fundingOutlook(state, REFUND_AFTER)).toMatchObject({
+      actionable: false,
+      code: "lapsed",
+      msRemaining: 0,
+    });
+
+    const locked = applyFrame(state, lockFrame(state), T0);
+    expect(locked.ok).toBe(true);
+    expect(fundingOutlook(locked.state, T0).code).toBe("funded");
+
+    const cancelled = applyFrame(state, {
+      type: "cancel",
+      from: PAYER_DID,
+      contract: state.contract!,
+    }, T0);
+    expect(cancelled.ok).toBe(true);
+    expect(fundingOutlook(cancelled.state, T0).code).toBe("cancelled");
+
+    const revealed = applyFrame(locked.state, {
+      type: "reveal",
+      from: PAYEE_DID,
+      contract: state.contract!,
+      secret: lock.preimage,
+    }, T0);
+    expect(revealed.ok).toBe(true);
+    expect(fundingOutlook(revealed.state, T0).code).toBe("settled");
+  });
+
+  it("reports both barriers a proposed offer can hit, in the order the machine hits them", () => {
+    const state = openContract(baseOffer());
+    expect(fundingOutlook(state, T0)).toMatchObject({
+      actionable: true,
+      code: "awaiting-accept",
+      msRemaining: EXPIRES - T0,
+    });
+    expect(fundingOutlook(state, EXPIRES).code).toBe("offer-expired");
+
+    // Nothing requires expiresMs < refundAfterMs, so an offer can still be acceptable at a clock
+    // where no lock could follow. That is a closed funding window, not an expired offer.
+    const late = openContract(baseOffer({ expiresMs: REFUND_AFTER + 600_000 }));
+    expect(fundingOutlook(late, REFUND_AFTER)).toMatchObject({ actionable: false, code: "lapsed" });
+    expect(applyFrame(late, makeAccept(late.offer, {
+      from: PAYEE_DID,
+      statement: generateHashLock().hash,
+    }), REFUND_AFTER).ok).toBe(true);
+  });
+
+  it("fails closed on a clock the machine would refuse", () => {
+    const { state } = accepted();
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+      const outlook = fundingOutlook(state, bad);
+      expect(outlook).toMatchObject({ actionable: false, code: "unreadable-clock", msRemaining: 0 });
+      expect(applyFrame(state, lockFrame(state), bad).ok).toBe(false);
+    }
+  });
+
+  it("never mutates the state it reads", () => {
+    const { state } = accepted();
+    const before = structuredClone(state);
+    fundingOutlook(state, T0);
+    fundingOutlook(state, REFUND_AFTER + 1);
+    expect(state).toEqual(before);
   });
 });


### PR DESCRIPTION
## What

`fundingOutlook(state, nowMs)` — a derived reading of whether a contract can still be funded.
No new frame, no new field, no new status, no wire byte, no golden vector.

Answers #41.

## Why the deadline already exists

#41 offers two candidates and both need a wire change: bind a `lockByMs` into `accept`, or add an
`abort` frame. Neither is necessary, because `applyFrame` already refuses a lock past a deadline
both parties signed:

```ts
case "lock": {
  …
  if (nowMs >= state.offer.refundAfterMs) return reject(state, "refund window is already open");
```

`refundAfterMs` is an offer field committed by `contractId`, so the bound was agreed before either
party acted. SPEC §4's own diagram already prints it: `accepted ──lock(payer, rail ∈ offer.rails,
now < refundAfterMs)──▶ locked`.

What was missing is that nothing exposed it. #41's measurement — 663 accepted contracts, 14 lock
frames, one cancel — cannot say which of those acceptances could still be funded, so an
abandonment and a party being briefly offline read identically. That is an observability gap, not a
state-machine gap.

## What it reports

The four buckets #41's acceptance criteria ask a funnel to distinguish, plus the proposed side:

| status | clock | `code` | `actionable` |
|---|---|---|---|
| `accepted` | `now < refundAfterMs` | `open` | **true** — merely unobserved |
| `accepted` | `now >= refundAfterMs` | `lapsed` | false — the window shut, no lock arrived |
| `locked` | any | `funded` | false — already happened |
| `cancelled` | any | `cancelled` | false — explicitly closed |
| `claimed`/`refunded` | any | `settled` | false |
| `proposed` | `now < expiresMs` | `awaiting-accept` | true |
| `proposed` | `now >= expiresMs` | `offer-expired` | false |
| any | not a finite non-negative clock | `unreadable-clock` | false |

Two details worth naming. Nothing requires `expiresMs < refundAfterMs`, so an offer can still be
acceptable at a clock where no lock could follow — that is `lapsed`, a closed funding window, not
an expired offer, and the test covers it by accepting such an offer successfully at that clock.
And `msRemaining` is reported rather than only a verdict, because **no safety margin is applied**:
a margin is rail-specific (how long a rail takes to accept a lock, how much slack a payee wants
before `claimByMs`), so it belongs to the caller. `claimByMs` is deliberately not a boundary here —
no transition guard reads it, and §3.1 calls it the payee's *safe* claim deadline.

## Why it is derived and not signed

This is the part that answers #41's decisions 3 through 5, and it is a deliberate refusal rather
than an omission. Absence of funding is not something a vanished party can be made to attest, and
a clock passing is not evidence that anyone intended to abort. So there is no signed terminal state
for the absence of funding: nothing here adds a frame, a field, a status, or contract state, and a
lapse authorises nothing on its own. Explicit, attributable abandonment is an agreement-state
question, which is tclk/2's to answer.

## Checks

`origin/main` at `5cc4ab9`.

```
pnpm install --frozen-lockfile
pnpm -r --include-workspace-root build
pnpm -r --include-workspace-root test
```

109 library (was 104) + 40 mcp + 33 worker = 182 passed, 0 failed.

**Both ways.** A pure addition has a trivial revert, so the meaningful proof is the drift
tripwire: the reading takes its boundary from the same comparison the guard uses, and one test
pins them together over six clocks across it. One mutation at a time:

| mutation | tests failing |
|---|---|
| the `lock` guard's `>=` becomes `>` | **2** of 43 — an existing boundary test, and the agreement test |
| the reading's `>=` becomes `>`, guard untouched | **2** of 43 — both mine |

The second row is the argument for that test. On `main` a wrong boundary inside a new derived
reading is invisible to the entire suite; nothing else compares the two.

Fork CI can sit at `action_required` with no jobs, so those numbers are from a local run rather
than a green check I watched.

## Overlap

- **#32** is the other open PR in `src/machine.ts`, `SPEC.md` and `tests/tclk.test.ts`. Its hunks
  are the `cancel` and `receipt` cases, a `ContractState` field, SPEC §3.5 and `tests/tclk.test.ts`
  around line 372. Mine are a new function after `applyFrame`, the end of SPEC §4, and a new
  `describe` at the end of the test file. `git merge-tree --write-tree` is clean in both
  directions.
- Seven of my own are open and all touch `CHANGELOG.md`; each is anchored after a different
  existing bullet, and every pairing merges clean, checked the same way. This one is anchored
  after the `heartbeat` entry.
- **#12** stays the source of truth for the payee-opened secret-assignment seam; nothing here
  touches condition authority.
- **What a hostile counterparty gets: nothing.** A pure function over a state a caller already
  holds. It reads `state.offer` and `nowMs`, returns a fresh object, mutates nothing (pinned by a
  test), performs no I/O, and is not reachable from any frame.

Which side I treated as correct: **the code**. The guard was already right; SPEC §4 did not draw
the consequence, so §4 gains a paragraph. Fits the boundary #58 records — improves auditability,
preserves every existing byte.

## Provenance

Signed with the same `did:key` as #59, #60 and #66–#74.

```
did        did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL
head       0c38102eae33de22ab90ec8a111384a5a9cbbed1
digest     8292fb2848716c99bb6e159582e00bdcfe8d51bd39ce605cbdebc0bfe320c218
signature  TqXlGyFxW-l_kfipeNURVzOU155zdsPDJutJa0vR0BwvtBjolwrgXTaLE3ft1tK2L1-HrVmIh9TWVHTa_6_0Cw
```

Rebuild the digest: `sha256` each file's bytes at `head`, one `<sha256>  <path>` line per file in
the order `CHANGELOG.md`, `SPEC.md`, `src/machine.ts`, `src/index.ts`, `tests/tclk.test.ts`, then `sha256` that text.

```
397fb1a727c62e0aac8a31a5d8760a412461e7c5394552d9769cf339b8f56570  CHANGELOG.md
42391a8bd76a74d7b6d09bf6580fb95786a87c02fcb2ab783c889164e193c364  SPEC.md
3f3e13fe5f81428c31c396c606c41ea992bb59c878810378f6e320edfaf9d311  src/machine.ts
d752e7615e4ef264e0af0e8515e033aa28bdba5f15563cba833c69ae7a107f42  src/index.ts
7f68ef63f151c9bf5bf3a8740be26e4b60101d7ce43a6aa17b09613484808d5e  tests/tclk.test.ts
```

Signed payload `tclk-pr|flop-labs/tclk|<head>|<digest>`. Verify with the public key decoded out of
the DID — no private key in the loop, and a tampered payload must fail. Key note:
<https://technocore.chat/kv/agent/f15ddb2552fee06f> (the documented `/kv/did/` namespace is at its
cap, flop-labs/technocore-chat#85).
