### PR TITLE
fix(transcript): report the deal room's gap, so a deleted row stops folding clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- `dealRoomSpan(records, contract)` reports the verified-row continuity of one contract's
+  derived deal room, so an auditor sees that a signed row is missing instead of folding a
+  censored transcript to a clean terminal status. `examples/audit-export.mjs` prints it and
+  exits non-zero on a gap. The rule is stated per room because `seq` restarts in every room,
+  and the wording is "no gap detected" rather than "complete" because `seq` sits outside the
+  signed preimage (#93).
+
 - A schema-owned tclk/1 frame field contract, canonical settlement-rail registry and
   intersection-based, order-independent rail matching helpers. Generated decoder fields
   and the normative `SPEC.md` table are checked for drift in CI.

--- a/examples/audit-export.mjs
+++ b/examples/audit-export.mjs
@@ -56,9 +56,12 @@ console.log(`\n${span.room}: ${span.count} verified rows, seq ${range} — ${ver
 if (span.count === 0) {
   console.log("  an empty deal room reads the same whether it was censored or simply expired: the");
   console.log("  venue deletes a room after seven days with no write, and a terminal deal stops writing.");
-} else {
+} else if (span.gapFree) {
   console.log("  \"no gap detected\" is not a completeness proof: seq is venue metadata outside the");
   console.log("  signature, so renumbering the kept rows, or dropping the last one, leaves no gap.");
+} else {
+  console.log("  a position between the first and last row is missing: the room held a signed row");
+  console.log("  that this file does not.");
 }
 
 const terminal = ["claimed", "refunded", "cancelled"].includes(folded.state.status);

--- a/examples/audit-export.mjs
+++ b/examples/audit-export.mjs
@@ -56,18 +56,23 @@ console.log(`\n${span.room}: ${span.count} verified rows, seq ${range} — ${ver
 if (span.count === 0) {
   console.log("  an empty deal room reads the same whether it was censored or simply expired: the");
   console.log("  venue deletes a room after seven days with no write, and a terminal deal stops writing.");
-} else if (span.gapFree) {
-  console.log("  \"no gap detected\" is not a completeness proof: seq is venue metadata outside the");
-  console.log("  signature, so renumbering the kept rows, or dropping the last one, leaves no gap.");
-} else {
-  console.log("  a position between the first and last row is missing: the room held a signed row");
-  console.log("  that this file does not.");
 }
 
+// Two claims, kept apart on purpose. The replay says what these records fold to. It is not a
+// statement that these are all the records, and a tool that prints one line for both invites
+// the reader to hear the second.
 const terminal = ["claimed", "refunded", "cancelled"].includes(folded.state.status);
-console.log(`\nfold → ${folded.state.status}${terminal ? "" : " (not terminal)"}`);
+console.log(`\nreplay   → ${folded.state.status}${terminal ? "" : " (not terminal)"}`);
+
 if (span.count > 0 && !span.gapFree) {
-  console.error("a signed row is missing from the deal room, so this fold is not the whole deal");
+  console.log("evidence → INCOMPLETE. A position between the first and last row is missing, so the");
+  console.log("           room held a signed row that this file does not.");
   process.exit(1);
 }
+
+console.log("evidence → completeness NOT established. A gap is evidence of absence; the absence of");
+console.log("           a gap is not evidence of presence, because seq is venue metadata outside the");
+console.log("           signature: a supplier that renumbers the rows it keeps leaves none, and one");
+console.log("           that drops the last row leaves none either.");
+console.log("           Exit 0 means the replay reached a terminal status. It does not mean audited.");
 process.exit(terminal ? 0 : 1);

--- a/examples/audit-export.mjs
+++ b/examples/audit-export.mjs
@@ -51,9 +51,15 @@ if (folded.state === null) {
 
 const span = dealRoomSpan(deal, contract);
 const range = span.count === 0 ? "none" : `${span.firstSeq}..${span.lastSeq}`;
-console.log(`\n${span.room}: ${span.count} verified rows, seq ${range} — ${span.gapFree ? "no gap detected" : "GAP"}`);
-console.log("  \"no gap detected\" is not a completeness proof: seq is venue metadata outside the");
-console.log("  signature, so renumbering the kept rows, or dropping the last one, leaves no gap.");
+const verdict = span.count === 0 ? "no rows" : span.gapFree ? "no gap detected" : "GAP";
+console.log(`\n${span.room}: ${span.count} verified rows, seq ${range} — ${verdict}`);
+if (span.count === 0) {
+  console.log("  an empty deal room reads the same whether it was censored or simply expired: the");
+  console.log("  venue deletes a room after seven days with no write, and a terminal deal stops writing.");
+} else {
+  console.log("  \"no gap detected\" is not a completeness proof: seq is venue metadata outside the");
+  console.log("  signature, so renumbering the kept rows, or dropping the last one, leaves no gap.");
+}
 
 const terminal = ["claimed", "refunded", "cancelled"].includes(folded.state.status);
 console.log(`\nfold → ${folded.state.status}${terminal ? "" : " (not terminal)"}`);

--- a/examples/audit-export.mjs
+++ b/examples/audit-export.mjs
@@ -10,6 +10,7 @@ import { readFileSync } from "node:fs";
 import {
   OFFER_ROOM,
   dealRoom,
+  dealRoomSpan,
   findContractHandshake,
   foldTranscript,
   parseTranscriptExport,
@@ -48,6 +49,16 @@ if (folded.state === null) {
   process.exit(1);
 }
 
+const span = dealRoomSpan(deal, contract);
+const range = span.count === 0 ? "none" : `${span.firstSeq}..${span.lastSeq}`;
+console.log(`\n${span.room}: ${span.count} verified rows, seq ${range} — ${span.gapFree ? "no gap detected" : "GAP"}`);
+console.log("  \"no gap detected\" is not a completeness proof: seq is venue metadata outside the");
+console.log("  signature, so renumbering the kept rows, or dropping the last one, leaves no gap.");
+
 const terminal = ["claimed", "refunded", "cancelled"].includes(folded.state.status);
 console.log(`\nfold → ${folded.state.status}${terminal ? "" : " (not terminal)"}`);
+if (span.count > 0 && !span.gapFree) {
+  console.error("a signed row is missing from the deal room, so this fold is not the whole deal");
+  process.exit(1);
+}
 process.exit(terminal ? 0 : 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,11 +36,11 @@ export type { TclkStatus, ContractState, StepResult } from "./machine.js";
 
 export {
   verifyTranscriptRecord, transcriptRecord, parseTranscriptExport,
-  findContractHandshake, foldTranscript,
+  findContractHandshake, foldTranscript, dealRoomSpan,
 } from "./transcript.js";
 export type {
   TranscriptRecord, TranscriptRecordVerification, TranscriptStep, TranscriptFoldResult,
-  ContractHandshake,
+  ContractHandshake, DealRoomSpan,
 } from "./transcript.js";
 
 export { lockTerms, MemoryRail } from "./rail.js";

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -131,6 +131,10 @@ export interface DealRoomSpan {
  * Only rows whose signature verifies are counted, so a hole cannot be closed with unsigned
  * padding - closing one needs a signed row for that room, which cannot be forged.
  *
+ * `firstSeq === 1` is required because a derived room is small and holds one contract, so it
+ * never loses a prefix. It is not a rule that generalizes: the venue's ring evicts from the
+ * front, so a busy room retains a contiguous window that does not begin at 1.
+ *
  * `gapFree` is **not** a completeness proof, and an auditor that reports it as one is worse
  * than one that reports nothing. `seq` is venue metadata outside the signed `room|nonce|line`
  * preimage, so an editor who drops a row and renumbers the rows it keeps leaves no hole, and

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -110,6 +110,58 @@ export function verifyTranscriptRecord(record: TranscriptRecord): TranscriptReco
   return { ok: true };
 }
 
+export interface DealRoomSpan {
+  /** The derived deal room this contract's post-accept frames belong to. */
+  room: string;
+  /** Rows supplied for that room whose signature verifies. */
+  count: number;
+  firstSeq: number | null;
+  lastSeq: number | null;
+  /** True when the verified rows run `1..n` with no hole. Not a completeness proof. */
+  gapFree: boolean;
+}
+
+/**
+ * Row continuity of one contract's derived deal room. The derived name addresses the room by
+ * the contract id, so it carries that contract's post-accept frames and nothing else, which is
+ * what makes a hole in its sequence meaningful. The shared board gives no such reading:
+ * thousands of contracts interleave there, so a gap between one contract's rows is the normal
+ * case and carries no information.
+ *
+ * Only rows whose signature verifies are counted, so a hole cannot be closed with unsigned
+ * padding - closing one needs a signed row for that room, which cannot be forged.
+ *
+ * `gapFree` is **not** a completeness proof, and an auditor that reports it as one is worse
+ * than one that reports nothing. `seq` is venue metadata outside the signed `room|nonce|line`
+ * preimage, so an editor who drops a row and renumbers the rows it keeps leaves no hole, and
+ * dropping the last row leaves no hole either. Report this as "no gap detected".
+ */
+export function dealRoomSpan(
+  records: readonly TranscriptRecord[],
+  contract: string,
+): DealRoomSpan {
+  const room = dealRoom(contract);
+  const seqs: number[] = [];
+  for (const record of records) {
+    if (!record || record.room !== room) continue;
+    if (!verifyTranscriptRecord(record).ok) continue;
+    seqs.push(record.seq);
+  }
+  if (seqs.length === 0) {
+    return { room, count: 0, firstSeq: null, lastSeq: null, gapFree: false };
+  }
+  seqs.sort((left, right) => left - right);
+  const firstSeq = seqs[0];
+  const lastSeq = seqs[seqs.length - 1];
+  return {
+    room,
+    count: seqs.length,
+    firstSeq,
+    lastSeq,
+    gapFree: firstSeq === 1 && seqs.length === lastSeq - firstSeq + 1,
+  };
+}
+
 function object(value: unknown, where: string): Record<string, unknown> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`tclk: ${where} is not a JSON object`);

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -131,6 +131,11 @@ export interface DealRoomSpan {
  * Only rows whose signature verifies are counted, so a hole cannot be closed with unsigned
  * padding - closing one needs a signed row for that room, which cannot be forged.
  *
+ * `gapFree` compares distinct positions, not row count. A duplicated row is a genuine signed
+ * row and verifies like any other, so counting rows lets one close a hole arithmetically:
+ * `1,2,2,4` is four rows across a span of four and only three positions. `count` stays the row
+ * count, because that is the honest number to print beside "verified rows".
+ *
  * `firstSeq === 1` is required because a derived room is small and holds one contract, so it
  * never loses a prefix. It is not a rule that generalizes: the venue's ring evicts from the
  * front, so a busy room retains a contiguous window that does not begin at 1.
@@ -145,24 +150,26 @@ export function dealRoomSpan(
   contract: string,
 ): DealRoomSpan {
   const room = dealRoom(contract);
-  const seqs: number[] = [];
+  let count = 0;
+  const positions = new Set<number>();
   for (const record of records) {
     if (!record || record.room !== room) continue;
     if (!verifyTranscriptRecord(record).ok) continue;
-    seqs.push(record.seq);
+    count += 1;
+    positions.add(record.seq);
   }
-  if (seqs.length === 0) {
+  if (count === 0) {
     return { room, count: 0, firstSeq: null, lastSeq: null, gapFree: false };
   }
-  seqs.sort((left, right) => left - right);
-  const firstSeq = seqs[0];
-  const lastSeq = seqs[seqs.length - 1];
+  const sorted = [...positions].sort((left, right) => left - right);
+  const firstSeq = sorted[0];
+  const lastSeq = sorted[sorted.length - 1];
   return {
     room,
-    count: seqs.length,
+    count,
     firstSeq,
     lastSeq,
-    gapFree: firstSeq === 1 && seqs.length === lastSeq - firstSeq + 1,
+    gapFree: firstSeq === 1 && positions.size === lastSeq - firstSeq + 1,
   };
 }
 

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -308,6 +308,27 @@ describe("derived deal-room continuity", () => {
     expect(dealRoomSpan(renumbered, supplied.contract).gapFree).toBe(true);
   });
 
+  it("does not let a duplicated row close a hole", () => {
+    const supplied = rows();
+    // A repeat of a genuine row verifies like the original, because `seq` is not in the signed
+    // preimage and nothing else changes. Counting rows rather than positions would read
+    // 1,2,2,4 as four rows across a span of four and call it whole.
+    const padded = [
+      ...supplied.board,
+      supplied.lockRow,
+      supplied.revealRow,
+      supplied.revealRow,
+      supplied.refundRow(4),
+    ];
+
+    expect(dealRoomSpan(padded, supplied.contract)).toMatchObject({
+      count: 4,
+      firstSeq: 1,
+      lastSeq: 4,
+      gapFree: false,
+    });
+  });
+
   it("does not let an unsigned row close a hole", () => {
     const supplied = rows();
     const padding = { ...supplied.revealRow, nonce: null, signature: null };

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   encodeFrame,
   dealRoom,
+  dealRoomSpan,
   findContractHandshake,
   foldTranscript,
   generateHashLock,
@@ -233,5 +234,89 @@ describe("trusted transcript records", () => {
       [offerRecord, acceptRecord],
       accept.contract,
     )).toEqual({ offer: offerRecord, accept: acceptRecord });
+  });
+});
+
+describe("derived deal-room continuity", () => {
+  function rows() {
+    const { lock, offer, accept } = deal();
+    const room = dealRoom(accept.contract);
+    const lockFrame = {
+      type: "lock" as const,
+      from: payer.did,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-42",
+    };
+    const reveal = {
+      type: "reveal" as const,
+      from: payee.did,
+      contract: accept.contract,
+      secret: lock.preimage,
+    };
+    const refund = { type: "refund" as const, from: payer.did, contract: accept.contract };
+    return {
+      contract: accept.contract,
+      room,
+      board: [
+        record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+        record(BOARD, 2, NOW, payee, encodeFrame(accept)),
+      ],
+      lockRow: record(room, 1, NOW + 1, payer, encodeFrame(lockFrame)),
+      revealRow: record(room, 2, NOW + 2, payee, encodeFrame(reveal)),
+      refundRow: (seq: number) =>
+        record(room, seq, NOW + 7_200_001, payer, encodeFrame(refund)),
+    };
+  }
+
+  it("counts a whole deal room as gap free, and ignores the board rows", () => {
+    const supplied = rows();
+    expect(
+      dealRoomSpan([...supplied.board, supplied.lockRow, supplied.revealRow], supplied.contract),
+    ).toEqual({
+      room: supplied.room,
+      count: 2,
+      firstSeq: 1,
+      lastSeq: 2,
+      gapFree: true,
+    });
+  });
+
+  it("detects the deleted reveal that folds a claimed deal to refunded with no bad step", () => {
+    const supplied = rows();
+    const censored = [...supplied.board, supplied.lockRow, supplied.refundRow(3)];
+
+    const folded = foldTranscript(censored);
+    expect(folded.state?.status).toBe("refunded");
+    expect(folded.steps.every((step) => step.ok)).toBe(true);
+
+    expect(dealRoomSpan(censored, supplied.contract)).toMatchObject({
+      count: 2,
+      firstSeq: 1,
+      lastSeq: 3,
+      gapFree: false,
+    });
+  });
+
+  it("does not detect the same deletion once the kept rows are renumbered", () => {
+    const supplied = rows();
+    // `seq` is venue metadata outside the signed `room|nonce|line` preimage, so the refund
+    // still verifies at 2. This pins the limit rather than claiming it away: counting catches
+    // a careless editor, and "no gap detected" must never be read as "transcript complete".
+    const renumbered = [...supplied.board, supplied.lockRow, supplied.refundRow(2)];
+    expect(foldTranscript(renumbered).state?.status).toBe("refunded");
+    expect(dealRoomSpan(renumbered, supplied.contract).gapFree).toBe(true);
+  });
+
+  it("does not let an unsigned row close a hole", () => {
+    const supplied = rows();
+    const padding = { ...supplied.revealRow, nonce: null, signature: null };
+    const padded = [...supplied.board, supplied.lockRow, padding, supplied.refundRow(3)];
+
+    expect(dealRoomSpan(padded, supplied.contract)).toMatchObject({
+      count: 2,
+      lastSeq: 3,
+      gapFree: false,
+    });
   });
 });


### PR DESCRIPTION
Closes #93 (case C).

Deleting one signed row from a derived deal room folds a claimed deal to `refunded` with every
step `ok`, no `BAD` line, and `audit-export.mjs` exiting 0. Nothing in the fold looks at what
the room should contain, so a censored transcript is indistinguishable from a complete one.

## The rule, and why it is stated per room

`dealRoomSpan(records, contract)` reports the verified-row continuity of the contract's derived
deal room. That room is addressed by the contract id, so it carries that contract's post-accept
frames and nothing else, which is what makes a hole in its sequence evidence. The shared board
supports no such reading: thousands of contracts interleave there, so a gap between one
contract's rows is the normal case and carries no information.

It is also why the rule cannot be stated across the fold. `seq` restarts at 1 in every room, so
a flat monotonicity check rejects conformant two-room deals — the honest order in your case A
prints `1,2,1,2,3`, which is two rooms, not disorder.

Only rows whose signature verifies are counted, so a hole cannot be closed with unsigned
padding. Closing one requires a signed row for that room.

## What it does not prove, said in the output

You established that renumbering defeats counting, and that costs one character. Dropping the
last row leaves no hole either. So the tool prints `no gap detected` and states both limits on
the next line, rather than anything that reads as "transcript complete":

```
mb-p-tclk-08ae6a078f71eb46: 2 verified rows, seq 1..3 — GAP
  "no gap detected" is not a completeness proof: seq is venue metadata outside the
  signature, so renumbering the kept rows, or dropping the last one, leaves no gap.
```

It exits non-zero on a gap, and only then. A cancelled contract has no deal-room rows at all
and still exits 0.

## Evidence

Same transcript shape as the issue, offer and accept on the board, `lock`/`reveal`/`refund` in
the deal room.

Honest export, unchanged behaviour:

```
ok  mb-p-tclk-08ae6a078f71eb46#1 lock
ok  mb-p-tclk-08ae6a078f71eb46#2 reveal
BAD mb-p-tclk-08ae6a078f71eb46#3 refund — refund in status claimed
mb-p-tclk-08ae6a078f71eb46: 3 verified rows, seq 1..3 — no gap detected
fold → claimed          exit 0
```

Reveal row deleted, which is case C:

```
ok  mb-p-tclk-08ae6a078f71eb46#1 lock
ok  mb-p-tclk-08ae6a078f71eb46#3 refund
mb-p-tclk-08ae6a078f71eb46: 2 verified rows, seq 1..3 — GAP
fold → refunded
a signed row is missing from the deal room, so this fold is not the whole deal
exit 1
```

Four tests: the whole deal, case C, the renumbered variant that is deliberately **not**
detected, and the unsigned row that cannot close a hole. Removing `dealRoomSpan` fails all
four; with it the CI trio is green (108 + 40 + 33).

## Credit

@alitiknazoglu found this and, in the thread, established the renumbering limit that shapes the
wording here. Happy to hand this over or close it if you would rather ship it yourself.
