### PR TITLE
fix(decode): reject non-printable-ASCII lines in decodeFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project are documented here. Format follows
 ## [Unreleased]
 
 ### Fixed
+- `decodeFrame` now rejects a line containing a raw non-printable-ASCII byte, matching the
+  guard `encodeFrame` already enforces on emission. A conforming sender can never produce
+  such a line (technocore's real single-line sweep would rewrite it before storing), so a
+  decoded line that fails the same test could not have reached a reader this way either.
+  Previously such a line would decode into a frame that looked legitimate — a gap for any
+  offline transcript audit. Legitimately-escaped non-ASCII content is unaffected.
+
+### Fixed
 
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved

--- a/src/frames.ts
+++ b/src/frames.ts
@@ -479,9 +479,10 @@ export function decodeFrame(text: string): TclkFrame {
   // The cap is a property of a frame, not just of our emitter: the venue refuses a longer
   // text, so a longer line was never a stored room message. Checked before the parse, so a
   // fold over an untrusted export bounds the work a single row can cost it.
-  if (text.length > MAX_FRAME_CHARS) {
+    if (text.length > MAX_FRAME_CHARS) {
     fail(`frame exceeds the ${MAX_FRAME_CHARS}-char room-message cap (${text.length})`);
   }
+  if (!/^[\x20-\x7e]*$/.test(text)) fail("frame line contains non-printable-ASCII characters");
   let parsed: unknown;
   try {
     parsed = JSON.parse(text.slice(TCLK_PREFIX.length));

--- a/tests/decode-sweep-guard.test.ts
+++ b/tests/decode-sweep-guard.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression test: decodeFrame() must reject exactly what encodeFrame() would refuse to
+ * emit.
+ *
+ * encodeFrame() already guards against non-printable-ASCII lines, because technocore's
+ * real single-line sweep replaces Unicode Cc/Cf/Cs/Co/Zl/Zp characters with a space before
+ * storing — so a line only a hand-crafted (non-conforming) sender or a corrupted/tampered
+ * export could ever contain such a byte. Before this fix, decodeFrame() (and by extension
+ * parseTranscriptExport / foldTranscript) had no matching guard: a line no conforming
+ * encoder could ever produce would still decode into a "valid" frame with a matching
+ * offerId, silently. That's the opposite of what an offline transcript auditor needs from
+ * this invariant.
+ *
+ * This is not a fund-safety bug (no rail in this repo custodies value yet, see
+ * SECURITY.md) — it's a canonical-encoding robustness gap: exactly the "bytes a signature
+ * covers are not the bytes stored" category SECURITY.md lists as in scope.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { canonicalJson, decodeFrame, encodeFrame, offerId, type OfferFields } from "../src/index.js";
+
+const DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+
+function baseOfferFields(jobId: string): OfferFields {
+  return {
+    type: "offer",
+    from: DID,
+    role: "payer",
+    amount: "1000",
+    asset: "USDC",
+    lock: "hash",
+    rails: ["flop-htlc"],
+    claimByMs: 2_000_000_000_000,
+    refundAfterMs: 2_000_000_100_000,
+    expiresMs: 2_000_000_000_000,
+    nonce: "aabbccdd",
+    job: { proto: "a2a", id: jobId },
+  };
+}
+
+describe("decodeFrame / encodeFrame sweep-guard symmetry", () => {
+  it("encodeFrame refuses a raw control byte (U+007F) in a free-text field", () => {
+    const fields = baseOfferFields("task-\x7f-123");
+    const offer = { ...fields, id: offerId(fields) };
+    expect(() => encodeFrame(offer)).toThrow(/non-printable-ASCII/);
+  });
+
+  it("decodeFrame refuses the same line an encoder could never have produced", () => {
+    const fields = baseOfferFields("task-\x7f-123");
+    const offer = { ...fields, id: offerId(fields) };
+    // Simulate a line that reached a reader some other way: a non-reference sender, a
+    // hand-edited transcript export, or a corrupted file — never through this SDK's
+    // encodeFrame(), which would have refused it above.
+    const rawLine = "tclk1 " + canonicalJson(offer);
+    expect(/\x7f/.test(rawLine)).toBe(true); // sanity: the raw byte really is in the line
+    expect(() => decodeFrame(rawLine)).toThrow(/non-printable-ASCII/);
+  });
+
+  it("legitimate non-ASCII content still round-trips exactly", () => {
+    const fields = baseOfferFields("tâche-日本語-123");
+    const offer = { ...fields, id: offerId(fields) };
+    const line = encodeFrame(offer);
+    expect(/^[\x20-\x7e]*$/.test(line)).toBe(true); // encoded line is pure printable ASCII
+    const decoded = decodeFrame(line);
+    expect(decoded.type === "offer" && decoded.job?.id).toBe("tâche-日本語-123");
+  });
+});


### PR DESCRIPTION
encodeFrame() already refuses to emit a line containing a non-printable-ASCII
byte, because technocore's real single-line sweep would rewrite such bytes
before storing them. decodeFrame() had no matching guard, so a line no
conforming encoder could ever produce (e.g. a raw U+007F byte in a free-text
field like job.id) would still decode into a frame that looked legitimate,
with a matching offerId.

This is not a fund-safety issue (no rail here custodies value yet), but it
sits in the "canonical encoding" category from SECURITY.md: the bytes a
frame's id/signature commit to should not be able to diverge silently from
what a conforming implementation could actually produce. It matters most for
offline transcript auditing, where decodeFrame is the only gate on untrusted
exported lines.

Included:
- A regression test (tests/decode-sweep-guard.test.ts) that fails without the
  fix and passes with it; also checks legitimate non-ASCII content still
  round-trips unaffected.
- The one-line guard in decodeFrame, mirroring encodeFrame's existing check.
- CHANGELOG entry under [Unreleased].

Verified locally:
pnpm install --frozen-lockfile
pnpm -r --include-workspace-root build
pnpm -r --include-workspace-root test
→ all passing except an unrelated, pre-existing schema-conformance failure
caused by Windows line-ending differences in a generated file, unrelated to
this change.