### PR TITLE
fix(transcript): surface unsigned ts/seq trust boundary and per-room gaps

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -62,9 +62,15 @@ the public manual (`/llms.txt`), and any self-hosted deployment works identicall
   `<room>|<nonce>|<text>`; `seq` and `ts` are venue metadata, not sender-signed fields. Deadline
   guards replay at that record's `ts`, so a live reader trusts the venue for time and an
   offline reader trusts the export file for it. Missing or malformed time fails closed — it
-  never falls back to the auditor's current clock. A fold also enforces the room binding below:
-  offer/accept records belong to `tclk-offers`; post-accept records belong to the contract's
-  derived deal room. A valid signature in the wrong room cannot advance state.
+  never falls back to the auditor's current clock. `ts`/`seq` being unsigned means a file
+  supplier (e.g. a payer handing a `deal.jsonl` to an arbiter) can rewrite `ts` to move a
+  reveal across `refundAfterMs` and flip `claimed`↔`refunded` with every signature still
+  valid — the transcript is coordination, not settlement proof; verify settlement on the
+  rail. `foldTranscript` surfaces this boundary via `warnings` (gaps, seq/timestamp
+  monotonicity, and the generic unsigned-timestamp note). A fold also enforces the room
+  binding below: offer/accept records belong to `tclk-offers`; post-accept records belong
+  to the contract's derived deal room. A valid signature in the wrong room cannot advance
+  state.
 - **Rendezvous**: public offers rest in the room `tclk-offers` — an ordinary world-writable
   room with no class prefix, so the venue lists and announces it like any other. Two agents who
   have never met have nowhere else to find each other, so a deal cannot start without a

--- a/examples/audit-export.mjs
+++ b/examples/audit-export.mjs
@@ -50,7 +50,7 @@ if (folded.warnings?.length) {
   // A backwards timestamp can flip a deadline with all signatures valid.
   const fatal = folded.warnings.some((w) => w.includes("gap detected") || w.includes("seq not strictly increasing") || w.includes("timestamp goes backwards"));
   if (fatal) {
-    console.error("\ntranscript is not per-room contiguous/monotonic — refusing to treat fold as audit proof");
+    console.error("\nevidence → INCOMPLETE: transcript is not per-room contiguous/monotonic — a signed row is missing or reordered. Refusing to treat fold as audit proof");
     process.exit(1);
   }
 }
@@ -61,8 +61,6 @@ if (folded.state === null) {
 }
 
 const terminal = ["claimed", "refunded", "cancelled"].includes(folded.state.status);
-console.log(`\nfold → ${folded.state.status}${terminal ? "" : " (not terminal)"}`);
-if (folded.warnings?.length) {
-  console.log("note: timestamps/seq are venue metadata, not covered by signature — verify settlement on the rail");
-}
+console.log(`\nreplay → ${folded.state.status}${terminal ? "" : " (not terminal)"}`);
+console.log("evidence → completeness NOT established. A gap is evidence of absence; the absence of a gap is not evidence of presence, because seq/ts are venue metadata outside the signature (room|nonce|line only). Exit 0 means the replay reached a terminal status. It does not mean audited — verify settlement on the rail.");
 process.exit(terminal ? 0 : 1);

--- a/examples/audit-export.mjs
+++ b/examples/audit-export.mjs
@@ -43,6 +43,18 @@ for (const step of folded.steps) {
   console.log(`${verdict} ${step.room}#${step.seq} ${step.type ?? "record"}${step.reason ? ` — ${step.reason}` : ""}`);
 }
 
+if (folded.warnings?.length) {
+  console.error("\nwarnings (timestamps/seq are venue metadata, not signed — see SPEC §2):");
+  for (const w of folded.warnings) console.error(`  WARN: ${w}`);
+  // A gap or reordering can flip claimed↔refunded with no BAD verdict (see #93).
+  // A backwards timestamp can flip a deadline with all signatures valid.
+  const fatal = folded.warnings.some((w) => w.includes("gap detected") || w.includes("seq not strictly increasing") || w.includes("timestamp goes backwards"));
+  if (fatal) {
+    console.error("\ntranscript is not per-room contiguous/monotonic — refusing to treat fold as audit proof");
+    process.exit(1);
+  }
+}
+
 if (folded.state === null) {
   console.error("no authenticated contract could be opened");
   process.exit(1);
@@ -50,4 +62,7 @@ if (folded.state === null) {
 
 const terminal = ["claimed", "refunded", "cancelled"].includes(folded.state.status);
 console.log(`\nfold → ${folded.state.status}${terminal ? "" : " (not terminal)"}`);
+if (folded.warnings?.length) {
+  console.log("note: timestamps/seq are venue metadata, not covered by signature — verify settlement on the rail");
+}
 process.exit(terminal ? 0 : 1);

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -285,6 +285,7 @@ export function createHandlers(options: HandlerOptions = {}) {
         // caller already holds, and this server never republishes secret material.
         secretRevealed: open.secret !== undefined,
         steps: folded.steps,
+        warnings: folded.warnings,
       };
     },
 

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -251,8 +251,12 @@ export function foldTranscript(records: readonly TranscriptRecord[]): Transcript
   // These do not refuse to fold — a partial window or post-reap export is legitimate —
   // but a silent gap or timestamp edit can flip a deadline-dependent outcome (reveal vs
   // refund) with every signature intact. Surface it instead of failing closed.
+  // Only verified rows count for gaps — an unsigned/BAD row still shows as BAD in
+  // `steps` but must not make a censored verified seq look contiguous (e.g. verified
+  // 1,3 padded with unverified 2 should still be a gap).
   const byRoom = new Map<string, TranscriptRecord[]>();
   for (const r of records) {
+    if (!verifyTranscriptRecord(r).ok) continue;
     const list = byRoom.get(r.room) ?? [];
     list.push(r);
     byRoom.set(r.room, list);
@@ -277,8 +281,9 @@ export function foldTranscript(records: readonly TranscriptRecord[]): Transcript
       }
     }
   }
-  // Generic trust-boundary warning when any deadline-sensitive frame is present.
+  // Generic trust-boundary warning when any verified deadline-sensitive frame is present.
   const hasDeadlineFrame = records.some((r) => {
+    if (!verifyTranscriptRecord(r).ok) return false;
     const f = tryDecodeFrame(r.line);
     return f !== null && (f.type === "accept" || f.type === "lock" || f.type === "reveal" || f.type === "refund");
   });

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -52,6 +52,7 @@ export interface TranscriptStep {
 export interface TranscriptFoldResult {
   state: ContractState | null;
   steps: TranscriptStep[];
+  warnings: string[];
 }
 
 export interface ContractHandshake {
@@ -232,10 +233,60 @@ export function findContractHandshake(
  * invalid signatures, forged `from` fields, wrong rooms, malformed lines and bad
  * transitions are rejected without changing state. Deadline guards use that record's
  * venue timestamp.
+ *
+ * `timestampMs` and `seq` are venue metadata, not covered by the sender's Ed25519
+ * signature (`room|nonce|line` only). A file supplier can therefore rewrite `ts`
+ * to move a reveal across `refundAfterMs` and flip `claimed`↔`refunded` with all
+ * signatures still valid. Callers that treat a fold as settlement proof must verify
+ * the rail (`verifyLock`/`claim`/`refund`) — the transcript is coordination, not
+ * settlement. `warnings` surfaces this and any per-room ordering or monotonicity
+ * issues (see also #93).
  */
 export function foldTranscript(records: readonly TranscriptRecord[]): TranscriptFoldResult {
   const steps: TranscriptStep[] = [];
+  const warnings: string[] = [];
   let state: ContractState | null = null;
+
+  // --- ordering / gap / timestamp-monotonicity checks (venue metadata, not signed) ---
+  // These do not refuse to fold — a partial window or post-reap export is legitimate —
+  // but a silent gap or timestamp edit can flip a deadline-dependent outcome (reveal vs
+  // refund) with every signature intact. Surface it instead of failing closed.
+  const byRoom = new Map<string, TranscriptRecord[]>();
+  for (const r of records) {
+    const list = byRoom.get(r.room) ?? [];
+    list.push(r);
+    byRoom.set(r.room, list);
+  }
+  for (const [room, list] of byRoom) {
+    for (let i = 1; i < list.length; i += 1) {
+      const prev = list[i - 1]!;
+      const cur = list[i]!;
+      if (cur.seq <= prev.seq) {
+        warnings.push(
+          `room ${room}: seq not strictly increasing at index ${records.indexOf(cur)} (${prev.seq} -> ${cur.seq}) — supplied order is not per-room append order`,
+        );
+      } else if (cur.seq !== prev.seq + 1) {
+        warnings.push(
+          `room ${room}: gap detected (seq ${prev.seq} -> ${cur.seq} at index ${records.indexOf(cur)}) — transcript may be partial; a missing reveal/lock can flip claimed↔refunded with no BAD verdict`,
+        );
+      }
+      if (cur.timestampMs < prev.timestampMs) {
+        warnings.push(
+          `room ${room}: timestamp goes backwards at seq ${cur.seq} (${prev.timestampMs} -> ${cur.timestampMs}) — ts is venue metadata, not signed`,
+        );
+      }
+    }
+  }
+  // Generic trust-boundary warning when any deadline-sensitive frame is present.
+  const hasDeadlineFrame = records.some((r) => {
+    const f = tryDecodeFrame(r.line);
+    return f !== null && (f.type === "accept" || f.type === "lock" || f.type === "reveal" || f.type === "refund");
+  });
+  if (hasDeadlineFrame) {
+    warnings.push(
+      "timestamps and seq are venue metadata, not covered by the Ed25519 signature (room|nonce|line only); a file supplier can rewrite ts to move a reveal across refundAfterMs and flip claimed↔refunded with all signatures valid — verify settlement on the rail",
+    );
+  }
 
   records.forEach((record, index) => {
     const base = { index, room: record?.room ?? "", seq: record?.seq ?? -1 };
@@ -310,5 +361,5 @@ export function foldTranscript(records: readonly TranscriptRecord[]): Transcript
     steps.push({ ...base, type: frame.type, ok: result.ok, reason: result.reason });
   });
 
-  return { state, steps };
+  return { state, steps, warnings };
 }

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -237,10 +237,13 @@ export function findContractHandshake(
  * `timestampMs` and `seq` are venue metadata, not covered by the sender's Ed25519
  * signature (`room|nonce|line` only). A file supplier can therefore rewrite `ts`
  * to move a reveal across `refundAfterMs` and flip `claimed`↔`refunded` with all
- * signatures still valid. Callers that treat a fold as settlement proof must verify
- * the rail (`verifyLock`/`claim`/`refund`) — the transcript is coordination, not
- * settlement. `warnings` surfaces this and any per-room ordering or monotonicity
- * issues (see also #93).
+ * signatures still valid. It can also delete a row and renumber the rows it keeps
+ * (or drop the last row) to leave no gap — `seq` is not signed, so a contiguous
+ * `1,2` proves nothing about completeness. A gap is evidence of absence; the
+ * absence of a gap is not evidence of presence. Callers that treat a fold as
+ * settlement proof must verify the rail (`verifyLock`/`claim`/`refund`) — the
+ * transcript is coordination, not settlement. `warnings` surfaces this and any
+ * per-room ordering or monotonicity issues (see also #93).
  */
 export function foldTranscript(records: readonly TranscriptRecord[]): TranscriptFoldResult {
   const steps: TranscriptStep[] = [];

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -13,6 +13,7 @@ import {
   makeAccept,
   makeOffer,
   parseTranscriptExport,
+  verifyTranscriptRecord,
   type TranscriptRecord,
 } from "../src/index.js";
 
@@ -215,6 +216,46 @@ describe("trusted transcript records", () => {
     });
     expect(() => parseTranscriptExport(BOARD, withoutTimezone)).toThrow(/timezone-qualified/);
     expect(() => parseTranscriptExport(BOARD, localeTimestamp)).toThrow(/timezone-qualified/);
+  });
+
+  it("documents that delete-and-renumber leaves no gap (seq is unsigned)", () => {
+    const { lock, offer, accept } = deal(NOW + 7_800_000);
+    const room = dealRoom(accept.contract);
+    const lockFrame = {
+      type: "lock" as const,
+      from: payer.did,
+      contract: accept.contract,
+      rail: "flop-htlc",
+      ref: "escrow-42",
+    };
+    const reveal = {
+      type: "reveal" as const,
+      from: payee.did,
+      contract: accept.contract,
+      secret: lock.preimage,
+    };
+    const refund = { type: "refund" as const, from: payer.did, contract: accept.contract };
+
+    const offerRec = record(BOARD, 1, NOW - 1, payer, encodeFrame(offer));
+    const acceptRec = record(BOARD, 2, NOW, payee, encodeFrame(accept));
+    const lockRec = record(room, 1, NOW + 1, payer, encodeFrame(lockFrame));
+    const revealRec = record(room, 2, NOW + 2, payee, encodeFrame(reveal));
+    const refundRec = record(room, 3, offer.refundAfterMs, payer, encodeFrame(refund));
+
+    const honest = foldTranscript([offerRec, acceptRec, lockRec, revealRec, refundRec]);
+    expect(honest.state?.status).toBe("claimed");
+    expect(honest.warnings.some((w) => w.includes("gap detected"))).toBe(false);
+
+    // Supplier deletes the reveal and renumbers refund 3 -> 2. seq is venue
+    // metadata outside room|nonce|line, so the signature still verifies.
+    const renumberedRefund = { ...refundRec, seq: 2 };
+    const tampered = foldTranscript([offerRec, acceptRec, lockRec, renumberedRefund]);
+    expect(renumberedRefund.nonce).toBe(refundRec.nonce);
+    expect(verifyTranscriptRecord(renumberedRefund).ok).toBe(true);
+    expect(tampered.state?.status).toBe("refunded");
+    expect(tampered.steps.every((s) => s.ok)).toBe(true);
+    expect(tampered.warnings.some((w) => w.includes("gap detected"))).toBe(false);
+    expect(tampered.warnings.some((w) => w.includes("seq not strictly"))).toBe(false);
   });
 
   it("never synthesizes offer-before-accept order while selecting a board handshake", () => {


### PR DESCRIPTION
Fixes #96

Problem
`src/transcript.ts:103` signatures cover `room|nonce|line` only. `seq`/`ts` are venue metadata (`transcriptRecord:131` -> `Date.parse`) but `foldTranscript:236` uses `record.timestampMs` as `nowMs` for every deadline guard (`machine.ts:121,158,178`). A file supplier can rewrite `ts` and flip `claimed`↔`refunded` with all signatures valid. Same silent flip happens if a row is deleted (#93) - gap, no BAD verdict.

This PR does not refuse to fold (partial windows/post-reap are legitimate), it reports:

- `TranscriptFoldResult.warnings: string[]`
- per-room `gap detected (seq 1->3)`, `seq not strictly increasing`, `timestamp goes backwards`
- generic note when any deadline frame (`accept`/`lock`/`reveal`/`refund`) is present: “timestamps and seq are venue metadata, not covered by signature, verify settlement on the rail”

`examples/audit-export.mjs` prints `WARN:` and exits 1 on gap/ordering/backwards; generic note is informational. `mcp/src/tools.ts:tclk_apply_transcript` forwards `warnings`. `SPEC.md:62` documents the boundary: transcript is coordination, not settlement proof.

Verification
- `pnpm build && pnpm test` - 103/104 (one `schema-conformance` CRLF artifact pre-existing #90), `mcp` 40/40, `worker` 33/33
- Repro `repro_warn.mjs` (honest `claimed` -> generic note only; tampered `reveal.ts=T+7210000` -> `timestamp goes backwards` + `refunded`; deleted `reveal` -> `gap detected` + `refunded`)

No wire change. Follow-up could sort by `(room,seq)` (#93 B) but reporting is enough for audit use.