### PR TITLE
fix(frames): stop echoing rejected secrets in requireString

### DIFF
--- a/src/frames.ts
+++ b/src/frames.ts
@@ -171,7 +171,10 @@ function fail(msg: string): never {
 
 function requireString(v: unknown, name: string, re?: RegExp): string {
   if (typeof v !== "string" || v.length === 0) fail(`${name} must be a non-empty string`);
-  if (re && !re.test(v)) fail(`${name} is malformed: ${v}`);
+  if (re && !re.test(v)) {
+    const shape = typeof v === "string" ? `${v.length} chars` : typeof v;
+    fail(`${name} is malformed (${re.source}, got ${shape})`);
+  }
   return v;
 }
 


### PR DESCRIPTION
Fixes #98

Problem
`src/frames.ts:172` `requireString` quoted the rejected value verbatim:

`fail(`${name} is malformed: ${v}`)`

`src/hex.ts:42` was fixed in #63 to report `got 66 chars` / pattern only because `hashLockFromPreimage`/`pointLockFromWitness` decode secrets through it and the old message leaked preimages into any log that caught the throw. The frame path (`secret` for `reveal`, `statement` for `accept`, `presig.s`, `paymentKey`) was not touched, so `decodeFrame` still returned `tclk: secret is malformed: 0X24440B7A...`.

Verification
- `pnpm build && pnpm test` - 103/104 (one `schema-conformance` CRLF #90 pre-existing), `mcp` 40/40, `worker` 33/33
- Before: `decodeFrame('tclk1 {"type":"reveal",...,"secret":"0X..."}')` → `... 0X24440B7A...` (leaks)
- After: `tclk: secret is malformed (^0x[0-9a-f]{64}$, got 66 chars)` - no value, `toThrow(/secret is malformed/)` still passes

Change
`src/frames.ts:172` now reports `(${re.source}, got ${len} chars)` with no value, matching `hex.ts`. No wire change, honest flows byte-identical. Completes #63 remediation for the frame path.