### PR TITLE
docs(spec): clarify adaptor pre-signature verification scope (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ All notable changes to this project are documented here. Format follows
   no fallback clock. `examples/audit-export.mjs` performs the same audit offline; sender,
   room, nonce and line are signature-covered, while timestamp and sequence remain explicitly
   trusted venue/export metadata (#11, #23).
+- Clarify SPEC §3.3 to explicitly document that Schnorr adaptor pre-signature verification
+  (`verifyPreSignature`) is evaluated out-of-band by the payee against the settlement rail's
+  claim message before revealing secrets, while transcript readers and `applyFrame` enforce
+  wire structural shapes without evaluating rail claim signatures. Pinned with unit and
+  negative regression tests (#36).
 
 ### Fixed
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -191,7 +191,11 @@ party advertises supported rails. For PTLC rails that settle by signature, `pres
 payer's Schnorr adaptor pre-signature `{nonce, s}` under the statement `Y` over the rail's claim
 message: the payee completes it with `y` (`adapt`), and the completed signature both settles the
 rail and — by `extractWitness` — hands `y` to anyone holding the pre-signature. Verifying it is
-`verifyPreSignature` against the payer's `paymentKey`.
+`verifyPreSignature` against the payer's `paymentKey`, evaluated out-of-band by the payee
+against the settlement rail's specific claim message prior to secret reveal. Transcript readers
+and `applyFrame` enforce the structural wire validity of `presig` (shape of `nonce` and scalar
+`s`), but do not evaluate the cryptographic pre-signature because the claim message is defined
+by the settlement rail and is not part of the coordination transcript.
 
 ### 3.4 `reveal`
 

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -427,6 +427,46 @@ describe("tclk PTLC path (adaptor cycle)", () => {
     expect(claimed.ok).toBe(true);
     expect(claimed.state.status).toBe("claimed");
   });
+
+  it("presig verification is an out-of-band payee obligation over the rail claimMsg; applyFrame enforces structural shape without claimMsg (#36)", () => {
+    const payerSecret = "0x" + "11".repeat(32);
+    const payerKey = schnorrAdaptor.getPublicKey(payerSecret)!;
+    const payeeKey = schnorrAdaptor.getPublicKey("0x" + "22".repeat(32))!;
+
+    const offer = baseOffer({ lock: "point", paymentKey: payerKey });
+    const ptlc = generatePointLock();
+    const accept = makeAccept(offer, { from: PAYEE_DID, statement: ptlc.statement, paymentKey: payeeKey });
+    const acceptedState = applyFrame(openContract(offer), accept, T0).state;
+
+    const realClaimMsg = "0x" + "cd".repeat(32);
+    const validPre = schnorrAdaptor.preSign(payerSecret, realClaimMsg, ptlc.statement)!;
+
+    // 1. Structural wire invalidity is rejected by applyFrame (and validateFrame)
+    const malformedNonce = { nonce: "0x" + "00".repeat(10), s: validPre.s };
+    expect(applyFrame(acceptedState, {
+      type: "lock", from: PAYER_DID, contract: acceptedState.contract!, rail: "flop-htlc",
+      ref: "escrow-7", presig: malformedNonce,
+    }, T0).ok).toBe(false);
+
+    // 2. Structurally valid presig with arbitrary/mismatched claim signature passes applyFrame:
+    // the coordination state machine has no claim message and does not verify the pre-signature.
+    const wrongClaimMsg = "0x" + "ee".repeat(32);
+    const mismatchedPre = schnorrAdaptor.preSign(payerSecret, wrongClaimMsg, ptlc.statement)!;
+    const lockedStep = applyFrame(acceptedState, {
+      type: "lock", from: PAYER_DID, contract: acceptedState.contract!, rail: "flop-htlc",
+      ref: "escrow-7", presig: mismatchedPre,
+    }, T0);
+    expect(lockedStep.ok).toBe(true);
+    expect(lockedStep.state.status).toBe("locked");
+    expect(lockedStep.state.presig).toEqual(mismatchedPre);
+
+    // 3. Out-of-band payee verification: payee checks presig against their rail claimMsg.
+    // When mismatched, payee verification fails, so payee refuses to adapt or reveal.
+    expect(schnorrAdaptor.verifyPreSignature(payerKey, realClaimMsg, ptlc.statement, lockedStep.state.presig!)).toBe(false);
+
+    // When valid for realClaimMsg, payee verification passes and reveals safely.
+    expect(schnorrAdaptor.verifyPreSignature(payerKey, realClaimMsg, ptlc.statement, validPre)).toBe(true);
+  });
 });
 
 describe("tclk MemoryRail (reference rail predicates)", () => {

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -460,6 +460,15 @@ describe("tclk PTLC path (adaptor cycle)", () => {
     expect(lockedStep.state.status).toBe("locked");
     expect(lockedStep.state.presig).toEqual(mismatchedPre);
 
+    // Not merely a pre-signature for the wrong message — a value from no signer at all is stored too.
+    const garbage = { nonce: "0x02" + "00".repeat(32), s: "0x" + "ff".repeat(32) };
+    const garbageStep = applyFrame(acceptedState, {
+      type: "lock", from: PAYER_DID, contract: acceptedState.contract!, rail: "flop-htlc",
+      ref: "escrow-7", presig: garbage,
+    }, T0);
+    expect(garbageStep.ok).toBe(true);
+    expect(garbageStep.state.presig).toEqual(garbage);
+
     // 3. Out-of-band payee verification: payee checks presig against their rail claimMsg.
     // When mismatched, payee verification fails, so payee refuses to adapt or reveal.
     expect(schnorrAdaptor.verifyPreSignature(payerKey, realClaimMsg, ptlc.statement, lockedStep.state.presig!)).toBe(false);


### PR DESCRIPTION
Resolves #36

### Context & Motivation
SPEC §3.3 previously stated:
> `presig` carries the payer's Schnorr adaptor pre-signature `{nonce, s}` under the statement `Y` over the rail's claim message. [...] Verifying it is `verifyPreSignature` against the payer's `paymentKey`.

As analyzed in #36, transcript replay (`applyFrame` in `src/machine.ts`) does not and cannot verify the pre-signature:
1. The coordination transcript and frames (`lock`) intentionally do not carry the settlement rail's specific claim message (such as an EVM escrow transaction hash or Bitcoin sighash).
2. Money moves on the settlement rail, not the transcript; transcript replay is rail-agnostic.
3. The adaptor pre-signature is verified out-of-band by the payee against their expected rail claim message before they reveal the witness $.

### Solution
- Clarify in `SPEC.md §3.3` that `verifyPreSignature` is evaluated out-of-band by the payee against the settlement rail's specific claim message prior to secret reveal.
- Note that transcript readers and `applyFrame` enforce wire structural shapes (e.g., `HEX33` nonce and valid scalar `s`) but do not evaluate the cryptographic claim signature.
- Add negative and isolation tests in `tests/tclk.test.ts` pinning this contract:
  - Malformed structural shapes in `presig` are rejected by `applyFrame`.
  - Structurally valid `presig` is accepted by `applyFrame` without evaluating `claimMsg`.
  - The payee verifies `verifyPreSignature` out-of-band against `claimMsg` before adapting/revealing, refusing secret reveal when `verifyPreSignature` fails.
- Document in `CHANGELOG.md` under `[Unreleased]` Changed.

### Compatibility
Zero wire format changes. Conformance schema generation remains clean.

### Verification
- `node scripts/generate-frame-fields.mjs --check`: passed (no drift).
- `pnpm test`: all 105 root tests pass (including new test).
- `cd mcp && pnpm test`: all 40 MCP tests + 33 worker tests pass.
- Full suite total: 178 tests passing clean.