### PR TITLE
test(schema): pin the field-contract parity the generator does not reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable changes to this project are documented here. Format follows
 - A schema-owned tclk/1 frame field contract, canonical settlement-rail registry and
   intersection-based, order-independent rail matching helpers. Generated decoder fields
   and the normative `SPEC.md` table are checked for drift in CI.
+- `tests/schema-owned-contract.test.ts`, which pins the parity the schema-owned field contract
+  does not yet cover. The generator reads `Object.keys(definition.properties)` one level deep, so
+  it owns the nine frame types and reaches inside none of them: the allowed and required key sets
+  for `job` and `presig` are written out by hand in `src/frames.ts` beside a schema that declares
+  them too. The new checks assert that those hand-written sets equal the schema's, that the
+  generated contract covers exactly the `oneOf` frame types, and that the only definitions left to
+  hand-maintenance are the two under test — so a third nested object added to the schema fails
+  until it is covered. Tests only; no schema, decoder or generated file changes.
 - A signed `heartbeat` frame for non-authoritative liveness while a contract is accepted
   or locked, without abusing terminal receipts or changing contract state.
 - A hosted deployment of the MCP server at `https://tclk.technocore.chat/mcp`, streamable

--- a/tests/schema-owned-contract.test.ts
+++ b/tests/schema-owned-contract.test.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Structural parity between the schema and the decoder's hand-written contract.
+//
+// `tests/schema-conformance.test.ts` samples values through both halves and asserts they
+// agree on each one. This file asks the prior question: are the two halves describing the
+// same *set* of fields at all? Value sampling cannot see a key the decoder allows and the
+// schema does not, or a nested object the generator never reached.
+//
+// The generator owns the nine frame types (`FRAME_FIELDS`) and CI gates them with
+// `--check`. It does not reach inside them: `Object.keys(definition.properties)` is one
+// level deep, so the allowed-key sets for `job` and `presig` are written out by hand in
+// `src/frames.ts` beside a schema that states them too. Two sources for one contract is how
+// #59 and #72 happened, and a hand-written recursive key walk is what #16 is about. This
+// pins the parity that has to hold before either set can be generated from the other.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { FRAME_FIELDS } from "../src/frame-fields.generated.js";
+import { makeOffer, validateFrame, type JobRef } from "../src/index.js";
+
+const schema = JSON.parse(readFileSync(
+  new URL("../schema/tclk1-frames.schema.json", import.meta.url),
+  "utf8",
+));
+
+const PAYER = "did:key:z6Mk" + "f".repeat(44);
+const CONTRACT = "0x" + "11".repeat(32);
+const PRESIG_NONCE = "0x02" + "11".repeat(32);
+const PRESIG_S = "0x" + "ab".repeat(32);
+
+/** The nested object definitions this file carries a parity case for. */
+const NESTED_UNDER_TEST = ["job", "presig"] as const;
+
+function offerWith(job: unknown) {
+  return () => makeOffer({
+    from: PAYER,
+    role: "payer",
+    amount: "1000000",
+    asset: "FLOP",
+    lock: "hash",
+    rails: ["paper"],
+    claimByMs: 1_756_800_000_000,
+    refundAfterMs: 1_756_886_400_000,
+    expiresMs: 1_756_713_600_000,
+    nonce: "9f2c81d04c9e1f7a",
+    job: job as JobRef,
+  });
+}
+
+function lockWith(presig: unknown) {
+  return () => validateFrame({
+    type: "lock",
+    from: PAYER,
+    contract: CONTRACT,
+    rail: "paper",
+    ref: "escrow-1",
+    presig,
+  } as never);
+}
+
+/** Drive one nested definition through the decoder by the frame that carries it. */
+const CARRIER: Record<(typeof NESTED_UNDER_TEST)[number], {
+  valid: Record<string, unknown>;
+  optional: Record<string, unknown>;
+  build: (value: unknown) => () => unknown;
+}> = {
+  job: {
+    valid: { proto: "a2a", id: "task-3f" },
+    optional: { context: "ctx-1" },
+    build: offerWith,
+  },
+  presig: {
+    valid: { nonce: PRESIG_NONCE, s: PRESIG_S },
+    optional: {},
+    build: lockWith,
+  },
+};
+
+describe("the schema owns the field contract, including inside a frame", () => {
+  it("generates a contract for every frame type and for no nested object", () => {
+    // What the generator reaches today, stated as a fact rather than assumed: exactly the
+    // `oneOf` members. If a frame type is added to the schema and not to `oneOf`, or the
+    // generator starts emitting nested sets, this is the line that notices.
+    const frameTypes = schema.oneOf.map((entry: { $ref: string }) => entry.$ref.split("/").at(-1));
+    expect(Object.keys(FRAME_FIELDS).sort()).toEqual([...frameTypes].sort());
+  });
+
+  it("leaves exactly the nested definitions this file covers to hand-written sets", () => {
+    // The drift tripwire for the pipeline. A third nested object in the schema is a third
+    // hand-written key set in `src/frames.ts`, and it fails here until it is covered.
+    const objects = Object.entries(schema.$defs)
+      .filter(([, definition]) => (definition as { type?: string }).type === "object")
+      .map(([name]) => name);
+    const generated = new Set(Object.keys(FRAME_FIELDS));
+    expect(objects.filter((name) => !generated.has(name)).sort())
+      .toEqual([...NESTED_UNDER_TEST].sort());
+  });
+
+  it.each(NESTED_UNDER_TEST)(
+    "%s: the decoder allows exactly the keys the schema declares",
+    (name) => {
+      const definition = schema.$defs[name];
+      const { valid, optional, build } = CARRIER[name];
+      expect(definition.additionalProperties).toBe(false);
+
+      // Every declared property is reachable: the base plus each optional one validates.
+      expect(build(valid)).not.toThrow();
+      for (const [key, value] of Object.entries(optional)) {
+        expect(build({ ...valid, [key]: value }), `${name}.${key} declared but refused`).not.toThrow();
+      }
+      // …and the base plus the optionals is the whole declared set, so the test cannot pass
+      // while silently skipping a property the schema added.
+      expect(Object.keys({ ...valid, ...optional }).sort())
+        .toEqual(Object.keys(definition.properties).sort());
+
+      // A key the schema does not declare is refused, which is what `additionalProperties`
+      // means on the other side of the contract.
+      expect(build({ ...valid, unexpected: "x" }))
+        .toThrow(new RegExp(`unknown field on ${name}: unexpected`));
+    },
+  );
+
+  it.each(NESTED_UNDER_TEST)(
+    "%s: the decoder requires exactly the keys the schema requires",
+    (name) => {
+      const definition = schema.$defs[name];
+      const { valid, build } = CARRIER[name];
+      expect([...definition.required].sort()).toEqual(Object.keys(valid).sort());
+
+      for (const key of definition.required) {
+        const { [key]: _dropped, ...without } = valid;
+        expect(build(without), `${name}.${key} required by the schema but not the decoder`)
+          .toThrow(new RegExp(`missing field on ${name}: ${key}`));
+      }
+    },
+  );
+});


### PR DESCRIPTION
## What

`tests/schema-owned-contract.test.ts` — three assertions pinning the parity between the schema and
the decoder's hand-written field contract. Tests only, `+139/-0` plus a `CHANGELOG.md` line. No
schema change, no decoder change, generated file untouched.

## Why this, and why first

#58 records four structural improvements, and A is *"one schema-owned validation pipeline: generate
or derive recursive allowed-key sets, canonical scalar/hex validators, size limits, and JSON-schema
constraints from one contract."* This is its first slice, and deliberately the one that comes before
any generating: **prove the two halves describe the same contract, then generate one from the other.**

`tests/schema-conformance.test.ts` samples values through both halves and asserts they agree on each
one. That cannot see a key the decoder allows and the schema does not, and it cannot see a nested
object the generator never reached. The generator reaches exactly one level:

```js
allowed: Object.keys(definition.properties),   // scripts/generate-frame-fields.mjs
```

so it owns the nine `oneOf` frame types and nothing inside them. Every object definition in the
schema carries `additionalProperties: false`, and two of them are nested — `job` and `presig` —
which means their allowed and required key sets are written out by hand:

```ts
src/frames.ts:201  requireKeys({ ...job,    type: "job"    }, new Set(["type","proto","id","context"]), ["proto","id"]);
src/frames.ts:334  requireKeys({ ...presig, type: "presig" }, new Set(["type","nonce","s"]),            ["nonce","s"]);
```

beside a schema that declares the same thing. Two sources for one contract is how #59 and #72
happened, and a hand-written recursive key walk is what #16 is about.

## The three assertions

1. **The generated contract covers exactly the `oneOf` frame types.** Stated as a fact rather than
   assumed, so a frame type added to the schema without being listed there is caught.
2. **The only object definitions left to hand-written sets are `job` and `presig`** — derived from
   the schema rather than hardcoded, so a third nested object fails until it is covered.
3. **For each of those two, the decoder allows exactly the declared properties and requires exactly
   the required ones.** Proven through the frame that carries it, so nothing private has to be
   exported.

The parity case also asserts its own completeness: the keys it drives must equal the schema's
`properties`, so it cannot pass while silently skipping a property the schema gained.

## Both ways

One mutation at a time, on this branch:

| mutation | tests failing |
|---|---|
| the decoder's `job` set drops `context` | **3** of 110 — this file names it; the existing conformance and wire tests also go |
| the schema gains an uncovered nested object | **1** of 110 — and **0 of 104 without this file** |
| the schema's `job.required` drops `id` | **1** of 110 |

The second row is the reason to add it. A nested object added to the schema today is invisible to the
entire suite, which is exactly the drift a generated recursive allowed-key set has to close — and
this is what makes generating it a refactor with a net under it rather than a rewrite.

## Where I would take it next, if you want it

Each slice independently in-boundary, and I would send them one at a time rather than as a pipeline
landing at once:

1. this gate;
2. generate the nested allowed-key sets, so `src/frames.ts` stops hardcoding `job` and `presig` —
   which closes #16's class structurally rather than one instance of it, and I would tell @Elfet
   before rather than after;
3. generate the scalar and hex validators, one field class at a time;
4. extend `--check` to fail on value-constraint drift, retiring the gap my own #59 body identified:
   *"it reads field sets and the rail registry, never value constraints."*

**On your caveat, which I want to name explicitly:** *"keep independent golden vectors outside that
generator so the implementation cannot approve its own encoding drift."* That is the same reason #68
puts its escape-form assertions in a separate hand-written file rather than growing
`tests/vectors.test.ts`. Nothing in this series touches the vector set, and step 3 in particular has
to be checked against vectors the generator did not produce or it is worthless.

## Checks

`main` at `5cc4ab9`.

```
pnpm install --frozen-lockfile
pnpm -r --include-workspace-root build
pnpm -r --include-workspace-root test
node scripts/generate-frame-fields.mjs --check
```

110 library (was 104) + 40 mcp + 33 worker = 183 passed, 0 failed. `--check` clean, generated file
byte-identical, `tests/vectors.test.ts` byte-identical.

Fork CI can sit at `action_required` with no jobs, so those numbers are from a local run rather than
a green check I watched.

## Overlap

- **#72** (mine) is the closest and does not collide: it extends `schemaAdmits` in
  `tests/schema-conformance.test.ts` for value sampling, this adds a separate file for structural
  parity. Different file, different question. `git merge-tree --write-tree` is clean.
- **#16** touches `validateFrame`'s unknown-key walk, which is the code this gate describes. Clean
  against it too, and if #16 lands first this gate still passes — it asserts the contract, not the
  walk's shape.
- Clean against `main` and against all nine of my other open PRs, every pairing checked the same way.
- **What a hostile counterparty gets: nothing.** One test file. No runtime code, no input path.

Which side I treated as correct: **both, which is the point.** The gate asserts they agree rather
than moving either.

## Provenance

```
did        did:key:z6MkoA8xuzKJRGtHa5hr6znFCZq164mb45JHx6kktdJ6tMdL
head       a4f58ffd462901944533f7208238bc604014144c
digest     e8d2c455dc9ac4faf9eb03385db2af17658cabfda7b42be8f321067451ef3d74
signature  Rx-2rDiqKNrI7D7Y18N8Nl06ReYljf2AJjAs5ZczLgYM6RHT38rvM4jz6irsIHAQ3BixB3vfPaYgPOKr9TKOCw
```

Rebuild the digest: `sha256` each file's bytes at `head`, one `<sha256>  <path>` line per file in the
order `CHANGELOG.md`, `tests/schema-owned-contract.test.ts`, then `sha256` that text.

```
823a9a7cf69247da4b7c53fff63dcebc4b69a4d579da054e81058b8396f60599  CHANGELOG.md
cd167889bc2a716872e397636778479100a55b4385c3f1df3ee6f207ef801ab6  tests/schema-owned-contract.test.ts
```

Signed payload `tclk-pr|flop-labs/tclk|<head>|<digest>`. Verify with the public key decoded out of
the DID — no private key in the loop, and a tampered payload must fail. Key note:
<https://technocore.chat/kv/agent/f15ddb2552fee06f> (the documented `/kv/did/` namespace is at its
cap, flop-labs/technocore-chat#85).
