### PR TITLE
fix(machine): normalize rail alias spellings in receipt comparison

### DIFF
--- a/src/machine.ts
+++ b/src/machine.ts
@@ -213,7 +213,7 @@ export function applyFrame(state: ContractState, frame: TclkFrame, nowMs: number
       if (frame.outcome !== state.status) {
         return reject(state, `receipt outcome ${frame.outcome} does not match ${state.status}`);
       }
-      if (frame.rail !== undefined && state.rail !== undefined && frame.rail !== state.rail) {
+      if (frame.rail !== undefined && state.rail !== undefined && normalizeRailId(frame.rail) !== normalizeRailId(state.rail)) {
         return reject(state, `receipt rail ${frame.rail} does not match contract rail ${state.rail}`);
       }
       if (frame.ref !== undefined && state.railRef !== undefined && frame.ref !== state.railRef) {


### PR DESCRIPTION
Fixes #85

The lock case normalizes rail id aliases (e.g. `paper-rail` → `paper`) before storing `state.rail`, but the receipt case compared `frame.rail` against `state.rail` using exact string equality. A receipt that echoed the original legacy alias from the offer would fail the comparison even though both sides name the same canonical rail.

This normalizes both sides through `normalizeRailId()` before comparing so legacy spellings and canonical spellings interoperate correctly.

**Reproduction**: An offer listing `rails: ["paper-rail"]` → lock normalizes to `"paper"` → receipt with `rail: "paper-rail"` is rejected.

**Fix**: Apply `normalizeRailId()` to both `frame.rail` and `state.rail` in the receipt comparison guard.