### PR TITLE
feat(vectors): portable cross-language golden vectors for all 8 frame types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. Format follows
 
 ## [Unreleased]
 
+### Added
+- `vectors/tclk-v1.golden.json`: a portable, language-agnostic companion to
+  `tests/vectors.test.ts` — one fully-populated, decodable example of every tclk/1 frame
+  type (offer, accept, lock, reveal, refund, cancel, receipt, heartbeat), for a
+  from-scratch implementation in any language to check its encoder/decoder against
+  without a TypeScript toolchain. See `vectors/README.md`.
+- `tests/interop-vectors.test.ts`: proves the portable file stays in sync with the
+  reference encoder/decoder (round-trip in both directions) on every test run.
+- `scripts/generate-interop-vectors.mjs`: regenerates the portable file from the built
+  reference implementation; only needed if the wire format changes on purpose.
+
 ### Fixed
 
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer

--- a/scripts/generate-interop-vectors.mjs
+++ b/scripts/generate-interop-vectors.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+//
+// Generates vectors/tclk-v1.golden.json from the built reference implementation
+// (run `pnpm build` first). See vectors/README.md for what this file is for.
+//
+// tests/vectors.test.ts already pins offer/accept ids and lines as TypeScript constants,
+// produced by an independent implementation of the spec — the anti-drift gate described in
+// AGENTS.md. That file is only readable by whoever can parse TypeScript, and it covers 2 of
+// the 8 frame types. This script re-derives the SAME offer/accept objects (byte-identical
+// inputs) plus one fully-populated, decodable example of every other frame type, and writes
+// them to a single portable JSON file: something a Python, Rust, or Go port can load and
+// check against directly, with no TypeScript toolchain and no test framework.
+//
+// Every `line` below is produced by encodeFrame() itself — never hand-typed — so the fixture
+// cannot silently drift from what this reference implementation actually emits. The
+// companion test (tests/interop-vectors.test.ts) re-checks that after every build: it
+// decodes each `line` and asserts the result equals `frame`, and re-encodes each `frame` and
+// asserts the result equals `line`, using the same *source* encoder/decoder this script's
+// dist build was compiled from.
+
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { encodeFrame, makeAccept, makeOffer } from "../dist/index.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const PAYER_DID = "did:key:z6Mk" + "f".repeat(44);
+const PAYEE_DID = "did:key:z6Mk" + "g".repeat(44);
+
+const offer = makeOffer({
+  from: PAYER_DID,
+  role: "payer",
+  amount: "1000000",
+  asset: "FLOP",
+  lock: "hash",
+  rails: ["flop-htlc", "x402"],
+  claimByMs: 1756703600000,
+  refundAfterMs: 1756707200000,
+  expiresMs: 1756700600000,
+  job: { proto: "a2a", id: "task-3f", context: "ctx-1" },
+  nonce: "9f2c81d04c9e1f7a",
+});
+
+const accept = makeAccept(offer, {
+  from: PAYEE_DID,
+  statement: "0x" + "ab".repeat(32),
+  nonce: "0011223344556677",
+});
+
+const lock = {
+  type: "lock",
+  from: PAYER_DID,
+  contract: accept.contract,
+  rail: "flop-htlc",
+  ref: "escrow-9001",
+};
+
+const reveal = {
+  type: "reveal",
+  from: PAYEE_DID,
+  contract: accept.contract,
+  ref: "escrow-9001",
+  secret: "0x" + "11".repeat(32),
+};
+
+const refund = {
+  type: "refund",
+  from: PAYER_DID,
+  contract: accept.contract,
+  ref: "escrow-9001",
+  reason: "claim window elapsed",
+};
+
+const cancel = {
+  type: "cancel",
+  from: PAYER_DID,
+  contract: accept.contract,
+  reason: "counterparty unresponsive",
+};
+
+const receipt = {
+  type: "receipt",
+  from: PAYEE_DID,
+  contract: accept.contract,
+  outcome: "claimed",
+  rail: "flop-htlc",
+  ref: "escrow-9001",
+};
+
+const heartbeat = {
+  type: "heartbeat",
+  from: PAYER_DID,
+  contract: accept.contract,
+  nonce: "aa11bb22cc33dd44",
+  note: "still here",
+};
+
+const frames = { offer, accept, lock, reveal, refund, cancel, receipt, heartbeat };
+
+const vectors = Object.fromEntries(
+  Object.entries(frames).map(([name, frame]) => [name, { frame, line: encodeFrame(frame) }]),
+);
+
+const doc = {
+  schema: "tclk-interop-vectors-v1",
+  wirePrefix: "tclk1 ",
+  generatedBy: "@flop-labs/tclk (reference TS implementation)",
+  purpose:
+    "One decodable, fully-populated example of every tclk/1 frame type, for a from-scratch " +
+    "port in any language to check its encoder and decoder against without a TypeScript " +
+    "toolchain. `frame` is the canonical object; `line` is exactly what encodeFrame() " +
+    "produces for it and what decodeFrame() must reproduce it from.",
+  vectors,
+};
+
+const outPath = join(root, "vectors", "tclk-v1.golden.json");
+writeFileSync(outPath, JSON.stringify(doc, null, 2) + "\n");
+console.log(`wrote ${Object.keys(vectors).length} vectors to ${outPath}`);

--- a/tests/interop-vectors.test.ts
+++ b/tests/interop-vectors.test.ts
@@ -1,0 +1,53 @@
+/**
+ * vectors/tclk-v1.golden.json is a portable, language-agnostic companion to
+ * tests/vectors.test.ts: one fully-populated, decodable example of every tclk/1 frame
+ * type, meant for a from-scratch port in another language to check itself against
+ * without a TypeScript toolchain (see vectors/README.md).
+ *
+ * This test is what keeps that file honest. It doesn't re-derive the vectors (that's
+ * scripts/generate-interop-vectors.mjs, run by hand when the wire format changes on
+ * purpose); it just proves, against the actual source encoder/decoder, that:
+ *   - every vector's `line` is exactly what encodeFrame(frame) produces, and
+ *   - decodeFrame(line) reproduces `frame` exactly (order-independent key comparison).
+ * A JSON fixture with no test behind it can drift from the code silently; this is the
+ * same anti-drift discipline AGENTS.md describes for tests/vectors.test.ts, applied to
+ * the portable file too.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+
+import { decodeFrame, encodeFrame, type TclkFrame } from "../src/index.js";
+
+interface GoldenVectorFile {
+  schema: string;
+  wirePrefix: string;
+  vectors: Record<string, { frame: TclkFrame; line: string }>;
+}
+
+const path = new URL("../vectors/tclk-v1.golden.json", import.meta.url);
+const doc: GoldenVectorFile = JSON.parse(readFileSync(path, "utf8"));
+
+describe("portable interop vectors (vectors/tclk-v1.golden.json)", () => {
+  it("covers all eight frame types, exactly once each", () => {
+    const types = Object.values(doc.vectors).map((v) => v.frame.type);
+    expect(new Set(types)).toEqual(
+      new Set(["offer", "accept", "lock", "reveal", "refund", "cancel", "receipt", "heartbeat"]),
+    );
+    expect(types).toHaveLength(8);
+  });
+
+  for (const [name, vector] of Object.entries(doc.vectors)) {
+    it(`${name}: frame -> line matches the reference encoder`, () => {
+      expect(encodeFrame(vector.frame)).toBe(vector.line);
+    });
+
+    it(`${name}: line -> frame matches the reference decoder`, () => {
+      expect(decodeFrame(vector.line)).toEqual(vector.frame);
+    });
+
+    it(`${name}: line starts with the documented wire prefix`, () => {
+      expect(vector.line.startsWith(doc.wirePrefix)).toBe(true);
+    });
+  }
+});

--- a/vectors/README.md
+++ b/vectors/README.md
@@ -1,0 +1,49 @@
+# tclk/1 portable interop vectors
+
+`tclk-v1.golden.json` is one fully-populated, decodable example of every tclk/1 frame
+type (`offer`, `accept`, `lock`, `reveal`, `refund`, `cancel`, `receipt`, `heartbeat`),
+meant to be loaded directly by a from-scratch implementation in **any language** — no
+TypeScript toolchain, no test framework, just JSON.
+
+## Why this exists
+
+`tests/vectors.test.ts` already pins the offer id, the contract id, and the canonical
+line for two frame types as TypeScript constants — the anti-drift gate described in
+[`AGENTS.md`](../AGENTS.md). Those values were themselves produced by an independent
+implementation of the spec, so they check this repo's encoding rather than restating
+it. But that file is only reachable by whoever can parse TypeScript and run this
+repo's test suite, and it covers 2 of the 8 frame types. This file is the same idea,
+made portable and complete: every `line` here is produced by this repo's own
+`encodeFrame()` — never hand-typed — and checked for exact round-trip agreement by
+[`tests/interop-vectors.test.ts`](../tests/interop-vectors.test.ts) on every test run,
+so it cannot silently drift from what this reference implementation actually emits.
+
+## How to use it, from any language
+
+For each entry under `vectors`:
+
+1. **Encode check.** Build the frame your implementation would construct from
+   `frame`'s fields, encode it with your own encoder, and compare the result
+   byte-for-byte against `line`.
+2. **Decode check.** Decode `line` with your own decoder and compare the result,
+   field by field, against `frame`.
+
+If either check fails, the disagreement is in your implementation, not in the vector —
+see `AGENTS.md`'s rule on the golden vectors: never edit a vector to make a check pass.
+
+`line` always starts with the `wirePrefix` (`"tclk1 "`); the remainder is the exact
+canonical JSON that a signature or an id commits to (sorted keys, compact separators,
+non-ASCII escaped to `\uXXXX` — see `SPEC.md` §Canonical encoding).
+
+## Regenerating this file
+
+Only needed if the wire format changes on purpose (and the version prefix bumps, per
+`AGENTS.md`). From the repo root:
+
+```bash
+pnpm build
+node scripts/generate-interop-vectors.mjs
+```
+
+Then re-run `pnpm test` — `tests/interop-vectors.test.ts` will fail loudly if the
+regenerated file and the source encoder/decoder ever disagree.

--- a/vectors/tclk-v1.golden.json
+++ b/vectors/tclk-v1.golden.json
@@ -1,0 +1,104 @@
+{
+  "schema": "tclk-interop-vectors-v1",
+  "wirePrefix": "tclk1 ",
+  "generatedBy": "@flop-labs/tclk (reference TS implementation)",
+  "purpose": "One decodable, fully-populated example of every tclk/1 frame type, for a from-scratch port in any language to check its encoder and decoder against without a TypeScript toolchain. `frame` is the canonical object; `line` is exactly what encodeFrame() produces for it and what decodeFrame() must reproduce it from.",
+  "vectors": {
+    "offer": {
+      "frame": {
+        "from": "did:key:z6Mkffffffffffffffffffffffffffffffffffffffffffff",
+        "role": "payer",
+        "amount": "1000000",
+        "asset": "FLOP",
+        "lock": "hash",
+        "rails": [
+          "flop-htlc",
+          "x402"
+        ],
+        "claimByMs": 1756703600000,
+        "refundAfterMs": 1756707200000,
+        "expiresMs": 1756700600000,
+        "job": {
+          "proto": "a2a",
+          "id": "task-3f",
+          "context": "ctx-1"
+        },
+        "nonce": "9f2c81d04c9e1f7a",
+        "type": "offer",
+        "id": "0xd001fbbf4fa36d9ab8ea88df02a8b3303539e9d59f7ff9d9bfeb679318e9ce75"
+      },
+      "line": "tclk1 {\"amount\":\"1000000\",\"asset\":\"FLOP\",\"claimByMs\":1756703600000,\"expiresMs\":1756700600000,\"from\":\"did:key:z6Mkffffffffffffffffffffffffffffffffffffffffffff\",\"id\":\"0xd001fbbf4fa36d9ab8ea88df02a8b3303539e9d59f7ff9d9bfeb679318e9ce75\",\"job\":{\"context\":\"ctx-1\",\"id\":\"task-3f\",\"proto\":\"a2a\"},\"lock\":\"hash\",\"nonce\":\"9f2c81d04c9e1f7a\",\"rails\":[\"flop-htlc\",\"x402\"],\"refundAfterMs\":1756707200000,\"role\":\"payer\",\"type\":\"offer\"}"
+    },
+    "accept": {
+      "frame": {
+        "type": "accept",
+        "from": "did:key:z6Mkgggggggggggggggggggggggggggggggggggggggggggg",
+        "ref": "0xd001fbbf4fa36d9ab8ea88df02a8b3303539e9d59f7ff9d9bfeb679318e9ce75",
+        "statement": "0xabababababababababababababababababababababababababababababababab",
+        "nonce": "0011223344556677",
+        "contract": "0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c"
+      },
+      "line": "tclk1 {\"contract\":\"0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c\",\"from\":\"did:key:z6Mkgggggggggggggggggggggggggggggggggggggggggggg\",\"nonce\":\"0011223344556677\",\"ref\":\"0xd001fbbf4fa36d9ab8ea88df02a8b3303539e9d59f7ff9d9bfeb679318e9ce75\",\"statement\":\"0xabababababababababababababababababababababababababababababababab\",\"type\":\"accept\"}"
+    },
+    "lock": {
+      "frame": {
+        "type": "lock",
+        "from": "did:key:z6Mkffffffffffffffffffffffffffffffffffffffffffff",
+        "contract": "0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c",
+        "rail": "flop-htlc",
+        "ref": "escrow-9001"
+      },
+      "line": "tclk1 {\"contract\":\"0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c\",\"from\":\"did:key:z6Mkffffffffffffffffffffffffffffffffffffffffffff\",\"rail\":\"flop-htlc\",\"ref\":\"escrow-9001\",\"type\":\"lock\"}"
+    },
+    "reveal": {
+      "frame": {
+        "type": "reveal",
+        "from": "did:key:z6Mkgggggggggggggggggggggggggggggggggggggggggggg",
+        "contract": "0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c",
+        "ref": "escrow-9001",
+        "secret": "0x1111111111111111111111111111111111111111111111111111111111111111"
+      },
+      "line": "tclk1 {\"contract\":\"0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c\",\"from\":\"did:key:z6Mkgggggggggggggggggggggggggggggggggggggggggggg\",\"ref\":\"escrow-9001\",\"secret\":\"0x1111111111111111111111111111111111111111111111111111111111111111\",\"type\":\"reveal\"}"
+    },
+    "refund": {
+      "frame": {
+        "type": "refund",
+        "from": "did:key:z6Mkffffffffffffffffffffffffffffffffffffffffffff",
+        "contract": "0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c",
+        "ref": "escrow-9001",
+        "reason": "claim window elapsed"
+      },
+      "line": "tclk1 {\"contract\":\"0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c\",\"from\":\"did:key:z6Mkffffffffffffffffffffffffffffffffffffffffffff\",\"reason\":\"claim window elapsed\",\"ref\":\"escrow-9001\",\"type\":\"refund\"}"
+    },
+    "cancel": {
+      "frame": {
+        "type": "cancel",
+        "from": "did:key:z6Mkffffffffffffffffffffffffffffffffffffffffffff",
+        "contract": "0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c",
+        "reason": "counterparty unresponsive"
+      },
+      "line": "tclk1 {\"contract\":\"0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c\",\"from\":\"did:key:z6Mkffffffffffffffffffffffffffffffffffffffffffff\",\"reason\":\"counterparty unresponsive\",\"type\":\"cancel\"}"
+    },
+    "receipt": {
+      "frame": {
+        "type": "receipt",
+        "from": "did:key:z6Mkgggggggggggggggggggggggggggggggggggggggggggg",
+        "contract": "0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c",
+        "outcome": "claimed",
+        "rail": "flop-htlc",
+        "ref": "escrow-9001"
+      },
+      "line": "tclk1 {\"contract\":\"0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c\",\"from\":\"did:key:z6Mkgggggggggggggggggggggggggggggggggggggggggggg\",\"outcome\":\"claimed\",\"rail\":\"flop-htlc\",\"ref\":\"escrow-9001\",\"type\":\"receipt\"}"
+    },
+    "heartbeat": {
+      "frame": {
+        "type": "heartbeat",
+        "from": "did:key:z6Mkffffffffffffffffffffffffffffffffffffffffffff",
+        "contract": "0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c",
+        "nonce": "aa11bb22cc33dd44",
+        "note": "still here"
+      },
+      "line": "tclk1 {\"contract\":\"0x2768bf32b455317879796093ff2e5882371cbec238611ca71f555a7fcbe58e1c\",\"from\":\"did:key:z6Mkffffffffffffffffffffffffffffffffffffffffffff\",\"nonce\":\"aa11bb22cc33dd44\",\"note\":\"still here\",\"type\":\"heartbeat\"}"
+    }
+  }
+}


### PR DESCRIPTION
tests/vectors.test.ts already pins the offer/accept ids and canonical lines as
TypeScript constants (the anti-drift gate AGENTS.md describes), produced by an
independent implementation of the spec. That file is only reachable by whoever can
parse TypeScript, and it covers 2 of the 8 frame types.

This adds vectors/tclk-v1.golden.json: a portable JSON file with one fully-populated,
decodable example of every tclk/1 frame type (offer, accept, lock, reveal, refund,
cancel, receipt, heartbeat), for a from-scratch implementation in any language to
check its encoder/decoder against without a TypeScript toolchain.

Every `line` in the file is produced by this repo's own encodeFrame() (never
hand-typed), and tests/interop-vectors.test.ts asserts round-trip agreement in both
directions on every test run, so the file cannot silently drift from the reference
implementation. scripts/generate-interop-vectors.mjs regenerates it if the wire
format ever changes on purpose.

See vectors/README.md for how another implementation should use this file.

Verified locally: pnpm install --frozen-lockfile / pnpm -r build / pnpm -r test, all
passing (Windows-only schema-conformance line-ending mismatch aside, unrelated to
this change).