### PR TITLE
fix(frames): reject extra type field in job and presig

### DIFF
--- a/src/frames.ts
+++ b/src/frames.ts
@@ -198,6 +198,7 @@ function requireKeys(
 function validateJob(v: unknown): JobRef {
   if (!v || typeof v !== "object" || Array.isArray(v)) fail("job must be an object");
   const job = v as Record<string, unknown>;
+  if ("type" in job) fail("unknown field on job: type");
   requireKeys({ ...job, type: "job" }, new Set(["type", "proto", "id", "context"]), ["proto", "id"]);
   requireString(job.proto, "job.proto", /^[a-z0-9][a-z0-9._-]{0,31}$/);
   requireString(job.id, "job.id");
@@ -331,6 +332,7 @@ export function validateFrame(value: unknown): TclkFrame {
       if (frame.presig !== undefined) {
         const presig = frame.presig as Record<string, unknown>;
         if (!presig || typeof presig !== "object" || Array.isArray(presig)) fail("presig must be an object");
+        if ("type" in presig) fail("unknown field on presig: type");
         requireKeys({ ...presig, type: "presig" }, new Set(["type", "nonce", "s"]), ["nonce", "s"]);
         requireString(presig.nonce, "presig.nonce", HEX33);
         requireString(presig.s, "presig.s", SCALAR_HEX);


### PR DESCRIPTION
Fixes #106

Problem
`src/frames.ts:199` `validateJob` and `src/frames.ts:331` `lock` presig do `requireKeys({ ...obj, type:"job" }, ...)` to make the error read “unknown field on job/presig”. The spread overwrites an attacker-supplied `type` before the unknown-field check, so `job:{proto:"a2a", id:"x", type:"evil"}` and `presig:{nonce:"0x02...", s:"0x11...", type:"evil"}` both pass. `schema/tclk1-frames.schema.json` has `additionalProperties:false` for both, so schema rejects while decoder accepts.

Verification
- `pnpm build && pnpm test` - 103/104 (one `schema-conformance` CRLF #90 pre-existing), `mcp` 40/40, `worker` 33/33
- Before: `makeOffer({..., job:{proto:"a2a", id:"x", type:"evil"}})` → succeeds, `encodeFrame` retains `type`; `decodeFrame('tclk1 {"type":"lock",...,"presig":{...,"type":"evil"}}')` → succeeds
- After: both → `tclk: unknown field on job: type` / `unknown field on presig: type`

Change
`src/frames.ts:199` and `:331` now explicitly `if ("type" in job/presig) fail(...)` before the spread. No wire change for honest canonical flows.