### PR TITLE
fix(interop): refuse an ACP job id a number cannot carry exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `acpJob` refuses a numeric ACP job id that a double cannot carry exactly, instead of
+  rendering the rounded value. `acpJob(9007199254740993)` produced `job.id`
+  `"9007199254740992"`, and the offer id — then the contract id — committed to it, so the
+  payment leg was bound to a job nobody opened with every signature valid and no error
+  raised. Non-integral and non-finite numbers are refused for the same reason (`String()`
+  renders them `1.5`, `NaN`, `1e+21`, and the frame validator has no opinion on the contents
+  of `job.id`). The refusal names the remedy: pass the id as a decimal string, which is
+  exact at any width. Builder-side only — the decoder is unchanged, so a frame already
+  posted in a room keeps folding.
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema

--- a/SPEC.md
+++ b/SPEC.md
@@ -341,6 +341,10 @@ the *payment leg* of a job defined elsewhere, never a competing task schema:
   evaluator accepting delivery is the payee's cue to reveal (or, with `Sig`-augmented policies
   on a rail that supports them, the evaluator is the co-signer). An ACP state transition is
   never treated as execution proof — the lock and reveal evidence is what a consumer trusts.
+  `id` is a **decimal string** on the wire, like every other job id: the offer id and then the
+  contract id commit to its exact text, and a job id above 2^53 does not survive a JavaScript
+  number, so `acpJob` refuses a number it cannot carry rather than binding the payment to a
+  rounded one.
 - **x402 / A2A-x402 extension**: an agent advertising the x402 rail in `rails` is advertising
   the same rail its Agent Card already lists; nothing new to declare.
 

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -65,7 +65,32 @@ export function a2aJob(taskId: string, contextId?: string): JobRef {
     : { proto: "a2a", id: taskId, context: contextId };
 }
 
-/** Bind an offer to a Virtuals ACP job. */
+/**
+ * Bind an offer to a Virtuals ACP job.
+ *
+ * `number` is accepted because an ACP job id reads as one, and `String(jobId)` was silently
+ * wrong for two shapes of it. A job id above `Number.MAX_SAFE_INTEGER` has already been
+ * rounded by the time this function sees it — `9007199254740993` arrives as
+ * `9007199254740992` — and the offer id, then the contract id, commit to the *rounded*
+ * value. The result is a payment leg bound to a job nobody opened, with every signature
+ * valid and no error anywhere: the same failure the transport nonce path already refuses
+ * numerically (see `mcp/src/technocore.ts`, "a stored nonce may exceed 2^53 and must stay
+ * exact"). A non-integral or non-finite number was worse still, since `String()` renders it
+ * as `1.5`, `NaN` or `1e+21` and the frame validator has no opinion on the contents of
+ * `job.id`.
+ *
+ * So the numeric arm is narrowed to what it can carry losslessly, and the remedy is in the
+ * message: pass the id as a decimal string, which is exact at any width. Builder-side only
+ * — `validateFrame` and the decoder are untouched, because a frame already posted in a room
+ * must keep decoding whatever it says.
+ */
 export function acpJob(jobId: string | number): JobRef {
+  if (typeof jobId === "number" && !Number.isSafeInteger(jobId)) {
+    throw new Error(
+      `tclk: ACP job id ${jobId} is not a safe integer, so a number cannot carry it ` +
+        "exactly — pass it as a decimal string. The offer and contract ids commit to this " +
+        "value, and a rounded one binds the payment to a different job",
+    );
+  }
   return { proto: "acp", id: String(jobId) };
 }

--- a/tests/tclk.test.ts
+++ b/tests/tclk.test.ts
@@ -555,4 +555,42 @@ describe("tclk interop mappings", () => {
     expect(a2aJob("t-1")).toEqual({ proto: "a2a", id: "t-1" });
     expect(a2aJob("t-1", "c-9")).toEqual({ proto: "a2a", id: "t-1", context: "c-9" });
   });
+
+  it("refuses an ACP job id a number cannot carry, and takes it as a string", () => {
+    // 2^53 + 1 does not exist as a double: it arrives here already rounded down, and
+    // `String()` would render the rounded value with nothing to notice. The offer id — and
+    // then the contract id — commit to whatever `job.id` says, so the payment leg would be
+    // bound to a job nobody opened, every signature valid.
+    expect(9_007_199_254_740_993).toBe(9_007_199_254_740_992);
+    expect(() => acpJob(9_007_199_254_740_993)).toThrow(/not a safe integer/);
+    expect(() => acpJob(9_007_199_254_740_993)).toThrow(/decimal string/);
+
+    // A decimal string is exact at any width, and is what the message asks for.
+    expect(acpJob("9007199254740993")).toEqual({ proto: "acp", id: "9007199254740993" });
+    const offer = baseOffer({ job: acpJob("9007199254740993") });
+    expect(decodeFrame(encodeFrame(offer)).job).toEqual({
+      proto: "acp",
+      id: "9007199254740993",
+    });
+
+    // Nothing a `String()` renders as a non-integer may reach `job.id` either: the frame
+    // validator has no opinion on its contents, so `1.5`, `NaN` and `1e+21` were all
+    // acceptable job identifiers.
+    for (const bad of [1.5, Number.NaN, Infinity, -Infinity, 1e21]) {
+      expect(() => acpJob(bad)).toThrow(/not a safe integer/);
+    }
+
+    // Ordinary ids still work, negatives and zero included — ACP assigns them, not us.
+    expect(acpJob(0)).toEqual({ proto: "acp", id: "0" });
+    expect(acpJob(-1)).toEqual({ proto: "acp", id: "-1" });
+    expect(acpJob(Number.MAX_SAFE_INTEGER)).toEqual({ proto: "acp", id: "9007199254740991" });
+  });
+
+  it("keeps decoding a frame whose job id was already rounded", () => {
+    // The builder is the only thing that got stricter. A frame posted before this fix is
+    // in a room forever and must keep folding, so the decoder's view of `job.id` is
+    // unchanged: it is an opaque non-empty string.
+    const line = encodeFrame(baseOffer({ job: { proto: "acp", id: "9007199254740992" } }));
+    expect(decodeFrame(line).job).toEqual({ proto: "acp", id: "9007199254740992" });
+  });
 });


### PR DESCRIPTION
## What

`acpJob(jobId: string | number)` rendered its argument with `String(jobId)`, which is silently wrong for two shapes of number.

**A job id above `Number.MAX_SAFE_INTEGER` is already rounded by the time the function sees it.** The rounded value then becomes part of the ids everything else is bound by:

```js
> acpJob(9007199254740993)
{ proto: "acp", id: "9007199254740992" }        // <<< a different job
```

```
offer id binding job "9007199254740993": 0xf3383a16900e81840f0acf8413a1f4c324148ea8040203779eb48d9802bb9ee2
offer id binding acpJob(9007199254740993):  0x8645c4e100e3a84c01c045f9d37e36af7370b64e0a78f3b58d5aa4a2a0e105f6
job on the lossy offer: {"proto":"acp","id":"9007199254740992"}
contract id:            0x6272cb4fcaea2efaef5be8cfbf627f1c1de592d8d749c03f0c4da071c8fc07de
```

`offerId` commits to `job`, `contractId` commits to the whole offer, and the transport signature covers the line. So the payment leg ends up bound to a job nobody opened — every signature valid, no error anywhere, and the frame is on the wire permanently.

This is the same failure class the transport nonce path already refuses numerically. `mcp/src/technocore.ts` says it outright — *"Sent as a string: a stored nonce may exceed 2^53 and must stay exact"* — and `tclk_post_frame` rejects an unsafe numeric nonce rather than rounding it (#55). The ACP job id was the remaining identifier still rounding silently.

**Non-integral and non-finite numbers were worse**, because `String()` renders them and `validateFrame` has no opinion on the contents of `job.id`:

```
acpJob(1.5)       -> id "1.5"        validateFrame ACCEPTS it
acpJob(NaN)       -> id "NaN"        validateFrame ACCEPTS it
acpJob(Infinity)  -> id "Infinity"   validateFrame ACCEPTS it
acpJob(1e21)      -> id "1e+21"      validateFrame ACCEPTS it
```

Every call above type-checks against the published signature.

## Fix

Narrow the numeric arm to what a double carries losslessly, and put the remedy in the message:

```
tclk: ACP job id 9007199254740992 is not a safe integer, so a number cannot carry it
exactly — pass it as a decimal string. The offer and contract ids commit to this value,
and a rounded one binds the payment to a different job
```

A decimal string is exact at any width and is already the accepted spelling, so `acpJob("9007199254740993")` is the working call.

**Builder-side only.** `validateFrame` and `decodeFrame` are untouched: a frame already posted in a room outlives any release of this package (AGENTS.md), so a line whose `job.id` was rounded before this fix must keep decoding and folding. A test pins that direction explicitly. Ordinary ids are unaffected, `0`, negatives and `MAX_SAFE_INTEGER` included — ACP assigns them, not us.

## Scope

- `src/interop.ts` — the guard, with the reasoning in the doc comment.
- `tests/tclk.test.ts` — two regression tests: the refusal (including the non-finite/non-integral set and the string that works), and the decoder still accepting an already-rounded frame.
- `SPEC.md` §6 — `job.id` for ACP is a decimal string on the wire, and why.
- `CHANGELOG.md` — `[Unreleased] / Fixed`.

No wire-format change: no golden vector moves, and the `tclk1 ` prefix is untouched.

## Validation

Exactly what CI runs (AGENTS.md), on Windows/Node 22 with pnpm 11.25.0:

```
pnpm install --frozen-lockfile
pnpm -r --include-workspace-root build
pnpm -r --include-workspace-root test
```

```
root    Test Files  9 passed (9)    Tests  106 passed (106)
mcp     Test Files  6 passed (6)    Tests   40 passed (40)
worker  Test Files  2 passed (2)    Tests   33 passed (33)
```

`node scripts/generate-frame-fields.mjs --check` also passes (the generated field contract and the SPEC table are untouched by this change).