### PR TITLE
feat(transcript): detect reordering the supplier cannot renumber away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to this project are documented here. Format follows
 
 ### Added
 
+- `checkNonceOrder(records)`, which reports where one signer's records are supplied out of
+  the order that signer numbered them. `seq` and `timestampMs` are venue metadata a file
+  supplier can renumber, while the record nonce is inside the signed preimage
+  `room|nonce|line` and cannot follow, so this detection survives a renumbering that defeats
+  a `seq`-based ordering check. Scoped per `(room, sender)` — the scope the venue enforces —
+  so it makes no claim about ordering between two parties, and it does not detect deletion
+  or truncation. `examples/audit-export.mjs` refuses to treat a fold as evidence when it
+  fires.
 - A schema-owned tclk/1 frame field contract, canonical settlement-rail registry and
   intersection-based, order-independent rail matching helpers. Generated decoder fields
   and the normative `SPEC.md` table are checked for drift in CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,14 @@ All notable changes to this project are documented here. Format follows
 - `checkNonceOrder(records)`, which reports where one signer's records are supplied out of
   the order that signer numbered them. `seq` and `timestampMs` are venue metadata a file
   supplier can renumber, while the record nonce is inside the signed preimage
-  `room|nonce|line` and cannot follow, so this detection survives a renumbering that defeats
-  a `seq`-based ordering check. Scoped per `(room, sender)` — the scope the venue enforces —
-  so it makes no claim about ordering between two parties, and it does not detect deletion
-  or truncation. `examples/audit-export.mjs` refuses to treat a fold as evidence when it
-  fires.
+  `room|nonce|line` and cannot follow, so this survives a renumbering that defeats a
+  `seq`-based ordering check. It closes reordering, including reorder-plus-renumber. It
+  does **not** close deletion, end-truncation, reordering across signers, or substituting
+  one of a signer's records for another of that signer's — a swap surfaces only when the
+  moved record is followed in the supplied order by a record from the same signer with a
+  lower nonce, so substituting a signer's final record is invisible to it. Scoped per
+  `(room, sender)`, the scope the venue enforces. `examples/audit-export.mjs` refuses to
+  treat a fold as evidence when it fires.
 - A schema-owned tclk/1 frame field contract, canonical settlement-rail registry and
   intersection-based, order-independent rail matching helpers. Generated decoder fields
   and the normative `SPEC.md` table are checked for drift in CI.

--- a/examples/audit-export.mjs
+++ b/examples/audit-export.mjs
@@ -13,6 +13,7 @@ import {
   findContractHandshake,
   foldTranscript,
   parseTranscriptExport,
+  checkNonceOrder,
 } from "../dist/index.js";
 
 const [offersFile, dealFile, contract] = process.argv.slice(2);
@@ -43,6 +44,19 @@ for (const step of folded.steps) {
   console.log(`${verdict} ${step.room}#${step.seq} ${step.type ?? "record"}${step.reason ? ` — ${step.reason}` : ""}`);
 }
 
+// `seq` and `ts` are venue metadata, so whoever hands over the file can renumber
+// them; the record nonce sits inside the signed preimage and cannot follow. A
+// signer's own records arriving out of the order that signer numbered them is
+// therefore attested rather than asserted, and survives a renumbering.
+const outOfOrder = checkNonceOrder([handshake.offer, handshake.accept, ...deal]);
+for (const issue of outOfOrder) {
+  const who = `${issue.sender.slice(0, 24)}…`;
+  console.error(
+    `BAD ${issue.room} rows ${issue.previousIndex} and ${issue.index} from ${who} are supplied ` +
+    `out of the order that signer signed them (nonce ${issue.previousNonce} then ${issue.nonce})`,
+  );
+}
+
 if (folded.state === null) {
   console.error("no authenticated contract could be opened");
   process.exit(1);
@@ -50,4 +64,11 @@ if (folded.state === null) {
 
 const terminal = ["claimed", "refunded", "cancelled"].includes(folded.state.status);
 console.log(`\nfold → ${folded.state.status}${terminal ? "" : " (not terminal)"}`);
+
+if (outOfOrder.length > 0) {
+  console.error(
+    `\nrefusing to treat this fold as evidence: ${outOfOrder.length} record(s) supplied out of signed order`,
+  );
+  process.exit(1);
+}
 process.exit(terminal ? 0 : 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,11 +36,11 @@ export type { TclkStatus, ContractState, StepResult } from "./machine.js";
 
 export {
   verifyTranscriptRecord, transcriptRecord, parseTranscriptExport,
-  findContractHandshake, foldTranscript,
+  findContractHandshake, foldTranscript, checkNonceOrder,
 } from "./transcript.js";
 export type {
   TranscriptRecord, TranscriptRecordVerification, TranscriptStep, TranscriptFoldResult,
-  ContractHandshake,
+  ContractHandshake, NonceOrderIssue,
 } from "./transcript.js";
 
 export { lockTerms, MemoryRail } from "./rail.js";

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -227,6 +227,78 @@ export function findContractHandshake(
   return null;
 }
 
+/** One place a signer's own records arrive out of the order that signer numbered them. */
+export interface NonceOrderIssue {
+  room: string;
+  sender: string;
+  /** Index in the supplied array of the record that goes backwards. */
+  index: number;
+  /** Index of that signer's previous record in the same room. */
+  previousIndex: number;
+  nonce: string;
+  previousNonce: string;
+}
+
+/**
+ * Check that each signer's records arrive in the order that signer numbered them.
+ *
+ * `seq` and `timestampMs` are venue metadata: a file supplier can renumber both, so a
+ * reordering check built on them is defeated by editing the numbers it reads. `nonce` is
+ * different — it sits inside the signed preimage `room|nonce|line`, and the venue requires
+ * it to exceed the last nonce that key used in that room. Reordering two records from one
+ * signer therefore moves their nonces out of order, and putting the nonces back means
+ * forging a signature over a different preimage.
+ *
+ * Scope is per `(room, sender)`, which is the scope the venue actually enforces. Two
+ * parties give two attested chains and no attested interleaving between them, so this
+ * says nothing about the order of a payer's record relative to a payee's.
+ *
+ * What it does not catch: deletion of a record, truncation of the last one, and
+ * reordering across signers. Nothing in an export catches the first two.
+ *
+ * Only authenticated records are considered — an unverified record's nonce is asserted,
+ * not attested, so it carries no ordering claim.
+ *
+ * One measured caveat: the venue looks for a key's last nonce only within the newest
+ * portion of a room it scans, so on a long busy room a legitimate lower nonce can appear
+ * once older traffic buries the record that would have refused it. Observed once in 12,387
+ * signed records on `tclk-offers`, and not at all in two quieter rooms. A derived deal room
+ * — a handful of records from two keys — is never near that boundary.
+ */
+export function checkNonceOrder(records: readonly TranscriptRecord[]): NonceOrderIssue[] {
+  const highest = new Map<string, { value: bigint; index: number; nonce: string }>();
+  const issues: NonceOrderIssue[] = [];
+
+  records.forEach((record, index) => {
+    if (!record || typeof record.nonce !== "string") return;
+    if (!verifyTranscriptRecord(record).ok) return;
+
+    let value: bigint;
+    try {
+      value = BigInt(record.nonce);
+    } catch {
+      return;
+    }
+
+    const key = `${record.room} ${record.sender}`;
+    const previous = highest.get(key);
+    if (previous !== undefined && value <= previous.value) {
+      issues.push({
+        room: record.room,
+        sender: record.sender,
+        index,
+        previousIndex: previous.index,
+        nonce: record.nonce,
+        previousNonce: previous.nonce,
+      });
+      return;
+    }
+    highest.set(key, { value, index, nonce: record.nonce });
+  });
+
+  return issues;
+}
+
 /**
  * Authenticate and fold records in the supplied order. Every record gets a verdict;
  * invalid signatures, forged `from` fields, wrong rooms, malformed lines and bad

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -253,8 +253,18 @@ export interface NonceOrderIssue {
  * parties give two attested chains and no attested interleaving between them, so this
  * says nothing about the order of a payer's record relative to a payee's.
  *
- * What it does not catch: deletion of a record, truncation of the last one, and
- * reordering across signers. Nothing in an export catches the first two.
+ * What it catches is reordering, including reordering hidden by renumbering `seq`.
+ * What it does not catch: deletion of a record, truncation of the last one,
+ * reordering across signers, and substituting one of a signer's records for another
+ * of that signer's.
+ *
+ * The last of those is worth stating precisely, because "shares a signer" is not the
+ * condition. A swap shows up only when the moved record is *followed in the supplied
+ * order* by a record from the same signer carrying a lower nonce. Substituting a
+ * signer's final record leaves nothing to bracket it, and the walk stays silent — so
+ * a supplier holding spare frames from both parties simply uses the one whose signer
+ * has no later row. That is a choice available to the supplier, not a gap this rule
+ * can be widened to close.
  *
  * Only authenticated records are considered — an unverified record's nonce is asserted,
  * not attested, so it carries no ordering claim.

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -276,7 +276,14 @@ export interface NonceOrderIssue {
  * — a handful of records from two keys — is never near that boundary.
  */
 export function checkNonceOrder(records: readonly TranscriptRecord[]): NonceOrderIssue[] {
-  const highest = new Map<string, { value: bigint; index: number; nonce: string }>();
+  // Against that signer's *immediately preceding* record, not the highest nonce seen
+  // from them. The rule above is stated that way — a swap shows when the moved record is
+  // followed in supplied order by a lower nonce — and the two readings disagree: with a
+  // running maximum, nonces 5, 3, 4 report both 5>3 and 5>4, when only the first steps
+  // backwards and 3 -> 4 rises. One reordering counted twice, the second row naming a
+  // predecessor the walk had already passed. The old name "highest" is what made the
+  // early return below look right.
+  const previousBySigner = new Map<string, { value: bigint; index: number; nonce: string }>();
   const issues: NonceOrderIssue[] = [];
 
   records.forEach((record, index) => {
@@ -290,8 +297,8 @@ export function checkNonceOrder(records: readonly TranscriptRecord[]): NonceOrde
       return;
     }
 
-    const key = `${record.room} ${record.sender}`;
-    const previous = highest.get(key);
+    const key = `${record.room} ${record.sender}`;
+    const previous = previousBySigner.get(key);
     if (previous !== undefined && value <= previous.value) {
       issues.push({
         room: record.room,
@@ -301,9 +308,10 @@ export function checkNonceOrder(records: readonly TranscriptRecord[]): NonceOrde
         nonce: record.nonce,
         previousNonce: previous.nonce,
       });
-      return;
     }
-    highest.set(key, { value, index, nonce: record.nonce });
+    // Advance even when this record was just reported: it is the predecessor of whatever
+    // this signer supplies next, and not advancing is what produced the duplicate row.
+    previousBySigner.set(key, { value, index, nonce: record.nonce });
   });
 
   return issues;

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -13,6 +13,7 @@ import {
   makeAccept,
   makeOffer,
   parseTranscriptExport,
+  checkNonceOrder,
   type TranscriptRecord,
 } from "../src/index.js";
 
@@ -233,5 +234,78 @@ describe("trusted transcript records", () => {
       [offerRecord, acceptRecord],
       accept.contract,
     )).toEqual({ offer: offerRecord, accept: acceptRecord });
+  });
+});
+
+describe("checkNonceOrder", () => {
+  // `nonce` here is the frame's own field, which exists to defeat the venue's
+  // duplicate-text filter — distinct from the record nonce this check reads.
+  function heartbeat(contract: string, nonce: string) {
+    return { type: "heartbeat" as const, from: payee.did, contract, nonce };
+  }
+
+  it("reports nothing on a deal supplied in the order it was signed", () => {
+    const { lock, offer, accept } = deal();
+    const room = dealRoom(accept.contract);
+    expect(checkNonceOrder([
+      record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+      record(BOARD, 2, NOW, payee, encodeFrame(accept)),
+      record(room, 1, NOW + 1, payer, encodeFrame({
+        type: "lock", from: payer.did, contract: accept.contract, rail: "flop-htlc", ref: "escrow-42",
+      })),
+      record(room, 2, NOW + 2, payee, encodeFrame({
+        type: "reveal", from: payee.did, contract: accept.contract, secret: lock.preimage,
+      })),
+    ])).toEqual([]);
+  });
+
+  it("catches two records of one signer supplied out of the order that signer numbered them", () => {
+    const { accept } = deal();
+    const room = dealRoom(accept.contract);
+    const first = record(room, 2, NOW + 2, payee, encodeFrame(heartbeat(accept.contract, "aa11bb22cc33dd44")));
+    const second = record(room, 3, NOW + 3, payee, encodeFrame(heartbeat(accept.contract, "bb22cc33dd44ee55")));
+
+    expect(checkNonceOrder([second, first])).toMatchObject([
+      { room, sender: payee.did, index: 1, previousIndex: 0 },
+    ]);
+  });
+
+  it("still catches the swap when the supplier renumbers seq and ts to hide it", () => {
+    const { accept } = deal();
+    const room = dealRoom(accept.contract);
+    const first = record(room, 2, NOW + 2, payee, encodeFrame(heartbeat(accept.contract, "aa11bb22cc33dd44")));
+    const second = record(room, 3, NOW + 3, payee, encodeFrame(heartbeat(accept.contract, "bb22cc33dd44ee55")));
+
+    // seq and ts are venue metadata and outside the signature, so a supplier may
+    // rewrite them freely; the nonce inside the preimage cannot follow.
+    const disguised = [
+      { ...second, seq: 2, timestampMs: NOW + 2 },
+      { ...first, seq: 3, timestampMs: NOW + 3 },
+    ];
+    expect(disguised.map((r) => r.seq)).toEqual([2, 3]);
+    expect(checkNonceOrder(disguised)).toHaveLength(1);
+  });
+
+  it("does not fault two signers whose records interleave", () => {
+    const { accept } = deal();
+    const room = dealRoom(accept.contract);
+    // The payee's nonce is lower than the payer's, and it arrives second. Ordering
+    // between two signers is not attested, so this is not an ordering fault.
+    const payerRow = record(room, 9, NOW + 9, payer, encodeFrame({
+      type: "lock", from: payer.did, contract: accept.contract, rail: "flop-htlc", ref: "escrow-42",
+    }));
+    const payeeRow = record(room, 1, NOW + 1, payee, encodeFrame(heartbeat(accept.contract, "cc33dd44ee55ff66")));
+    expect(BigInt(payeeRow.nonce as string) < BigInt(payerRow.nonce as string)).toBe(true);
+    expect(checkNonceOrder([payerRow, payeeRow])).toEqual([]);
+  });
+
+  it("ignores a record whose signature does not verify, since its nonce is asserted only", () => {
+    const { accept } = deal();
+    const room = dealRoom(accept.contract);
+    const first = record(room, 2, NOW + 2, payee, encodeFrame(heartbeat(accept.contract, "aa11bb22cc33dd44")));
+    const second = record(room, 3, NOW + 3, payee, encodeFrame(heartbeat(accept.contract, "bb22cc33dd44ee55")));
+    const forged = { ...first, signature: second.signature };
+
+    expect(checkNonceOrder([second, forged])).toEqual([]);
   });
 });

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -270,6 +270,23 @@ describe("checkNonceOrder", () => {
     ]);
   });
 
+  it("counts one violation, not two, when a signer's records go 5, 3, 4", () => {
+    // The comparison is against the immediate predecessor, so a single displaced record
+    // is a single row. Comparing against a running maximum instead reported 5>3 and then
+    // 5>4 — the same reordering twice, the second naming a predecessor already walked
+    // past — and 3 -> 4 does not go backwards at all. luch91 raised this on #110.
+    const { accept } = deal();
+    const room = dealRoom(accept.contract);
+    const five  = record(room, 5, NOW + 5, payee, encodeFrame(heartbeat(accept.contract, "aa11bb22cc33dd44")));
+    const three = record(room, 3, NOW + 3, payee, encodeFrame(heartbeat(accept.contract, "bb22cc33dd44ee55")));
+    const four  = record(room, 4, NOW + 4, payee, encodeFrame(heartbeat(accept.contract, "cc33dd44ee55ff66")));
+
+    expect([five, three, four].map((r) => r.nonce)).toEqual(["10005", "10003", "10004"]);
+    expect(checkNonceOrder([five, three, four])).toMatchObject([
+      { room, sender: payee.did, index: 1, previousIndex: 0, nonce: "10003", previousNonce: "10005" },
+    ]);
+  });
+
   it("still catches the swap when the supplier renumbers seq and ts to hide it", () => {
     const { accept } = deal();
     const room = dealRoom(accept.contract);

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -299,6 +299,31 @@ describe("checkNonceOrder", () => {
     expect(checkNonceOrder([payerRow, payeeRow])).toEqual([]);
   });
 
+  // The limit, asserted rather than described. @alitiknazoglu established on #110 that
+  // the condition is not "shares a signer": a swap surfaces only when the moved record
+  // is followed in the supplied order by a record from the same signer with a lower
+  // nonce. A signer's final record has nothing after it to bracket against, so
+  // substituting that one is invisible here — and a supplier holding spares from both
+  // parties picks exactly that one. Locking it down so the claim cannot quietly widen.
+  it("is silent when the substituted record is that signer's last, and speaks when it is not", () => {
+    const { accept } = deal();
+    const room = dealRoom(accept.contract);
+    const payeeRow = record(room, 1, NOW + 1, payee, encodeFrame(heartbeat(accept.contract, "aa11bb22cc33dd44")));
+    const payerRow = record(room, 2, NOW + 2, payer, encodeFrame({
+      type: "refund", from: payer.did, contract: accept.contract,
+    }));
+    const payeeSpare = record(room, 8, NOW + 8, payee, encodeFrame(heartbeat(accept.contract, "dd44ee55ff66aa77")));
+    const payerSpare = record(room, 9, NOW + 9, payer, encodeFrame(heartbeat(accept.contract, "ee55ff66aa77bb88")));
+
+    // The payee's spare is written last for that signer, so nothing of the payee's
+    // follows it once it is dropped in: no bracket, no violation.
+    expect(checkNonceOrder([payeeRow, payeeSpare, payerRow])).toEqual([]);
+
+    // The payer's spare is bracketed by the payer's own earlier refund, which follows
+    // it in the supplied order carrying a lower nonce.
+    expect(checkNonceOrder([payeeRow, payerSpare, payerRow])).toHaveLength(1);
+  });
+
   it("ignores a record whose signature does not verify, since its nonce is asserted only", () => {
     const { accept } = deal();
     const room = dealRoom(accept.contract);


### PR DESCRIPTION
Closes nothing on its own — this adds the one ordering check on #93 that a supplier cannot renumber away, alongside rather than instead of #94 and #97.

## What changes for a caller

A new exported `checkNonceOrder(records)` returning `NonceOrderIssue[]`. It reports positions where one signer's records are supplied out of the order that signer numbered them. `examples/audit-export.mjs` calls it and refuses to treat the fold as evidence when it fires.

Nothing else changes: `foldTranscript`'s result shape is untouched, deliberately, so this lands whichever of #94/#97 goes in and either can call it.

## Why nonce rather than seq

`seq` and `timestampMs` are venue metadata. A file supplier can rewrite both, which is what makes @alitiknazoglu's relabelling case in #93 beat a pairwise `seq` walk — moving one row the supplier already holds costs a character and reads the same afterwards.

`nonce` is inside the signed preimage `room|nonce|line`, and the venue requires it to exceed the last nonce that key used in that room. So reordering two records from one signer moves their nonces out of order, and putting the nonces back means forging a signature over a different preimage.

Scope is per `(room, sender)` — the scope the venue actually enforces. Two parties give two attested chains and no attested interleaving, so this says nothing about a payer's record relative to a payee's. It does not detect deletion or end-truncation; nothing in an export does. Records whose signature does not verify are skipped, since an unverified nonce is asserted rather than attested.

## Measured before writing it

Grouping signed records by sender in export order, on live rooms 2026-09-05:

| room | signed records | keys with 2+ rows | nonce order violations |
|---|---:|---:|---:|
| `mb-9f28e3dca219` | 585 | 24 | 0 |
| `signing-messages` | 55 | 7 | 0 |
| `tclk-offers` | 12,387 | 565 | 1 |

The single violation is a pair the venue ordered against its own clock: the key's nonces are ordered and the venue's `seq` is not. That is the boundary the doc comment names — the venue looks for a key's last nonce only within the newest portion of a room it scans, so a long busy board can legitimately show a lower nonce once older traffic buries the record that would have refused it. A derived deal room, a handful of records from two keys, is never near it.

(Same reading also cleared #97's fatal `timestamp goes backwards`: the venue's `ts` is non-monotonic 107 times in 12,414 board records, worst by 44.6 minutes, but across 3,500 real offer/accept pairs the number where the accept carries an earlier `ts` than its offer is zero. The inversions are between unrelated contracts, which a fold never compares. Detail in the issue thread.)

## Tests

Five, in `tests/transcript.test.ts`:

- an honest deal reports nothing
- two records of one signer supplied swapped are caught
- **the same swap with `seq` and `timestampMs` renumbered to hide it is still caught** — the regression that fails without this change
- two signers whose records interleave, the later one carrying the lower nonce, are not faulted
- a record whose signature does not verify is ignored rather than treated as an ordering claim

## SPEC

`SPEC.md` and the code agree. This adds a check over what §2 already states about which fields a signature covers, and changes no wire format — the golden vectors are untouched.

## Hostile counterparty

Nothing. It reads records and returns positions; it holds no secret, performs no write, and declines to conclude anything from a record it could not authenticate.

## CI

`pnpm install --frozen-lockfile`, `pnpm -r --include-workspace-root build`, `pnpm -r --include-workspace-root test` run locally: build clean, 108 root tests passing against 103 before, `mcp/` 40 and 33 passing.

One failure locally, `tests/schema-conformance.test.ts`, identical before and after this branch: `generate-frame-fields.mjs --check` on a Windows checkout, which is #90 and has fixes open in #91 and #103.
