### PR TITLE
fix(points): a CSPRNG failure hung generatePointLock instead of surfa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `generatePointLock` no longer turns a CSPRNG failure into a silent, unkillable spin. Its
+  rejection-sampling loop caught every throw from the draw, including `randomU8a`'s refusal
+  when no Web Crypto CSPRNG is available and the 16-byte blinding draw `@noble/curves` makes
+  during the scalar multiplication. Either one was retried forever, synchronously, so the
+  loud failure `hex.ts` raises on purpose became a hang no timer, `await` or signal handler
+  could interrupt — the test runner itself wedges on it. The draw is now range-checked inline
+  and the loop is bounded, so a broken CSPRNG surfaces the way it already does through
+  `generateHashLock` and `generateSalt`.
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema

--- a/src/points.ts
+++ b/src/points.ts
@@ -46,14 +46,22 @@ export function pointLockFromWitness(witness: string | Uint8Array): PointLock {
 
 /** Mint a fresh random point lock `(y, Y=y·G)`. */
 export function generatePointLock(): PointLock {
-  // Rejection-sample a valid scalar (overwhelmingly first try; guards the y∉[1,n) tail).
-  for (;;) {
-    try {
-      return pointLockFromWitness(randomU8a(32));
-    } catch {
-      // negligible-probability out-of-range draw; retry.
-    }
+  // Rejection-sample a valid scalar, testing the draw inline rather than by catching
+  // `pointLockFromWitness`. A bare `catch` here also swallows `randomU8a`'s refusal on a
+  // runtime with no Web Crypto CSPRNG, and retrying *that* forever turns the loud failure
+  // `hex.ts` raises on purpose into a synchronous spin that no timer, signal handler or
+  // `await` can interrupt. `generateHashLock` and `generateSalt` let the same refusal
+  // through; this was the one generator that did not.
+  //
+  // Bounded for the same reason: a draw lands outside [1, n) with probability under 2^-128,
+  // so exhausting these attempts means the CSPRNG is broken, not that we were unlucky.
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const y = randomU8a(32);
+    const v = BigInt(u8aToHex(y));
+    if (v === 0n || v >= SECP256K1_N) continue;
+    return pointLockFromWitness(y);
   }
+  throw new Error("tclk: CSPRNG returned no scalar in [1, n) in 8 draws");
 }
 
 /** True iff `witness` (y) is the discrete-log of `statement` (Y): `compressed(y·G) == Y`. */

--- a/src/points.ts
+++ b/src/points.ts
@@ -53,8 +53,10 @@ export function generatePointLock(): PointLock {
   // `await` can interrupt. `generateHashLock` and `generateSalt` let the same refusal
   // through; this was the one generator that did not.
   //
-  // Bounded for the same reason: a draw lands outside [1, n) with probability under 2^-128,
-  // so exhausting these attempts means the CSPRNG is broken, not that we were unlucky.
+  // Bounded for the same reason. A draw is rejected when it is zero or >= n, which is
+  // (2^256 - n + 1) / 2^256 of the space -- about 3.7e-39, or 2^-127.65. (Just *above*
+  // 2^-128: 2^256 - n is 4.32e38 and 2^128 is 3.40e38.) Eight such draws in a row is
+  // 2^-1021, so exhausting these attempts means the CSPRNG is broken, not bad luck.
   for (let attempt = 0; attempt < 8; attempt++) {
     const y = randomU8a(32);
     const v = BigInt(u8aToHex(y));

--- a/tests/points.test.ts
+++ b/tests/points.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for PTLC point-lock minting.
+ *
+ * `generatePointLock` rejection-samples a scalar, so it is the one generator with a loop
+ * around the CSPRNG. The loop must not become a way to *lose* a CSPRNG failure:
+ * `randomU8a` throws when no Web Crypto is available, and that refusal has to leave the
+ * loop the way it leaves `generateHashLock` and `generateSalt`.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import {
+  generatePointLock,
+  pointLockFromWitness,
+  verifyPointWitness,
+  isValidPointStatement,
+  SECP256K1_N,
+} from "../src/points.js";
+import { generateHashLock } from "../src/locks.js";
+import { generateSalt } from "../src/commitments.js";
+
+const OUT_OF_RANGE = new Uint8Array(32).fill(0xff); // > n
+const IN_RANGE = new Uint8Array(32).fill(0x01);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** How many 32-byte witness draws the spy saw (ignoring the curve's 16-byte blinding). */
+function draws32(spy: { mock: { calls: unknown[][] } }): number {
+  return spy.mock.calls.filter((c) => (c[0] as Uint8Array | undefined)?.length === 32).length;
+}
+
+describe("generatePointLock", () => {
+  it("mints a lock whose witness opens its own statement", () => {
+    const lock = generatePointLock();
+    expect(lock.witness).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(isValidPointStatement(lock.statement)).toBe(true);
+    expect(verifyPointWitness(lock.statement, lock.witness)).toBe(true);
+    expect(BigInt(lock.witness)).toBeGreaterThan(0n);
+    expect(BigInt(lock.witness)).toBeLessThan(SECP256K1_N);
+  });
+
+  it("retries past an out-of-range draw", () => {
+    // Count witness draws only: @noble/curves also pulls 16 bytes to blind the scalar
+    // multiplication, so total CSPRNG calls are not the same thing as attempts.
+    const spy = vi
+      .spyOn(globalThis.crypto, "getRandomValues")
+      .mockImplementationOnce(() => OUT_OF_RANGE.slice() as never)
+      .mockImplementationOnce(() => IN_RANGE.slice() as never);
+    const lock = generatePointLock();
+    expect(draws32(spy)).toBe(2);
+    expect(lock).toEqual(pointLockFromWitness(IN_RANGE));
+  });
+
+  it("propagates a CSPRNG refusal raised by the curve's own blinding", () => {
+    // The same defect reached through @noble/curves: `randomU8a` succeeds, then the
+    // blinding draw inside `pointLockFromWitness` fails. Catching the whole call meant
+    // this too became a silent retry forever.
+    vi.spyOn(globalThis.crypto, "getRandomValues").mockImplementation(((a: Uint8Array) => {
+      if (a.length === 32) return IN_RANGE.slice();
+      throw new Error("tclk: no Web Crypto CSPRNG available (crypto.getRandomValues)");
+    }) as never);
+    expect(() => generatePointLock()).toThrow(/no Web Crypto CSPRNG available/);
+  });
+
+  it("propagates a CSPRNG refusal instead of spinning on it", () => {
+    // The regression: catching the draw swallowed this, and the retry loop then span
+    // synchronously and forever -- no error, and no timer or signal able to interrupt it.
+    const spy = vi.spyOn(globalThis.crypto, "getRandomValues").mockImplementation(() => {
+      throw new Error("tclk: no Web Crypto CSPRNG available (crypto.getRandomValues)");
+    });
+    expect(() => generatePointLock()).toThrow(/no Web Crypto CSPRNG available/);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after a bounded number of unusable draws", () => {
+    const spy = vi
+      .spyOn(globalThis.crypto, "getRandomValues")
+      .mockImplementation(() => OUT_OF_RANGE.slice() as never);
+    expect(() => generatePointLock()).toThrow(/no scalar in \[1, n\)/);
+    expect(draws32(spy)).toBeLessThanOrEqual(16);
+  });
+
+  it("fails the same way the other secret generators do", () => {
+    vi.spyOn(globalThis.crypto, "getRandomValues").mockImplementation(() => {
+      throw new Error("tclk: no Web Crypto CSPRNG available (crypto.getRandomValues)");
+    });
+    for (const mint of [generatePointLock, generateHashLock, generateSalt]) {
+      expect(mint).toThrow(/no Web Crypto CSPRNG available/);
+    }
+  });
+});

--- a/tests/points.test.ts
+++ b/tests/points.test.ts
@@ -82,6 +82,17 @@ describe("generatePointLock", () => {
     expect(draws32(spy)).toBeLessThanOrEqual(16);
   });
 
+  it("rejects the share of the draw space its bound claims", () => {
+    // Pins the arithmetic the loop bound is argued from, so the comment cannot drift.
+    // Valid witnesses are [1, n-1], so a draw is rejected with mass (2^256 - n + 1) / 2^256.
+    // Integer comparisons only -- floats cannot represent these magnitudes exactly.
+    const TOTAL = 1n << 256n;
+    const rejected = TOTAL - (SECP256K1_N - 1n);
+    expect(rejected).toBe(432420386565659656852420866394968145600n);
+    expect(rejected).toBeGreaterThan(1n << 128n); // p > 2^-128
+    expect(rejected).toBeLessThan(1n << 129n); //  p < 2^-127
+  });
+
   it("fails the same way the other secret generators do", () => {
     vi.spyOn(globalThis.crypto, "getRandomValues").mockImplementation(() => {
       throw new Error("tclk: no Web Crypto CSPRNG available (crypto.getRandomValues)");


### PR DESCRIPTION
## What

`generatePointLock` now lets a CSPRNG failure out instead of retrying it forever: only an
out-of-range draw continues the rejection-sampling loop, and the loop is bounded. Callers
that were getting a valid lock still get one.

## Why

`hex.ts` makes `randomU8a` throw when no Web Crypto CSPRNG is available: "a silent
`Math.random()` fallback would mint guessable preimages and witnesses, which is a stolen
payment rather than a degraded one". `generatePointLock` wrapped the whole draw in
`try { … } catch { }` and redrew on anything, so that refusal was swallowed.

The loop is synchronous, so this is not a slow failure but an unkillable one. On `main` I
measured 432,240 iterations in two seconds with no error, and no timer, `await` or signal
handler able to run — `vitest` cannot even time the case out; the runner wedges.

The same `catch` also swallowed the 16-byte blinding draw `@noble/curves` makes inside
`pointLockFromWitness`, so the hang is reachable without `randomU8a` failing.

generateHashLock and generateSalt already let the refusal through; this was the one generator that did not. The bound is eight draws: a draw lands outside [1, n) with probability (2^256 − n + 1)/2^256 ≈ 3.7e-39, i.e. 2^-127.65, so exhausting them means the CSPRNG is broken, not bad luck.

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test` — 110 / 40 / 33 pass
- [x] Golden vectors untouched
- [x] `CHANGELOG.md` has an `[Unreleased]` entry
- [x] No doc needs updating — this restores the behaviour `hex.ts` already documents
- [x] New surface on the money path: nothing new. A hostile counterparty gains nothing;
      an operator on a runtime without Web Crypto now gets the error instead of a wedged
      process. `tests/points.test.ts` is new — four of its six cases hang the runner on the
      old implementation.
