### PR TITLE
fix(transcript): fold ignores signed non-frame lines instead of reporting them as defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- `foldTranscript` no longer reports a signed room line that is not a `tclk1 ` frame (the deliverable a payee
+  posts in the deal room before revealing, or chat) as a failed step. Such records are `{ok: true, ignored: true}`:
+  no transition, not a defect, so a reader counting `!ok` steps counts only frames that failed. A line that carries
+  the `tclk1 ` prefix and does not decode is still rejected.
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema

--- a/mcp/tests/transcript.test.ts
+++ b/mcp/tests/transcript.test.ts
@@ -158,7 +158,7 @@ describe("fail-closed folding", () => {
       ),
     });
 
-    expect(result.steps[0]).toMatchObject({ ok: false });
+    expect(result.steps[0]).toMatchObject({ ok: true, ignored: true }); // chat is ignored, never a throw and never a defect
     expect(result.steps[1]).toMatchObject({ ok: true, type: "offer" });
     expect(result.steps[2]).toMatchObject({ ok: false });
     expect(result.steps[3]).toMatchObject({ ok: true, type: "accept" });

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -8,7 +8,7 @@
 import { ed25519 } from "@noble/curves/ed25519.js";
 import { base58, base64urlnopad } from "@scure/base";
 
-import { decodeFrame, tryDecodeFrame } from "./frames.js";
+import { decodeFrame, tryDecodeFrame, isTclkLine } from "./frames.js";
 import { applyFrame, openContract, type ContractState } from "./machine.js";
 import { dealRoom, OFFER_ROOM } from "./technocore.js";
 
@@ -47,6 +47,9 @@ export interface TranscriptStep {
   type?: string;
   ok: boolean;
   reason?: string;
+  /** True when the record was a signed room line that is not a `tclk1 ` frame (a deliverable, chat) and was
+   *  ignored: no transition, not a defect. Readers counting defects should skip these. */
+  ignored?: boolean;
 }
 
 export interface TranscriptFoldResult {
@@ -245,6 +248,14 @@ export function foldTranscript(records: readonly TranscriptRecord[]): Transcript
       return;
     }
 
+    // A signed line that is not a tclk/1 frame at all — the deliverable a payee posts in the deal room before
+    // revealing (patterns.md §6), or chat — is not a transcript defect: the spec says readers ignore what is not
+    // a frame, and nothing here transitions. Report it as ignored so a reader counting `!ok` steps counts only
+    // frames that failed. A line that *claims* to be a frame and does not decode stays a rejected step.
+    if (!isTclkLine(record.line)) {
+      steps.push({ ...base, ok: true, ignored: true, reason: "not a tclk/1 line: ignored" });
+      return;
+    }
     const frame = tryDecodeFrame(record.line);
     if (frame === null) {
       steps.push({ ...base, ok: false, reason: decodeReason(record.line) });

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -107,6 +107,35 @@ describe("trusted transcript records", () => {
     expect(folded.state?.status).toBe("claimed");
   });
 
+  it("ignores a signed non-frame line in the deal room instead of reporting a defect", () => {
+    const { offer, accept, lock } = deal();
+    const lockFrame = { type: "lock" as const, from: payer.did, contract: accept.contract, rail: "flop-htlc", ref: "escrow-42" };
+    const reveal = { type: "reveal" as const, from: payee.did, contract: accept.contract, secret: lock.preimage };
+    const room = dealRoom(accept.contract);
+    const folded = foldTranscript([
+      record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+      record(BOARD, 2, NOW, payee, encodeFrame(accept)),
+      record(room, 1, NOW + 1, payer, encodeFrame(lockFrame)),
+      record(room, 2, NOW + 2, payee, "count=7, rows 12 and 19 (the deliverable, posted before the reveal)"),
+      record(room, 3, NOW + 3, payee, encodeFrame(reveal)),
+    ]);
+
+    expect(folded.steps.map((step) => step.ok)).toEqual([true, true, true, true, true]);
+    expect(folded.steps[3]).toMatchObject({ ok: true, ignored: true, reason: expect.stringMatching(/not a tclk\/1 line/) });
+    expect(folded.steps.filter((step) => !step.ok)).toHaveLength(0);
+    expect(folded.state?.status).toBe("claimed");
+  });
+
+  it("still rejects a line that claims the tclk1 prefix but does not decode", () => {
+    const { offer } = deal();
+    const folded = foldTranscript([
+      record(BOARD, 1, NOW - 1, payer, encodeFrame(offer)),
+      record(BOARD, 2, NOW, payee, "tclk1 {\"type\":\"lock\",\"contract\":\"0x00\"}"),
+    ]);
+    expect(folded.steps[1].ok).toBe(false);
+    expect(folded.steps[1].ignored).toBeUndefined();
+  });
+
   it("rejects a validly signed record when the frame claims a different sender", () => {
     const { offer, accept } = deal();
     const forgedLock = {


### PR DESCRIPTION
## What

`foldTranscript` reported every signed room line that is not a `tclk1 ` frame as a failed step (`tclk: not a tclk/1 line`). A payee posts its deliverable in the derived deal room before revealing (patterns.md §6), so a reader counting `!ok` steps — the documented way to find defects in a transcript — counted deliverables as defects.

Such records now fold as `{ ok: true, ignored: true, reason: "not a tclk/1 line: ignored" }`: no transition, not a defect. A line that carries the `tclk1 ` prefix and does not decode is still a rejected step.

## Why

SPEC §2: an unsigned frame is data, not a commitment — readers ignore it. A signed line that is not a frame at all is in the same class. Measured on live technocore.chat transcripts (our fleet's own deals, folded with this library): 907 of 4,455 deals that fold to `claimed` carried exactly 2 rejected steps, both the payee's deliverable lines. Any evidence consumer that weights "defects in the transcript" (the #108 discussion) was penalising the deals that delivered.

## Tests

- new: a complete deal with a plain deliverable line between lock and reveal folds to `claimed` with zero `!ok` steps and the deliverable marked `ignored`.
- new: a line with the `tclk1 ` prefix that does not decode is still `ok: false` and not `ignored`.
- full suite: 106 passed.

Refs #108 (evidence counting), #104 (where the deliverable lands when the room exists).