### PR TITLE
test(frames): clarify tclk1 prefix validation boundary

### DIFF
--- a/src/frames.ts
+++ b/src/frames.ts
@@ -454,7 +454,11 @@ export function makeAccept(
 
 // ── Line codec ───────────────────────────────────────────────────────────────
 
-/** True iff a room-message text is a tclk/1 frame line. */
+/**
+ * True iff a room-message text carries the `tclk1 ` version prefix. A cheap prefilter,
+ * not a validity check: a prefixed line can still fail `decodeFrame`, so count frames
+ * with `tryDecodeFrame`.
+ */
 export function isTclkLine(text: string): boolean {
   return text.startsWith(TCLK_PREFIX);
 }

--- a/tests/live-wire-conformance.test.ts
+++ b/tests/live-wire-conformance.test.ts
@@ -12,6 +12,7 @@ import {
   decodeFrame,
   encodeFrame,
   generateHashLock,
+  isTclkLine,
   makeAccept,
   makeOffer,
   matchingRails,
@@ -259,5 +260,50 @@ describe("live-wire conformance gaps", () => {
     // The bound is what keeps one doctored export row from costing a fold a megabyte of parsing.
     const megabyte = `${TCLK_PREFIX}${canonicalJson(beat("x".repeat(1_000_000)))}`;
     expect(tryDecodeFrame(megabyte)).toBeNull();
+  });
+
+  // The prefix is the version marker, not a validity guarantee: it says which revision a
+  // line claims, not that the line decodes. Measured on the live board (#89), 5,529 of
+  // 13,939 prefixed lines were rejected here, mostly one fleet naming the offer `offer_id`
+  // instead of `ref` and posting types this union does not define. So a count taken by
+  // prefix is not a count of frames; take it with tryDecodeFrame.
+  it("treats the tclk1 prefix as a version marker, not a validity check", () => {
+    const id = offerId(offer());
+    const statement = "0x" + "11".repeat(32);
+
+    const foreign: Array<[string, RegExp]> = [
+      // accept naming the offer with offer_id, where SPEC 3.2 says ref
+      [
+        `{"type":"accept","offer_id":"${id}","from":"${PAYEE}","statement":"${statement}","nonce":"8899aabbccddeeff"}`,
+        /unknown field on accept: offer_id/,
+      ],
+      // settle, a type this union does not define
+      [
+        `{"type":"settle","offer_id":"${id}","from":"${PAYER}","rail":"paper","status":"settled"}`,
+        /unknown frame type: settle/,
+      ],
+      // confirm, a type this union does not define
+      [
+        `{"type":"confirm","offer_id":"${id}","from":"${PAYER}","status":"confirmed"}`,
+        /unknown frame type: confirm/,
+      ],
+    ];
+
+    for (const [body, reason] of foreign) {
+      const line = TCLK_PREFIX + body;
+      expect(isTclkLine(line)).toBe(true);
+      expect(tryDecodeFrame(line)).toBeNull();
+      expect(() => decodeFrame(line)).toThrow(reason);
+    }
+
+    // A line without the prefix is the other rejection class: not this version at all.
+    expect(isTclkLine("gm from ~alice")).toBe(false);
+    expect(() => decodeFrame("gm from ~alice")).toThrow(/not a tclk\/1 line/);
+
+    // And a frame this library emits still passes both, so the filter is not just
+    // rejecting everything that reaches it.
+    const canonical = encodeFrame(offer());
+    expect(isTclkLine(canonical)).toBe(true);
+    expect(tryDecodeFrame(canonical)).not.toBeNull();
   });
 });


### PR DESCRIPTION
## What

Clarifies that `isTclkLine()` is a `tclk1 ` prefix/version prefilter rather than a validity check, and adds live-wire regression coverage for that boundary.

The new test covers three `tclk1 `-prefixed inputs that strict decoding correctly rejects:

- an `accept` using `offer_id` instead of canonical `ref`
- unsupported `settle`
- unsupported `confirm`

It also includes positive and negative controls showing the distinction between prefix detection and successful frame decoding.

## Why

#89 documents live traffic where counting by the `tclk1 ` prefix produces a materially different result from counting successfully decoded frames.

The implementation already behaves correctly, but `isTclkLine` had no direct test coverage and its JSDoc could be read as a validity guarantee. This change makes that boundary explicit and pins the existing behavior.

Refs #89.

## Verification

- No runtime or wire-format change; the production edit is JSDoc only.
- `tests/live-wire-conformance.test.ts` + `tests/vectors.test.ts`: 18 passed.
- Golden vectors unchanged and passing.
- `pnpm -r --include-workspace-root build`: passes.
- Full local suite: 104 passed, 1 pre-existing Windows schema-conformance failure tracked in #90; this PR does not touch that area.
- `CHANGELOG.md` unchanged because runtime behavior is unchanged.
