### PR TITLE
fix(transcript): preserve large numeric export nonces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- Preserve exact numeric nonces from Technocore `/export` responses before JSON parsing
+  can round values above JavaScript's safe-integer range.
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -160,6 +160,17 @@ export function transcriptRecord(room: string, value: unknown): TranscriptRecord
   };
 }
 
+function parseTranscriptExportLine(line: string): unknown {
+  // Technocore may serialize nonce as a JSON number. Preserve the exact
+  // decimal digits before JSON.parse can round values above 2^53 - 1.
+  const exactNonce = /("nonce"\s*:\s*)(-?\d+)(?=\s*[,}])/;
+  const normalized = line.replace(
+    exactNonce,
+    (_match, prefix: string, nonce: string) => `${prefix}"${nonce}"`,
+  );
+  return JSON.parse(normalized);
+}
+
 /** Parse a byte-exact technocore `/export` JSONL response. One malformed row fails all. */
 export function parseTranscriptExport(room: string, jsonl: string): TranscriptRecord[] {
   const records: TranscriptRecord[] = [];
@@ -167,7 +178,7 @@ export function parseTranscriptExport(room: string, jsonl: string): TranscriptRe
     if (line.trim() === "") return;
     let value: unknown;
     try {
-      value = JSON.parse(line);
+      value = parseTranscriptExportLine(line);
     } catch {
       throw new Error(`tclk: transcript export line ${index + 1} is not JSON`);
     }

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -217,6 +217,28 @@ describe("trusted transcript records", () => {
     expect(() => parseTranscriptExport(BOARD, localeTimestamp)).toThrow(/timezone-qualified/);
   });
 
+  it("preserves large numeric nonces from byte-exact exports", () => {
+    const { offer } = deal();
+    const line = encodeFrame(offer);
+    const nonce = "1788605346703840081";
+
+    const raw = `{"seq":7,"ts":"${new Date(NOW).toISOString()}","from":${JSON.stringify(
+      payer.did,
+    )},"nonce":${nonce},"sig":null,"text":${JSON.stringify(line)}}`;
+
+    expect(parseTranscriptExport(BOARD, raw)).toEqual([
+      {
+        room: BOARD,
+        seq: 7,
+        timestampMs: NOW,
+        sender: payer.did,
+        nonce,
+        signature: null,
+        line,
+      },
+    ]);
+  });
+
   it("never synthesizes offer-before-accept order while selecting a board handshake", () => {
     const { offer, accept } = deal();
     const earlyAccept = record(BOARD, 1, NOW - 1, payee, encodeFrame(accept));


### PR DESCRIPTION
## What

Preserve exact numeric `nonce` values from Technocore `/export` JSONL before `JSON.parse()` can round integers above JavaScript's safe-integer range.

Callers of `parseTranscriptExport()` can now parse retained Technocore rows containing large numeric nonces without losing precision.

## Why

Technocore has retained transcript rows where `nonce` is serialized as a JSON number above `Number.MAX_SAFE_INTEGER`.

For example, the live `/r/tclk-offers/export` contains `1788605346703840081`. Direct JSON parsing rounds that value and causes transcript parsing to fail with `transcript message nonce must be decimal text`.

`SPEC.md` is unchanged; this is a transport parsing fix only.

## Checks

- [x] `pnpm install --frozen-lockfile && pnpm -r --include-workspace-root build`
- [x] `pnpm -r --include-workspace-root test`
- [x] Golden vectors untouched
- [x] `CHANGELOG.md` has an `[Unreleased]` entry
- [x] No documentation became incorrect
- [x] New surface on the money path: nothing new