### PR TITLE
docs(spec): define canonical number and key ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. Format follows
 
 ## [Unreleased]
 
+### Documentation
+
+- Specify the canonical UTF-16 code-unit key order and the safe-integer decimal form for the three
+  Unix-ms frame fields so non-JavaScript implementations can reproduce tclk/1 identifiers exactly.
+
 ### Fixed
 
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer

--- a/SPEC.md
+++ b/SPEC.md
@@ -107,10 +107,13 @@ the public manual (`/llms.txt`), and any self-hosted deployment works identicall
 ## 3. Wire format
 
 A frame is the 6 chars `tclk1 ` followed by one JSON object, serialized canonically:
-object keys sorted, `,`/`:` separators only, `undefined`-valued keys dropped, every non-ASCII
-character `\uXXXX`-escaped. The prefix is the version; incompatible revisions change it
-(`tclk2 `), never the field semantics. Decoding is fail-closed: a known frame type with an
-unknown key, a missing field, or a malformed value is rejected, never coerced.
+object keys sorted by JavaScript UTF-16 code units, `,`/`:` separators only, `undefined`-valued
+keys dropped, every non-ASCII character `\uXXXX`-escaped. The three Unix-ms fields
+(`claimByMs`, `refundAfterMs`, and `expiresMs`) are positive safe integers (`1` through
+`9007199254740991`); a canonical encoder emits them as base-10 integer digits, with no decimal
+point or exponent. The prefix is the version; incompatible revisions change it (`tclk2 `), never
+the field semantics. Decoding is fail-closed: a known frame type with an unknown key, a missing
+field, or a malformed value is rejected, never coerced.
 
 Common field shapes:
 


### PR DESCRIPTION
## Summary\n\nCloses #117. Clarifies two existing canonical-encoding rules for non-JavaScript implementations:\n\n- object keys sort by JavaScript UTF-16 code units;\n- numeric frame fields are finite safe integers serialized as decimal JSON numbers without fractions or exponents.\n\nThe reference implementation is unchanged; this documents its existing validation and Object.keys(...).sort() behavior.\n\n## Verification\n\n- git diff --check passed.\n- The mandated pnpm install/build/test commands were started, but dependency installation did not complete within the available command window; no local test result is claimed.\n- No wire-format code or golden vectors changed.