### PR TITLE
fix(generator): accept CRLF checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project are documented here. Format follows
 
 ### Fixed
 
+- The generated protocol-field freshness check now treats CRLF and LF checkouts as equivalent,
+  so Windows line-ending conversion does not report unchanged generated content as stale.
+
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer
   numbers, so signed Technocore nonces above JavaScript's safe-integer range are preserved
   without precision loss. Unsafe numeric nonces (> 2^53 - 1) are rejected at the MCP schema

--- a/scripts/generate-frame-fields.mjs
+++ b/scripts/generate-frame-fields.mjs
@@ -5,6 +5,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { normalizeLineEndings } from "./normalize-line-endings.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const schemaPath = join(root, "schema/tclk1-frames.schema.json");
@@ -57,7 +58,8 @@ if (nextSpec === spec && !spec.includes(table)) {
 }
 
 if (process.argv.includes("--check")) {
-  if (readFileSync(generatedPath, "utf8") !== generated || spec !== nextSpec) {
+  if (normalizeLineEndings(readFileSync(generatedPath, "utf8")) !== generated ||
+      normalizeLineEndings(spec) !== normalizeLineEndings(nextSpec)) {
     console.error("generated protocol fields are stale; run pnpm generate:protocol");
     process.exit(1);
   }

--- a/scripts/normalize-line-endings.mjs
+++ b/scripts/normalize-line-endings.mjs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export function normalizeLineEndings(value) {
+  return value.replace(/\r\n?/g, "\n");
+}

--- a/tests/generator-line-endings.test.ts
+++ b/tests/generator-line-endings.test.ts
@@ -1,0 +1,47 @@
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { normalizeLineEndings } from "../scripts/normalize-line-endings.mjs";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+describe("protocol generator line endings", () => {
+  it("normalizes CRLF and bare CR without changing content", () => {
+    expect(normalizeLineEndings("first\r\nsecond\rthird\nfourth")).toBe(
+      "first\nsecond\nthird\nfourth",
+    );
+  });
+
+  it("accepts a CRLF checkout in the generator freshness check", () => {
+    const checkout = mkdtempSync(join(tmpdir(), "tclk-generator-"));
+    try {
+      for (const relative of [
+        "scripts/generate-frame-fields.mjs",
+        "scripts/normalize-line-endings.mjs",
+        "schema/tclk1-frames.schema.json",
+        "src/frame-fields.generated.ts",
+        "SPEC.md",
+      ]) {
+        const target = join(checkout, relative);
+        mkdirSync(dirname(target), { recursive: true });
+        cpSync(join(root, relative), target);
+      }
+      for (const relative of ["SPEC.md", "src/frame-fields.generated.ts"]) {
+        const target = join(checkout, relative);
+        writeFileSync(target, readFileSync(target, "utf8").replace(/\r?\n/g, "\r\n"));
+      }
+
+      expect(() => execFileSync(
+        process.execPath,
+        [join(checkout, "scripts/generate-frame-fields.mjs"), "--check"],
+        { cwd: checkout, stdio: "pipe" },
+      )).not.toThrow();
+    } finally {
+      rmSync(checkout, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #90.

`generate-frame-fields.mjs --check` compared checked-out text byte-for-byte with LF-generated output. A Windows checkout using CRLF therefore reported generated protocol files as stale even when their content was unchanged.

This change:

- normalizes CRLF and LF only for freshness comparisons;
- adds a regression test that runs the generator against an isolated CRLF checkout;
- leaves regeneration output behavior, the schema, generated field values, canonical encoding, and wire format unchanged.

## Verification

- `node scripts/generate-frame-fields.mjs --check` — passed.
- Isolated temporary CRLF checkout running the generator — exited 0.
- Direct helper assertion for CRLF, CR, and LF input — passed.
- JavaScript syntax checks — passed.
- `git diff --check` — passed.

The full pnpm/Vitest suite was not runnable locally because the pinned Windows platform packages could not be downloaded from the npm registry and the available Rolldown binding was incomplete; CI should provide the complete matrix.