### PR TITLE
feat(rail): add EvmHashRail binding, split from #21 (binding only, no toolchain)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ All notable changes to this project are documented here. Format follows
   stdio build remains the right choice wherever a local process can run — `mcp/worker/`
   documents what a shared instance costs, including that frames leave from its IP and share
   one rate budget.
+- An `EvmHashRail` binding (`src/evm-hash-rail.ts`) of the `SettlementRail` interface to the
+  `evm-htlc` rail named in `SPEC.md` §5 — hash-lock only. Chain-agnostic: it takes an
+  injected `viem` `PublicClient`/`WalletClient` plus caller-supplied DID→address and
+  asset→token lookups, the same way `PaperRail` takes a `NoteStore`. `viem` is an optional
+  peer dependency kept off the main entry point. `lock`/`claim`/`refund` each have a
+  happy-path and a revert-path test against a mocked `viem` transport, with real ABI
+  encoding/decoding and revert-reason formatting, not a stubbed client. The Solidity
+  contract and Foundry toolchain that would deploy and exercise it end-to-end on a real
+  chain are a separate change; this is the TypeScript binding on its own.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./evm-hash-rail": {
+      "types": "./dist/evm-hash-rail.d.ts",
+      "default": "./dist/evm-hash-rail.js"
     }
   },
   "files": [
@@ -54,9 +58,18 @@
     "@noble/hashes": "^2.4.0",
     "@scure/base": "^2.4.0"
   },
+  "peerDependencies": {
+    "viem": "^2.56.1"
+  },
+  "peerDependenciesMeta": {
+    "viem": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "typescript": "^7.0.2",
+    "viem": "^2.56.1",
     "vitest": "^4.1.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      viem:
+        specifier: ^2.56.1
+        version: 2.56.3(typescript@7.0.2)(zod@3.25.76)
       vitest:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@22.20.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.1))
@@ -35,7 +38,7 @@ importers:
         version: link:..
       '@modelcontextprotocol/sdk':
         specifier: ^1.30.0
-        version: 1.30.0(zod@3.25.76)
+        version: 1.30.0(supports-color@10.2.2)(zod@3.25.76)
       '@noble/curves':
         specifier: ^2.4.0
         version: 2.4.0
@@ -63,6 +66,9 @@ importers:
         version: 4.127.1
 
 packages:
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -458,9 +464,21 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@2.4.0':
     resolution: {integrity: sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==}
     engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@2.4.0':
     resolution: {integrity: sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==}
@@ -577,8 +595,17 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
   '@scure/base@2.4.0':
     resolution: {integrity: sha512-thZ1TuJwFwBblOhgsjDKvvGirBxNp+wSvY/DR6tJBJOTDhdAAcHJ8Vbr2eFnqaxeca4+t0i9KBf+uHYGWwZORg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
@@ -751,6 +778,17 @@ packages:
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -889,6 +927,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
   eventsource-parser@3.1.1:
     resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
@@ -994,6 +1035,11 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
 
   jose@6.2.10:
     resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
@@ -1139,6 +1185,14 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  ox@0.14.44:
+    resolution: {integrity: sha512-O54qXXHEk4ySamMSyBpI0AeBegS5frxU6+LA6Jb9Sf6kMOxcTNaxYmwZfpOu22DIQsdKfgQxHq8EsAGaoBQScA==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -1318,6 +1372,14 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  viem@2.56.3:
+    resolution: {integrity: sha512-vUObq3GO7D3lz9gPNEE/xd5jIUnMbeVDWewh252o54pDEDlW4pDe6FEd/qTGL5RyK52cGHMM7kQ3wjxhilEvkQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite@8.2.2:
     resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1457,6 +1519,8 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@adraffy/ens-normalize@1.11.1': {}
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
@@ -1687,7 +1751,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.6.0
 
-  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 2.1.1(hono@4.13.5)
       ajv: 8.20.0
@@ -1697,8 +1761,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.1
-      express: 5.2.1
-      express-rate-limit: 8.7.0(express@5.2.1)
+      express: 5.2.1(supports-color@10.2.2)
+      express-rate-limit: 8.7.0(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)
       hono: 4.13.5
       jose: 6.2.10
       json-schema-typed: 8.0.2
@@ -1709,9 +1773,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/curves@2.4.0':
     dependencies:
       '@noble/hashes': 2.4.0
+
+  '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.4.0': {}
 
@@ -1776,7 +1848,20 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@scure/base@1.2.6': {}
+
   '@scure/base@2.4.0': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@sindresorhus/is@7.2.0': {}
 
@@ -1898,6 +1983,11 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
+  abitype@1.2.3(typescript@7.0.2)(zod@3.25.76):
+    optionalDependencies:
+      typescript: 7.0.2
+      zod: 3.25.76
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -1918,11 +2008,11 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@10.2.2):
     dependencies:
       bytes: 3.1.2
       content-type: 2.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
@@ -1971,9 +2061,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   depd@2.0.0: {}
 
@@ -2038,6 +2130,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter3@5.0.1: {}
+
   eventsource-parser@3.1.1: {}
 
   eventsource@3.0.7:
@@ -2046,28 +2140,28 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express-rate-limit@8.7.0(express@5.2.1):
+  express-rate-limit@8.7.0(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
-      express: 5.2.1
+      debug: 4.4.3(supports-color@10.2.2)
+      express: 5.2.1(supports-color@10.2.2)
       ip-address: 10.7.0
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@10.2.2)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@10.2.2)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -2078,9 +2172,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.16.0
       range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@10.2.2)
+      send: 1.2.1(supports-color@10.2.2)
+      serve-static: 2.2.1(supports-color@10.2.2)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -2095,9 +2189,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.7
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -2164,6 +2258,10 @@ snapshots:
   is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
+
+  isows@1.0.7(ws@8.21.0):
+    dependencies:
+      ws: 8.21.0
 
   jose@6.2.10: {}
 
@@ -2272,6 +2370,21 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  ox@0.14.44(typescript@7.0.2)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@7.0.2)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - zod
+
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
@@ -2336,9 +2449,9 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.6
       '@rolldown/binding-win32-x64-msvc': 1.2.6
 
-  router@2.2.0:
+  router@2.2.0(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -2350,9 +2463,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -2366,12 +2479,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -2511,6 +2624,23 @@ snapshots:
   unpipe@1.0.0: {}
 
   vary@1.1.2: {}
+
+  viem@2.56.3(typescript@7.0.2)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@7.0.2)(zod@3.25.76)
+      isows: 1.0.7(ws@8.21.0)
+      ox: 0.14.44(typescript@7.0.2)(zod@3.25.76)
+      ws: 8.21.0
+    optionalDependencies:
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
 
   vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.1):
     dependencies:

--- a/src/evm-hash-rail.ts
+++ b/src/evm-hash-rail.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// tclk/1 `evm-htlc` settlement rail (SPEC.md §5) — hash-lock only. Binds LockTerms onto
+// contracts/EvmHashRail.sol. Point-lock (`t*G == Y`) is a separate rail, out of scope here.
+//
+// Not part of the main barrel: this is the package's only dependency on an EVM library, kept
+// behind the "@flop-labs/tclk/evm-hash-rail" subpath so nothing pulls in viem unless it asks
+// to. viem is an optional peerDependency for the same reason.
+//
+// DID -> chain-address mapping is deliberately NOT part of LockTerms: tclk's DIDs (did:key,
+// Ed25519) and an EVM account (secp256k1) are unrelated key material, and the protocol layer
+// has no business bridging that. The caller supplies the mapping at construction time, the
+// same way PaperRail takes a NoteStore — a rail's external dependencies are its own concern.
+
+import { isAddressEqual, type Address, type Hex, type PublicClient, type WalletClient, type Account, type Chain, type Transport } from "viem";
+import type { LockTerms, SettlementRail } from "./rail.js";
+
+export const EVM_HASH_RAIL_ABI = [
+  {
+    type: "function",
+    name: "lock",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "hashLock", type: "bytes32" },
+      { name: "payee", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "token", type: "address" },
+      { name: "claimByMs", type: "uint256" },
+      { name: "refundAfterMs", type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "claim",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "hashLock", type: "bytes32" },
+      { name: "preimage", type: "bytes32" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "refund",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "hashLock", type: "bytes32" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "locks",
+    stateMutability: "view",
+    inputs: [{ name: "", type: "bytes32" }],
+    outputs: [
+      { name: "payer", type: "address" },
+      { name: "payee", type: "address" },
+      { name: "token", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "claimByMs", type: "uint256" },
+      { name: "refundAfterMs", type: "uint256" },
+      { name: "status", type: "uint8" },
+    ],
+  },
+] as const;
+
+/** Mirrors the Solidity `Status` enum in contracts/EvmHashRail.sol, in declaration order. */
+const enum OnChainStatus {
+  None = 0,
+  Locked = 1,
+  Claimed = 2,
+  Refunded = 3,
+}
+
+/** Resolves a tclk DID to the EVM address it should be paid at, or throws if unknown. */
+export interface AddressBook {
+  resolve(did: string): Address;
+}
+
+/** Resolves a tclk `asset` identifier (e.g. "FLOP") to the ERC20 contract that represents it. */
+export interface AssetBook {
+  resolve(asset: string): Address;
+}
+
+/**
+ * Binds tclk's SettlementRail interface onto contracts/EvmHashRail.sol.
+ *
+ * One instance is bound to one EVM account (`walletClient`) — the same way each party in
+ * examples/live-deal.mjs holds its own rail handle. The party calling `lock`/`refund` must be
+ * this account; `claim` is permissionless on-chain, so any instance can relay it.
+ *
+ * `ref` here is the on-chain lock key, `terms.statement` (the hashLock) — NOT `terms.contract`
+ * like MemoryRail/PaperRail use. The contract has no notion of the tclk contract id; the
+ * hashLock is what it actually indexes locks by.
+ */
+export class EvmHashRail implements SettlementRail {
+  readonly id = "evm-htlc";
+
+  private readonly publicClient: PublicClient;
+  private readonly walletClient: WalletClient<Transport, Chain, Account>;
+  private readonly contractAddress: Address;
+  private readonly addressBook: AddressBook;
+  private readonly assetBook: AssetBook;
+  private readonly clock: () => number;
+
+  constructor(options: {
+    publicClient: PublicClient;
+    walletClient: WalletClient<Transport, Chain, Account>;
+    contractAddress: Address;
+    addressBook: AddressBook;
+    assetBook: AssetBook;
+    clock?: () => number;
+  }) {
+    this.publicClient = options.publicClient;
+    this.walletClient = options.walletClient;
+    this.contractAddress = options.contractAddress;
+    this.addressBook = options.addressBook;
+    this.assetBook = options.assetBook;
+    this.clock = options.clock ?? Date.now;
+  }
+
+  async lock(terms: LockTerms): Promise<string> {
+    if (terms.lock !== "hash") {
+      throw new Error(`tclk: EvmHashRail only supports hash locks, got ${terms.lock}`);
+    }
+    if (this.clock() >= terms.refundAfterMs) {
+      throw new Error("tclk: refusing to lock into an already-open refund window");
+    }
+
+    const hashLock = terms.statement as Hex;
+    const payee = this.addressBook.resolve(terms.payee);
+    const token = this.assetBook.resolve(terms.asset);
+
+    try {
+      const hash = await this.walletClient.writeContract({
+        address: this.contractAddress,
+        abi: EVM_HASH_RAIL_ABI,
+        functionName: "lock",
+        args: [hashLock, payee, BigInt(terms.amount), token, BigInt(terms.claimByMs), BigInt(terms.refundAfterMs)],
+      });
+      await this.publicClient.waitForTransactionReceipt({ hash });
+    } catch (err) {
+      throw new Error(`tclk: ${extractRevertReason(err)}`);
+    }
+
+    // The contract indexes by hashLock, not by the tclk contract id — this IS the ref.
+    return hashLock;
+  }
+
+  async verifyLock(terms: LockTerms, ref: string): Promise<boolean> {
+    if (terms.lock !== "hash" || ref !== terms.statement) return false;
+    try {
+      const [payer, payee, token, amount, claimByMs, refundAfterMs, status] =
+        await this.publicClient.readContract({
+          address: this.contractAddress,
+          abi: EVM_HASH_RAIL_ABI,
+          functionName: "locks",
+          args: [ref as Hex],
+        });
+      return (
+        status === OnChainStatus.Locked &&
+        isAddressEqual(payer, this.addressBook.resolve(terms.payer)) &&
+        isAddressEqual(payee, this.addressBook.resolve(terms.payee)) &&
+        isAddressEqual(token, this.assetBook.resolve(terms.asset)) &&
+        amount === BigInt(terms.amount) &&
+        claimByMs === BigInt(terms.claimByMs) &&
+        refundAfterMs === BigInt(terms.refundAfterMs)
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  async claim(ref: string, secret: string): Promise<void> {
+    try {
+      const hash = await this.walletClient.writeContract({
+        address: this.contractAddress,
+        abi: EVM_HASH_RAIL_ABI,
+        functionName: "claim",
+        args: [ref as Hex, secret as Hex],
+      });
+      await this.publicClient.waitForTransactionReceipt({ hash });
+    } catch (err) {
+      throw new Error(`tclk: ${extractRevertReason(err)}`);
+    }
+  }
+
+  async refund(ref: string): Promise<void> {
+    try {
+      const hash = await this.walletClient.writeContract({
+        address: this.contractAddress,
+        abi: EVM_HASH_RAIL_ABI,
+        functionName: "refund",
+        args: [ref as Hex],
+      });
+      await this.publicClient.waitForTransactionReceipt({ hash });
+    } catch (err) {
+      throw new Error(`tclk: ${extractRevertReason(err)}`);
+    }
+  }
+}
+
+/**
+ * viem surfaces a revert's require() string as `shortMessage` (and nests the same text
+ * through `.walk()` for wrapped errors) — pull that out so callers see "tclk: EvmHashRail:
+ * ..." instead of an ABI-encoding dump. Falls back to the raw error, never throws itself.
+ */
+function extractRevertReason(err: unknown): string {
+  if (err && typeof err === "object") {
+    const withMessage = err as { shortMessage?: unknown; message?: unknown };
+    if (typeof withMessage.shortMessage === "string") return withMessage.shortMessage;
+    if (typeof withMessage.message === "string") return withMessage.message;
+  }
+  return String(err);
+}

--- a/src/evm-hash-rail.ts
+++ b/src/evm-hash-rail.ts
@@ -138,7 +138,10 @@ export class EvmHashRail implements SettlementRail {
         functionName: "lock",
         args: [hashLock, payee, BigInt(terms.amount), token, BigInt(terms.claimByMs), BigInt(terms.refundAfterMs)],
       });
-      await this.publicClient.waitForTransactionReceipt({ hash });
+      const receipt = await this.publicClient.waitForTransactionReceipt({ hash });
+      if (receipt.status !== "success") {
+        throw new Error(`EvmHashRail: lock transaction mined but reverted on-chain (hash: ${hash})`);
+      }
     } catch (err) {
       throw new Error(`tclk: ${extractRevertReason(err)}`);
     }
@@ -179,7 +182,10 @@ export class EvmHashRail implements SettlementRail {
         functionName: "claim",
         args: [ref as Hex, secret as Hex],
       });
-      await this.publicClient.waitForTransactionReceipt({ hash });
+      const receipt = await this.publicClient.waitForTransactionReceipt({ hash });
+      if (receipt.status !== "success") {
+        throw new Error(`EvmHashRail: claim transaction mined but reverted on-chain (hash: ${hash})`);
+      }
     } catch (err) {
       throw new Error(`tclk: ${extractRevertReason(err)}`);
     }
@@ -193,7 +199,10 @@ export class EvmHashRail implements SettlementRail {
         functionName: "refund",
         args: [ref as Hex],
       });
-      await this.publicClient.waitForTransactionReceipt({ hash });
+      const receipt = await this.publicClient.waitForTransactionReceipt({ hash });
+      if (receipt.status !== "success") {
+        throw new Error(`EvmHashRail: refund transaction mined but reverted on-chain (hash: ${hash})`);
+      }
     } catch (err) {
       throw new Error(`tclk: ${extractRevertReason(err)}`);
     }

--- a/tests/evm-hash-rail.test.ts
+++ b/tests/evm-hash-rail.test.ts
@@ -1,0 +1,252 @@
+/**
+ * verifyLock must not care whether AddressBook/AssetBook and the on-chain read disagree on
+ * casing for the same address — see PR #21 review feedback (string equality on EVM addresses
+ * broke when one side was checksummed and the other wasn't).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  getAddress,
+  createPublicClient,
+  createWalletClient,
+  custom,
+  encodeErrorResult,
+  decodeFunctionData,
+  type Address,
+  type PublicClient,
+  type WalletClient,
+  type Account,
+  type Chain,
+  type Transport,
+} from "viem";
+import { foundry } from "viem/chains";
+
+import { EvmHashRail, EVM_HASH_RAIL_ABI, type AddressBook, type AssetBook } from "../src/evm-hash-rail.js";
+import type { LockTerms } from "../src/rail.js";
+
+const PAYER_LOWER = "0xaaaa1111bbbb2222cccc3333dddd4444eeee5566" as Address;
+const PAYEE_LOWER = "0xbbbb2222cccc3333dddd4444eeee5566aaaa1111" as Address;
+const TOKEN_LOWER = "0xcccc3333dddd4444eeee5566aaaa1111bbbb2222" as Address;
+
+const PAYER_CHECKSUM = getAddress(PAYER_LOWER);
+const PAYEE_CHECKSUM = getAddress(PAYEE_LOWER);
+const TOKEN_CHECKSUM = getAddress(TOKEN_LOWER);
+
+const terms: LockTerms = {
+  contract: "tclk1test",
+  lock: "hash",
+  statement: "0x" + "ab".repeat(32),
+  amount: "1000000",
+  asset: "FLOP",
+  payer: "did:key:zPayer",
+  payee: "did:key:zPayee",
+  claimByMs: 1_756_700_000_000,
+  refundAfterMs: 1_756_707_200_000,
+};
+
+/** locks(hashLock) tuple, with the on-chain addresses in whichever casing the chain returns. */
+function locksResult(payer: Address, payee: Address, token: Address) {
+  return [
+    payer,
+    payee,
+    token,
+    BigInt(terms.amount),
+    BigInt(terms.claimByMs),
+    BigInt(terms.refundAfterMs),
+    1, // OnChainStatus.Locked
+  ] as const;
+}
+
+function railWith(addressBook: AddressBook, assetBook: AssetBook, onChain: ReturnType<typeof locksResult>) {
+  const publicClient = { readContract: async () => onChain } as unknown as PublicClient;
+  const walletClient = {} as unknown as WalletClient<Transport, Chain, Account>;
+  return new EvmHashRail({
+    publicClient,
+    walletClient,
+    contractAddress: "0x0000000000000000000000000000000000dEaD",
+    addressBook,
+    assetBook,
+  });
+}
+
+describe("EvmHashRail.verifyLock — address comparison is case-insensitive", () => {
+  it("matches when AddressBook/AssetBook resolve lowercase but the chain returns checksummed", async () => {
+    const addressBook: AddressBook = {
+      resolve: (did) => (did === terms.payer ? PAYER_LOWER : PAYEE_LOWER),
+    };
+    const assetBook: AssetBook = { resolve: () => TOKEN_LOWER };
+    const rail = railWith(addressBook, assetBook, locksResult(PAYER_CHECKSUM, PAYEE_CHECKSUM, TOKEN_CHECKSUM));
+
+    expect(await rail.verifyLock(terms, terms.statement)).toBe(true);
+  });
+
+  it("matches when AddressBook/AssetBook resolve checksummed and the chain returns lowercase", async () => {
+    const addressBook: AddressBook = {
+      resolve: (did) => (did === terms.payer ? PAYER_CHECKSUM : PAYEE_CHECKSUM),
+    };
+    const assetBook: AssetBook = { resolve: () => TOKEN_CHECKSUM };
+    const rail = railWith(addressBook, assetBook, locksResult(PAYER_LOWER, PAYEE_LOWER, TOKEN_LOWER));
+
+    expect(await rail.verifyLock(terms, terms.statement)).toBe(true);
+  });
+
+  it("still fails closed when the addresses are genuinely different", async () => {
+    const addressBook: AddressBook = { resolve: () => PAYER_LOWER };
+    const assetBook: AssetBook = { resolve: () => TOKEN_LOWER };
+    const rail = railWith(addressBook, assetBook, locksResult(PAYEE_CHECKSUM, PAYEE_CHECKSUM, TOKEN_CHECKSUM));
+
+    expect(await rail.verifyLock(terms, terms.statement)).toBe(false);
+  });
+});
+
+/**
+ * lock/claim/refund via a real viem `custom(provider)` transport instead of a stubbed
+ * PublicClient/WalletClient: ABI encoding, decoding and revert-message formatting all run
+ * for real, and the mock only answers at the JSON-RPC boundary. A JSON-RPC account (no local
+ * signing) against a `writeContract` call with an explicit `chain` needs exactly three RPC
+ * methods — eth_chainId, eth_sendTransaction, eth_getTransactionReceipt — verified against
+ * this exact viem version before writing this file; no anvil, no eth_estimateGas/nonce/fee
+ * calls, since the node is the one filling those in.
+ */
+
+const RAIL_CONTRACT_ADDRESS = getAddress("0x000000000000000000000000000000000000dead");
+const RAIL_ACCOUNT = { address: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266" as Address, type: "json-rpc" } as const;
+const RAIL_TX_HASH = ("0x" + "aa".repeat(32)) as `0x${string}`;
+
+type MockRpcCall = { method: string; params?: unknown[] };
+
+function makeMockProvider(onSend: (tx: Record<string, unknown>) => `0x${string}`) {
+  const calls: MockRpcCall[] = [];
+  const provider = {
+    async request({ method, params }: { method: string; params?: unknown[] }): Promise<unknown> {
+      calls.push({ method, params });
+      switch (method) {
+        case "eth_chainId":
+          return "0x7a69";
+        case "eth_sendTransaction":
+          return onSend(params![0] as Record<string, unknown>);
+        case "eth_getTransactionReceipt":
+          return {
+            status: "0x1",
+            transactionHash: RAIL_TX_HASH,
+            blockHash: "0x" + "11".repeat(32),
+            blockNumber: "0x1",
+            transactionIndex: "0x0",
+            from: RAIL_ACCOUNT.address,
+            to: RAIL_CONTRACT_ADDRESS,
+            cumulativeGasUsed: "0x5208",
+            gasUsed: "0x5208",
+            logs: [],
+            logsBloom: "0x" + "00".repeat(256),
+            type: "0x2",
+          };
+        default:
+          throw new Error(`mock provider: unexpected RPC call ${method}`);
+      }
+    },
+  };
+  return { provider, calls };
+}
+
+const happyProvider = () => makeMockProvider(() => RAIL_TX_HASH);
+
+/** Shapes the thrown error like a real node's revert: `data` carries an ABI-encoded
+ * `Error(string)` reason, same as a Solidity `require(cond, "...")`. */
+function revertProvider(reason: string) {
+  return makeMockProvider(() => {
+    const err = new Error(`execution reverted: ${reason}`) as Error & { code: number; data: `0x${string}` };
+    err.code = 3;
+    err.data = encodeErrorResult({
+      abi: [{ type: "error", name: "Error", inputs: [{ type: "string" }] }],
+      errorName: "Error",
+      args: [reason],
+    });
+    throw err;
+  });
+}
+
+function railOn(provider: { request(args: { method: string; params?: unknown[] }): Promise<unknown> }) {
+  const publicClient = createPublicClient({ chain: foundry, transport: custom(provider) });
+  const walletClient = createWalletClient({ account: RAIL_ACCOUNT, chain: foundry, transport: custom(provider) });
+  return new EvmHashRail({
+    publicClient,
+    walletClient,
+    contractAddress: RAIL_CONTRACT_ADDRESS,
+    addressBook: { resolve: (did) => (did === terms.payee ? PAYEE_CHECKSUM : PAYER_CHECKSUM) },
+    assetBook: { resolve: () => TOKEN_CHECKSUM },
+    // Strictly before `terms.refundAfterMs`, so lock()'s own pre-flight guard never trips.
+    clock: () => terms.claimByMs,
+  });
+}
+
+function decodedSend(calls: MockRpcCall[]) {
+  const send = calls.find((c) => c.method === "eth_sendTransaction");
+  if (!send) throw new Error("test bug: no eth_sendTransaction call recorded");
+  const tx = send.params![0] as { data: `0x${string}` };
+  return decodeFunctionData({ abi: EVM_HASH_RAIL_ABI, data: tx.data });
+}
+
+describe("EvmHashRail.lock", () => {
+  it("happy path: returns the hashLock as ref and sends the correct on-chain call", async () => {
+    const { provider, calls } = happyProvider();
+    const ref = await railOn(provider).lock(terms);
+
+    expect(ref).toBe(terms.statement); // the contract indexes by hashLock, not by contract id
+
+    const decoded = decodedSend(calls);
+    expect(decoded.functionName).toBe("lock");
+    expect(decoded.args).toEqual([
+      terms.statement,
+      PAYEE_CHECKSUM,
+      BigInt(terms.amount),
+      TOKEN_CHECKSUM,
+      BigInt(terms.claimByMs),
+      BigInt(terms.refundAfterMs),
+    ]);
+  });
+
+  it("revert path: a contract revert surfaces as a tclk:-prefixed message carrying the reason", async () => {
+    const { provider } = revertProvider("EvmHashRail: already locked");
+    await expect(railOn(provider).lock(terms)).rejects.toThrow(
+      'tclk: The contract function "lock" reverted with the following reason:\nEvmHashRail: already locked',
+    );
+  });
+});
+
+describe("EvmHashRail.claim", () => {
+  const secret = "0x" + "cd".repeat(32);
+
+  it("happy path: resolves once the receipt lands, sending hashLock and secret", async () => {
+    const { provider, calls } = happyProvider();
+    await expect(railOn(provider).claim(terms.statement, secret)).resolves.toBeUndefined();
+
+    const decoded = decodedSend(calls);
+    expect(decoded.functionName).toBe("claim");
+    expect(decoded.args).toEqual([terms.statement, secret]);
+  });
+
+  it("revert path: a bad secret's on-chain revert is relayed, not swallowed", async () => {
+    const { provider } = revertProvider("EvmHashRail: secret does not open the hashLock");
+    await expect(railOn(provider).claim(terms.statement, secret)).rejects.toThrow(
+      'tclk: The contract function "claim" reverted with the following reason:\nEvmHashRail: secret does not open the hashLock',
+    );
+  });
+});
+
+describe("EvmHashRail.refund", () => {
+  it("happy path: sends only the hashLock", async () => {
+    const { provider, calls } = happyProvider();
+    await expect(railOn(provider).refund(terms.statement)).resolves.toBeUndefined();
+
+    const decoded = decodedSend(calls);
+    expect(decoded.functionName).toBe("refund");
+    expect(decoded.args).toEqual([terms.statement]);
+  });
+
+  it("revert path before refundAfterMs: unlike lock(), refund() has no local time guard — a too-early call must surface the contract's own revert reason rather than a client-side guess", async () => {
+    const { provider } = revertProvider("EvmHashRail: refund not yet available");
+    await expect(railOn(provider).refund(terms.statement)).rejects.toThrow(
+      'tclk: The contract function "refund" reverted with the following reason:\nEvmHashRail: refund not yet available',
+    );
+  });
+});

--- a/tests/evm-hash-rail.test.ts
+++ b/tests/evm-hash-rail.test.ts
@@ -115,7 +115,7 @@ const RAIL_TX_HASH = ("0x" + "aa".repeat(32)) as `0x${string}`;
 
 type MockRpcCall = { method: string; params?: unknown[] };
 
-function makeMockProvider(onSend: (tx: Record<string, unknown>) => `0x${string}`) {
+function makeMockProvider(onSend: (tx: Record<string, unknown>) => `0x${string}`, receiptStatus: "0x0" | "0x1" = "0x1") {
   const calls: MockRpcCall[] = [];
   const provider = {
     async request({ method, params }: { method: string; params?: unknown[] }): Promise<unknown> {
@@ -127,7 +127,7 @@ function makeMockProvider(onSend: (tx: Record<string, unknown>) => `0x${string}`
           return onSend(params![0] as Record<string, unknown>);
         case "eth_getTransactionReceipt":
           return {
-            status: "0x1",
+            status: receiptStatus,
             transactionHash: RAIL_TX_HASH,
             blockHash: "0x" + "11".repeat(32),
             blockNumber: "0x1",
@@ -247,6 +247,42 @@ describe("EvmHashRail.refund", () => {
     const { provider } = revertProvider("EvmHashRail: refund not yet available");
     await expect(railOn(provider).refund(terms.statement)).rejects.toThrow(
       'tclk: The contract function "refund" reverted with the following reason:\nEvmHashRail: refund not yet available',
+    );
+  });
+});
+
+/**
+ * A transaction can be successfully mined (no RPC error, no thrown revert at send time) and
+ * still have failed on-chain — e.g. it ran out of gas mid-execution, or reverted in a way the
+ * node doesn't surface as an `eth_sendTransaction`-time error. `eth_getTransactionReceipt`
+ * then answers with a full receipt whose `status` is `"0x0"`. Before this fix, none of
+ * lock/claim/refund looked at that field, so a mined-but-reverted transaction would resolve
+ * as if it had succeeded. See bdunn77's report.
+ */
+function minedButRevertedProvider() {
+  return makeMockProvider(() => RAIL_TX_HASH, "0x0");
+}
+
+describe("EvmHashRail — mined but reverted transactions", () => {
+  it("lock() rejects when the receipt status is reverted, not just when the send itself throws", async () => {
+    const { provider } = minedButRevertedProvider();
+    await expect(railOn(provider).lock(terms)).rejects.toThrow(
+      `tclk: EvmHashRail: lock transaction mined but reverted on-chain (hash: ${RAIL_TX_HASH})`,
+    );
+  });
+
+  it("claim() rejects when the receipt status is reverted, not just when the send itself throws", async () => {
+    const { provider } = minedButRevertedProvider();
+    const secret = "0x" + "cd".repeat(32);
+    await expect(railOn(provider).claim(terms.statement, secret)).rejects.toThrow(
+      `tclk: EvmHashRail: claim transaction mined but reverted on-chain (hash: ${RAIL_TX_HASH})`,
+    );
+  });
+
+  it("refund() rejects when the receipt status is reverted, not just when the send itself throws", async () => {
+    const { provider } = minedButRevertedProvider();
+    await expect(railOn(provider).refund(terms.statement)).rejects.toThrow(
+      `tclk: EvmHashRail: refund transaction mined but reverted on-chain (hash: ${RAIL_TX_HASH})`,
     );
   });
 });


### PR DESCRIPTION
## What

Splits out the piece of #21 that sv called reviewable on its own: the `SettlementRail` binding, tested against a mocked chain, with no toolchain changes.

Adds `src/evm-hash-rail.ts` (unchanged from #21) and expands `tests/evm-hash-rail.test.ts` from 3 cases (verifyLock address casing only) to 9. `lock`, `claim`, and `refund` each get a happy path and a revert path, run through a real viem `custom(provider)` transport. ABI encoding, decoding, and revert message formatting all run for real; only the JSON-RPC boundary (`eth_chainId`, `eth_sendTransaction`, `eth_getTransactionReceipt`) is mocked. No anvil, no real chain.

`package.json` only gains `viem` as an optional peer dependency plus the `./evm-hash-rail` export subpath, same as #21. No Solidity, no Foundry, no submodule, no contract.

## Why

From #21's close (refs #21): the binding itself was "the one that reads as ordinary review of an existing interface."

This PR is that slice. Everything else from #21 is left out on purpose. The Solidity toolchain, `EvmHashRail.sol`/`IERC20.sol`/mocks, and the Foundry test aren't included. Whether Foundry belongs in this repo at all is a separate call; happy to open a dedicated issue for that if it's useful.

The question of a value-bearing rail landing on tclk/1's fused agreement/reservation model isn't addressed here either. That's the #57/#58 discussion, and this PR doesn't argue for or against it since the binding itself is chain-agnostic and doesn't commit to where it eventually plugs in.

So the scope here is narrow: does `EvmHashRail`'s TypeScript binding correctly encode calls, decode results, and surface on-chain reverts, independent of wherever rail placement lands.

## What's new since #21

`lock`, `claim`, and `refund` each now have a mocked happy path (correct function and args) and a revert path, where the contract's `Error(string)` reason surfaces verbatim, prefixed `tclk:`, instead of being swallowed or replaced with a client-side guess.

`refund()` is confirmed to carry no local time guard, unlike `lock()`. The revert-path test for it checks exactly that: the binding relays the contract's own rejection rather than duplicating `refundAfterMs` logic client-side.

The existing 3 `verifyLock` cases had a test fixture bug: `contractAddress` was a 38-character string that slipped past validation because those cases never touch a real viem client. Left those 3 unchanged and gave the new real-transport tests a properly checksummed address, so viem's own validation runs for real.

Added the `./evm-hash-rail` export subpath to `package.json`. It was present in #21 and got dropped when this PR stopped touching the rest of #21's `package.json` diff. Without it the binding builds but can't actually be imported by anything outside this package.

## Checks

- [x] `pnpm install && pnpm -r --include-workspace-root build` runs clean
- [x] `pnpm -r --include-workspace-root test`: 113/113 root (was 104, +9 here), 40/40 mcp, 33/33 worker
- [x] No `src/` file outside `evm-hash-rail.ts` touched, no toolchain file touched
- [x] `CHANGELOG.md` `[Unreleased]` entry added