### PR TITLE
docs(spec): require decoding before prefix-based frame counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. Format follows
 
 ## [Unreleased]
 
+### Documentation
+
+- Clarify that the `tclk1 ` prefix is a version discriminator only; readers must decode the full
+  line before counting or interpreting it as a tclk/1 frame.
+
 ### Fixed
 
 - `tclk_post_frame` now accepts exact decimal-string nonces in addition to safe integer

--- a/SPEC.md
+++ b/SPEC.md
@@ -112,6 +112,11 @@ character `\uXXXX`-escaped. The prefix is the version; incompatible revisions ch
 (`tclk2 `), never the field semantics. Decoding is fail-closed: a known frame type with an
 unknown key, a missing field, or a malformed value is rejected, never coerced.
 
+The `tclk1 ` prefix is only a version discriminator, not proof that the remainder is a valid
+tclk/1 frame. Readers MUST pass the complete line to the tclk/1 decoder and use only records it
+accepts; prefix-matching or reading the self-declared `type` field alone can count another
+dialect or malformed data as a tclk/1 frame.
+
 Common field shapes:
 
 | shape | rule |


### PR DESCRIPTION
## Summary

- clarify in `SPEC.md` that `tclk1 ` is a version discriminator, not proof that a line is a valid tclk/1 frame;
- require readers to decode the complete line before counting or interpreting it;
- record the guidance in `CHANGELOG.md` under `[Unreleased]`.

Closes the documentation gap described in #89 without changing the wire format or decoder behavior.

## Evidence

The existing decoder already rejects unknown frame types, unknown fields, missing fields, and malformed values. The clarification prevents prefix-only or self-declared-`type` counts from being presented as tclk/1 measurements.

## Validation

- `git diff --check` passed.
- `pnpm install --frozen-lockfile` could not complete in this Windows environment: several registry downloads returned npm error 23. Build and test commands were therefore not run, and no runtime result is claimed.